### PR TITLE
Allow images to upscale

### DIFF
--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -591,7 +591,7 @@ public struct Decompressor: Processing {
     }
 
     public func process(_ image: Image) -> Image? {
-        return decompress(image, targetSize: targetSize, contentMode: _map(mode: contentMode))
+        return decompress(image, targetSize: targetSize, contentMode: _map(mode: contentMode), upscale: false)
     }
 
     public static func ==(lhs: Decompressor, rhs: Decompressor) -> Bool {

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -117,19 +117,21 @@ public struct ImageDecompressor: ImageProcessing {
 
     private let targetSize: CGSize
     private let contentMode: ContentMode
+    private let upscale: Bool
 
     /// Initializes `Decompressor` with the given parameters.
     /// - parameter targetSize: Size in pixels. `MaximumSize` by default.
     /// - parameter contentMode: An option for how to resize the image
     /// to the target size. `.aspectFill` by default.
-    public init(targetSize: CGSize = MaximumSize, contentMode: ContentMode = .aspectFill) {
+    public init(targetSize: CGSize = MaximumSize, contentMode: ContentMode = .aspectFill, upscale: Bool = false) {
         self.targetSize = targetSize
         self.contentMode = contentMode
+        self.upscale = upscale
     }
 
     /// Decompresses and scales the image.
     public func process(image: Image, context: ImageProcessingContext) -> Image? {
-        return decompress(image, targetSize: targetSize, contentMode: contentMode)
+        return decompress(image, targetSize: targetSize, contentMode: contentMode, upscale: upscale)
     }
 
     /// Returns true if both have the same `targetSize` and `contentMode`.
@@ -148,13 +150,13 @@ public struct ImageDecompressor: ImageProcessing {
     #endif
 }
 
-internal func decompress(_ image: UIImage, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode) -> UIImage {
+internal func decompress(_ image: UIImage, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode, upscale: Bool) -> UIImage {
     guard let cgImage = image.cgImage else { return image }
     let bitmapSize = CGSize(width: cgImage.width, height: cgImage.height)
     let scaleHor = targetSize.width / bitmapSize.width
     let scaleVert = targetSize.height / bitmapSize.height
     let scale = contentMode == .aspectFill ? max(scaleHor, scaleVert) : min(scaleHor, scaleVert)
-    return decompress(image, scale: CGFloat(min(scale, 1)))
+    return decompress(image, scale: CGFloat(upscale ? scale : min(scale, 1)))
 }
 
 internal func decompress(_ image: UIImage, scale: CGFloat) -> UIImage {

--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -154,18 +154,18 @@ public struct ImageRequest {
     /// - parameter targetSize: Size in pixels.
     /// - parameter contentMode: An option for how to resize the image
     /// to the target size.
-    public init(url: URL, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode) {
+    public init(url: URL, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode, upscale: Bool = false) {
         self = ImageRequest(url: url)
-        self.processor = AnyImageProcessor(ImageDecompressor(targetSize: targetSize, contentMode: contentMode))
+        self.processor = AnyImageProcessor(ImageDecompressor(targetSize: targetSize, contentMode: contentMode, upscale: upscale))
     }
 
     /// Initializes a request with the given request.
     /// - parameter targetSize: Size in pixels.
     /// - parameter contentMode: An option for how to resize the image
     /// to the target size.
-    public init(urlRequest: URLRequest, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode) {
+    public init(urlRequest: URLRequest, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode, upscale: Bool = false) {
         self = ImageRequest(urlRequest: urlRequest)
-        self.processor = AnyImageProcessor(ImageDecompressor(targetSize: targetSize, contentMode: contentMode))
+        self.processor = AnyImageProcessor(ImageDecompressor(targetSize: targetSize, contentMode: contentMode, upscale: upscale))
     }
 
     fileprivate static let decompressor = AnyImageProcessor(ImageDecompressor())


### PR DESCRIPTION
Hello, so I ran into a problem. I have a required design, and minimal control over my content pipeline. So I rely heavily on client side optimizations. I am only recently trying Nuke, and love it so far, but ran into a little snag, line 157 of ImageProcessing.swift. This `CGFloat(min(scale, 1))` in particular.

What this means is you wouldn't expect anyone to need to upscale an image. Though I use client-side image processing for 2 main reasons (among others).
1. to decode off the main thread, which Nuke does beautifully
2. to ensure there is no scaling using offscreen rendering

The problem is, the images I get back are just slightly smaller than the views they are displayed in, so with this, and the the maximum of scale 1, means the only option is to use UIImageView scaling again. Basically, that makes the Nuke targetSize transformation a bit pointless for this case.

So when trying to figure out the best approach, I couldn't really decide, but chose one to make a pull request. Here are some thoughts:
1. Remove the `CGFloat(min(scale, 1))` and just use the scale as is. Allowing upscaling by default.
2. Make 2 new ContentModes, for `aspectFillWithUpscaling` and `aspectFitWithUpscaling`
3. Make the current ContentModes take a bool `aspectFill(true)` or `aspectFit(false)`
4. Finally, add a third boolean to accompany targetSize, and contentMode through the process.

For this PR as you can see I went with 4, and it defaults to `false` because I am no stranger to open source, and I understand how important backward compatibility can be.

So let me know your thoughts. In the mean time, I am using a fork with my changes in number 4 applied.