### PR TITLE
Fix the contentModes not set when initializing a ImageLoadingOptions object

### DIFF
--- a/Sources/ImageView.swift
+++ b/Sources/ImageView.swift
@@ -183,6 +183,7 @@ public struct ImageLoadingOptions {
         self.transition = transition
         self.failureImage = failureImage
         self.failureImageTransition = failureImageTransition
+        self.contentModes = contentModes
     }
     #else
     public init(placeholder: Image? = nil, transition: Transition? = nil, failureImage: Image? = nil, failureImageTransition: Transition? = nil) {


### PR DESCRIPTION
Hi, I recently got tired of SDWebImage and wanted something more up to date and Swift based so I added your awesome library (I really like how it's crafted!) in a project but didn't manage to make the `contentModes` attribute work properly. My image placeholder was always displayed as `.scaleAspectFit` instead of `.center`. I think I figured out why.. 😄 