### PR TITLE
Appreciate UIImage.scale when decompressing images

### DIFF
--- a/Nuke/Source/Core/ImageLoader.swift
+++ b/Nuke/Source/Core/ImageLoader.swift
@@ -59,7 +59,7 @@ extension ImageLoaderDelegate {
         #if os(OSX)
             return nil
         #else
-            return ImageDecompressor(targetSize: request.targetSize, contentMode: request.contentMode)
+            return ImageDecompressor(targetSize: request.targetSize, targetScale: request.targetScale, contentMode: request.contentMode)
         #endif
     }
 }

--- a/Nuke/Source/Core/ImageProcessor.swift
+++ b/Nuke/Source/Core/ImageProcessor.swift
@@ -90,18 +90,17 @@ public func ==(lhs: ImageProcessorComposition, rhs: ImageProcessorComposition) -
     
     private func decompressImage(image: UIImage, targetSize: CGSize, contentMode: ImageContentMode) -> UIImage {
         let bitmapSize = CGSize(width: CGImageGetWidth(image.CGImage), height: CGImageGetHeight(image.CGImage))
-        let scaleWidth = targetSize.width / bitmapSize.width
-        let scaleHeight = targetSize.height / bitmapSize.height
+        let scaleWidth = image.scale * targetSize.width / bitmapSize.width
+        let scaleHeight = image.scale * targetSize.height / bitmapSize.height
         let scale = contentMode == .AspectFill ? max(scaleWidth, scaleHeight) : min(scaleWidth, scaleHeight)
         return decompressImage(image, scale: Double(scale))
     }
     
     private func decompressImage(image: UIImage, scale: Double) -> UIImage {
         let imageRef = image.CGImage
-        var imageSize = CGSize(width: CGImageGetWidth(imageRef), height: CGImageGetHeight(imageRef))
-        if scale < 1.0 {
-            imageSize = CGSize(width: Double(imageSize.width) * scale, height: Double(imageSize.height) * scale)
-        }
+        let minification = CGFloat(min(scale, 1))
+        let imageSize = CGSize(width: round(CGFloat(CGImageGetWidth(imageRef)) * minification),
+                               height: round(CGFloat(CGImageGetHeight(imageRef)) * minification))
         // See Quartz 2D Programming Guide and https://github.com/kean/Nuke/issues/35 for more info
         guard let contextRef = CGBitmapContextCreate(nil, Int(imageSize.width), Int(imageSize.height), 8, 0, CGColorSpaceCreateDeviceRGB(), CGImageAlphaInfo.PremultipliedLast.rawValue) else {
             return image

--- a/Nuke/Source/Core/ImageProcessor.swift
+++ b/Nuke/Source/Core/ImageProcessor.swift
@@ -70,15 +70,17 @@ public func ==(lhs: ImageProcessorComposition, rhs: ImageProcessorComposition) -
     
     public class ImageDecompressor: ImageProcessing, Equatable {
         public let targetSize: CGSize
+        public let targetScale: CGFloat
         public let contentMode: ImageContentMode
         
-        public init(targetSize: CGSize = ImageMaximumSize, contentMode: ImageContentMode = .AspectFill) {
+        public init(targetSize: CGSize = ImageMaximumSize, targetScale: CGFloat = 1, contentMode: ImageContentMode = .AspectFill) {
             self.targetSize = targetSize
+            self.targetScale = targetScale
             self.contentMode = contentMode
         }
         
         public func processImage(image: Image) -> Image? {
-            return decompressImage(image, targetSize: self.targetSize, contentMode: self.contentMode)
+            return decompressImage(image, targetSize: self.targetSize, targetScale: self.targetScale, contentMode: self.contentMode)
         }
     }
     
@@ -88,17 +90,12 @@ public func ==(lhs: ImageProcessorComposition, rhs: ImageProcessorComposition) -
     
     // MARK: - Misc
     
-    private func decompressImage(image: UIImage, targetSize: CGSize, contentMode: ImageContentMode) -> UIImage {
-        let bitmapSize = CGSize(width: CGImageGetWidth(image.CGImage), height: CGImageGetHeight(image.CGImage))
-        let scaleWidth = image.scale * targetSize.width / bitmapSize.width
-        let scaleHeight = image.scale * targetSize.height / bitmapSize.height
-        let scale = contentMode == .AspectFill ? max(scaleWidth, scaleHeight) : min(scaleWidth, scaleHeight)
-        return decompressImage(image, scale: Double(scale))
-    }
-    
-    private func decompressImage(image: UIImage, scale: Double) -> UIImage {
+    private func decompressImage(image: UIImage, targetSize: CGSize, targetScale: CGFloat, contentMode: ImageContentMode) -> UIImage {
         let imageRef = image.CGImage
-        let minification = CGFloat(min(scale, 1))
+        let bitmapSize = CGSize(width: CGImageGetWidth(imageRef), height: CGImageGetHeight(imageRef))
+        let scaleWidth = targetScale * targetSize.width / bitmapSize.width
+        let scaleHeight = targetScale * targetSize.height / bitmapSize.height
+        let minification = min(1, contentMode == .AspectFill ? max(scaleWidth, scaleHeight) : min(scaleWidth, scaleHeight))
         let imageSize = CGSize(width: round(CGFloat(CGImageGetWidth(imageRef)) * minification),
                                height: round(CGFloat(CGImageGetHeight(imageRef)) * minification))
         // See Quartz 2D Programming Guide and https://github.com/kean/Nuke/issues/35 for more info
@@ -109,7 +106,7 @@ public func ==(lhs: ImageProcessorComposition, rhs: ImageProcessorComposition) -
         guard let decompressedImageRef = CGBitmapContextCreateImage(contextRef) else {
             return image
         }
-        return UIImage(CGImage: decompressedImageRef, scale: image.scale, orientation: image.imageOrientation)
+        return UIImage(CGImage: decompressedImageRef, scale: targetScale, orientation: image.imageOrientation)
     }
 
 #endif

--- a/Nuke/Source/Core/ImageRequest.swift
+++ b/Nuke/Source/Core/ImageRequest.swift
@@ -27,6 +27,10 @@ public struct ImageRequest {
     */
     public var targetSize: CGSize = ImageMaximumSize
     
+    /** Target scale in pixels per screen point. Default value is 1.
+    */
+    public var targetScale: CGFloat = 1
+    
     /** Content mode. Default value is .AspectFill.
     */
     public var contentMode: ImageContentMode = .AspectFill


### PR DESCRIPTION
Change `targetSize` to use the same scale as `UIImage.size`. Also use `round` (to nearest) to convert scaled dimensions to integer rather than truncating the fractional part.

Since sizes in iOS are expressed in logical points, not pixels, it is more natural to treat `targetSize` as logical points, so that decompressing an image of `image.size == CGSize(width: 400, height: 300)` and `image.scale == 2.0` down to `targetSize == CGSize(width: 200, height: 150)` would actually mean the same as `decompressImage(image, 0.5)` – rather than `decompressImage(image, 0.25)` which it did before this patch.