### PR TITLE
fix Carthage wrong target

### DIFF
--- a/Documentation/Guides/Installation Guide.md
+++ b/Documentation/Guides/Installation Guide.md
@@ -40,7 +40,7 @@ $ brew install carthage
 To integrate Nuke into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "Nuke/Nuke" ~> 4.0
+github "kean/Nuke" ~> 4.0
 ```
 
 Run `carthage update` to build the framework and drag the built `Nuke.framework` into your Xcode project.


### PR DESCRIPTION
Hi,

Trying to update for the current beta, I've noticed that you were targeting the `Nuke/Nuke` and that brought an error on `carthage update`

`A shell task (/usr/bin/env git fetch --prune --quiet https://github.com/Nuke/Nuke.git refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/*) failed with exit code 128:
fatal: could not read Username for 'https://github.com': terminal prompts disabled`

Using `github "kean/Nuke" ~> 4.0` worked great for me.

Thanks for building Nuke,
Francisco