### PR TITLE
allow custom processor through init

### DIFF
--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -146,17 +146,37 @@ public struct ImageRequest {
 
     #if !os(macOS)
 
-    // Convenience initializers with `targetSize` and `contentMode`. The reason
-    // why those are implemented as separate init methods is to take advantage
-    // of memorized `decompressor` when custom parameters are not needed.
+    // Convenience initializers with custom processor. The reason why these
+    // are implemented as separate init methods is to take advantage of
+    // memorized `decompressor` when a custom processor is not needed.
+
+    /// Initializes a request with the given URL.
+    /// - parameter processor: Custom image processer.
+    public init<Processor: ImageProcessing>(url: URL, processor: Processor) {
+        self.init(url: url)
+        self.processor = AnyImageProcessor(processor)
+    }
+
+    /// Initializes a request with the given request.
+    /// - parameter processor: Custom image processer.
+    public init<Processor: ImageProcessing>(urlRequest: URLRequest, processor: Processor) {
+        self.init(urlRequest: urlRequest)
+        self.processor = AnyImageProcessor(processor)
+    }
+
+    // Convenience initializers with `targetSize`, `contentMode`, and `upscale`
+    // to provide to ImageDecompressor custom processor.
 
     /// Initializes a request with the given URL.
     /// - parameter targetSize: Size in pixels.
     /// - parameter contentMode: An option for how to resize the image
     /// to the target size.
     public init(url: URL, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode, upscale: Bool = false) {
-        self = ImageRequest(url: url)
-        self.processor = AnyImageProcessor(ImageDecompressor(targetSize: targetSize, contentMode: contentMode, upscale: upscale))
+        self.init(url: url, processor: ImageDecompressor(
+            targetSize: targetSize,
+            contentMode: contentMode,
+            upscale: upscale
+        ))
     }
 
     /// Initializes a request with the given request.
@@ -164,8 +184,11 @@ public struct ImageRequest {
     /// - parameter contentMode: An option for how to resize the image
     /// to the target size.
     public init(urlRequest: URLRequest, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode, upscale: Bool = false) {
-        self = ImageRequest(urlRequest: urlRequest)
-        self.processor = AnyImageProcessor(ImageDecompressor(targetSize: targetSize, contentMode: contentMode, upscale: upscale))
+        self.init(urlRequest: urlRequest, processor: ImageDecompressor(
+            targetSize: targetSize,
+            contentMode: contentMode,
+            upscale: upscale
+        ))
     }
 
     fileprivate static let decompressor = AnyImageProcessor(ImageDecompressor())

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -132,6 +132,17 @@ class ImageProcessingTests: XCTestCase {
     // MARK: - Resizing
 
     #if !os(macOS)
+    func testUsingProcessorRequestParameter() {
+        // Given
+        let processor = ImageDecompressor(targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit, upscale: false)
+
+        // When
+        let request = ImageRequest(url: Test.url, processor: processor)
+
+        // Then
+        XCTAssertEqual(AnyImageProcessor(processor), request.processor)
+    }
+
     func testResizingUsingRequestParameters() {
         // Given
         let request = ImageRequest(url: Test.url, targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit)
@@ -156,6 +167,34 @@ class ImageProcessingTests: XCTestCase {
         // Then
         XCTAssertEqual(image?.cgImage?.width, 40)
         XCTAssertEqual(image?.cgImage?.height, 30)
+    }
+
+    func testResizingShouldNotUpscaleWithoutParamater() {
+        // Given
+        let targetSize = CGSize(width: 960, height: 720)
+        let request = ImageRequest(url: Test.url, targetSize: targetSize, contentMode: .aspectFit)
+        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
+
+        // When
+        let image = request.processor!.process(image: Test.image, context: context)
+
+        // Then
+        XCTAssertEqual(image?.cgImage?.width, 640)
+        XCTAssertEqual(image?.cgImage?.height, 480)
+    }
+
+    func testResizingShouldUpscaleWithParamater() {
+        // Given
+        let targetSize = CGSize(width: 960, height: 720)
+        let request = ImageRequest(url: Test.url, targetSize: targetSize, contentMode: .aspectFit, upscale: true)
+        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
+
+        // When
+        let image = request.processor!.process(image: Test.image, context: context)
+
+        // Then
+        XCTAssertEqual(image?.cgImage?.width, 960)
+        XCTAssertEqual(image?.cgImage?.height, 720)
     }
     #endif
 }


### PR DESCRIPTION
- This allows shared custom processors to be provided rather than depending only on factory methods of image requests

e.g.
```swift
let imageRequest = ImageRequest(url: url, processor: MyProccessor.shared)
```

I also added tests for this and my previous pull request for upscaling.