### PR TITLE
Reset task ID

### DIFF
--- a/Sources/ImageView.swift
+++ b/Sources/ImageView.swift
@@ -321,6 +321,9 @@ private final class ImageViewController {
         if request.memoryCacheOptions.isReadAllowed,
             let imageCache = pipeline.configuration.imageCache,
             let response = imageCache.cachedResponse(for: request) {
+
+            self.taskId = 0
+
             handle(response: response, error: nil, fromMemCache: true, options: options)
             completion?(response, nil)
             return nil


### PR DESCRIPTION
### Tracking Down #174

Of course, state restoration in landscape mode is mere correlation, but the related selecting of the current table view row exposed itself causing #174.

```swift
selectRow(at:animated:scrollPosition:) - UITableView
```

Investigating further showed, the issue only occurred with quick synchronous memory cache lookup, when `imageCache.cachedResponse(for: request)` returned a response. 

A comment, in `ImageView.swift`, made me curious.

```swift      
// Make sure that view reuse is handled correctly.
self.taskId += 1
let taskId = self.taskId
```

And sure enough, resetting the task identifier after an image cache hit, resolves this issue. 🙌

Unfortunately, I couldn’t come up with a tight test case, reproducing this timing issue. Maybe you can think of way to test this.

Sidebar, why not use `UUID` as `taskId`, instead of incrementing?