### PR TITLE
Now removing existing node from linked list when adding node with same key

### DIFF
--- a/Sources/Cache.swift
+++ b/Sources/Cache.swift
@@ -100,6 +100,10 @@ public final class Cache: Caching {
     }
 
     private func add(node: Node<CachedImage>) {
+        if let existingNode = map[node.value.key] {
+            remove(node: existingNode)
+        }
+        
         list.append(node)
         map[node.value.key] = node
         totalCost += node.value.cost


### PR DESCRIPTION
`Cache.add(_:)` does not check to see if a node already exists for a given key. While the existing node in `map` will be overwritten, it will not be removed from `list`.

This PR checks for an `existingNode` in `map` (where `existingNode.value.key == node.value.key`)  and properly removes it.