### PR TITLE
Update/swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os: osx
 osx_image:
   - xcode9.4
   - xcode10
+  - xcode10.2
 
 env:
   global:
@@ -12,6 +13,8 @@ env:
   - WATCHOS_SCHEME="Nuke watchOS"
 
   matrix:
+  - DESTINATION="OS=12.2,name=iPhone X"
+    SCHEME="$IOS_SCHEME"     RUN_TESTS="YES"
   - DESTINATION="OS=11.3,name=iPhone X"
     SCHEME="$IOS_SCHEME"     RUN_TESTS="YES"
   - DESTINATION="OS=10.3.1,name=iPhone 7 Plus"
@@ -19,6 +22,8 @@ env:
   - DESTINATION="OS=9.3,name=iPhone 5"
     SCHEME="$IOS_SCHEME"     RUN_TESTS="YES"
 
+  - DESTINATION="OS=12.2,name=Apple TV 4K"
+    SCHEME="$TVOS_SCHEME"    RUN_TESTS="YES"
   - DESTINATION="OS=11.3,name=Apple TV 4K"
     SCHEME="$TVOS_SCHEME"    RUN_TESTS="YES"
 

--- a/Demo/NukeDemo.xcodeproj/project.pbxproj
+++ b/Demo/NukeDemo.xcodeproj/project.pbxproj
@@ -452,7 +452,7 @@
 				PRODUCT_NAME = NukeDemo_Example;
 				SWIFT_OBJC_BRIDGING_HEADER = "Sources/NukeDemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -472,7 +472,7 @@
 				PRODUCT_NAME = NukeDemo_Example;
 				SWIFT_OBJC_BRIDGING_HEADER = "Sources/NukeDemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Demo/NukeDemo.xcodeproj/project.pbxproj
+++ b/Demo/NukeDemo.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
@@ -201,7 +201,7 @@
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "NukeDemo" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -263,7 +263,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-NukeDemo/Pods-NukeDemo-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-NukeDemo/Pods-NukeDemo-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/DFCache/DFCache.framework",
 				"${BUILT_PRODUCTS_DIR}/FLAnimatedImage/FLAnimatedImage.framework",
@@ -282,7 +282,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-NukeDemo/Pods-NukeDemo-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NukeDemo/Pods-NukeDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -335,6 +335,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -390,6 +391,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -429,6 +431,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -800,7 +800,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Alexander Grebenyuk";
 				TargetAttributes = {
 					0C22D9C41BCA9734006E1D3B = {
@@ -851,6 +851,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -1461,6 +1462,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1507,7 +1509,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1518,6 +1520,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1557,7 +1560,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke iOS.xcscheme
+++ b/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke macOS.xcscheme
+++ b/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke tvOS.xcscheme
+++ b/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke watchOS.xcscheme
+++ b/Nuke.xcodeproj/xcshareddata/xcschemes/Nuke watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -26,7 +26,7 @@ public protocol ImageCaching: class {
 /// Convenience subscript.
 public extension ImageCaching {
     /// Accesses the image associated with the given request.
-    public subscript(request: ImageRequest) -> Image? {
+    subscript(request: ImageRequest) -> Image? {
         get {
             return cachedResponse(for: request)?.image
         }

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -82,12 +82,12 @@ public /* final */ class ImageTask: Hashable {
 
     // MARK: - Hashable
 
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self).hashValue)
+    }
+    
     public static func == (lhs: ImageTask, rhs: ImageTask) -> Bool {
         return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
-    }
-
-    public var hashValue: Int {
-        return ObjectIdentifier(self).hashValue
     }
 }
 

--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -253,7 +253,7 @@ public struct ImageRequest {
 public extension ImageRequest {
     /// Appends a processor to the request. You can append arbitrary number of
     /// processors to the request.
-    public mutating func process<P: ImageProcessing>(with processor: P) {
+    mutating func process<P: ImageProcessing>(with processor: P) {
         guard let existing = self.processor else {
             self.processor = AnyImageProcessor(processor)
             return
@@ -264,7 +264,7 @@ public extension ImageRequest {
 
     /// Appends a processor to the request. You can append arbitrary number of
     /// processors to the request.
-    public func processed<P: ImageProcessing>(with processor: P) -> ImageRequest {
+    func processed<P: ImageProcessing>(with processor: P) -> ImageRequest {
         var request = self
         request.process(with: processor)
         return request
@@ -272,13 +272,13 @@ public extension ImageRequest {
 
     /// Appends a processor to the request. You can append arbitrary number of
     /// processors to the request.
-    public mutating func process<Key: Hashable>(key: Key, _ closure: @escaping (Image) -> Image?) {
+    mutating func process<Key: Hashable>(key: Key, _ closure: @escaping (Image) -> Image?) {
         process(with: AnonymousImageProcessor<Key>(key, closure))
     }
 
     /// Appends a processor to the request. You can append arbitrary number of
     /// processors to the request.
-    public func processed<Key: Hashable>(key: Key, _ closure: @escaping (Image) -> Image?) -> ImageRequest {
+    func processed<Key: Hashable>(key: Key, _ closure: @escaping (Image) -> Image?) -> ImageRequest {
         return processed(with: AnonymousImageProcessor<Key>(key, closure))
     }
 }

--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -291,7 +291,9 @@ internal extension ImageRequest {
             if let customKey = request._ref.cacheKey {
                 hasher.combine(customKey)
             }
-            hasher.combine(request._ref._urlString?.hashValue ?? 0)
+            else {
+                hasher.combine(request._ref._urlString?.hashValue ?? 0)
+            }
         }
 
         static func == (lhs: CacheKey, rhs: CacheKey) -> Bool {
@@ -314,7 +316,9 @@ internal extension ImageRequest {
             if let customKey = request._ref.loadKey {
                 hasher.combine(customKey)
             }
-            hasher.combine(request._ref._urlString?.hashValue ?? 0)
+            else {
+                hasher.combine(request._ref._urlString?.hashValue ?? 0)
+            }
         }
 
         static func == (lhs: LoadKey, rhs: LoadKey) -> Bool {

--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -286,12 +286,12 @@ public extension ImageRequest {
 internal extension ImageRequest {
     struct CacheKey: Hashable {
         let request: ImageRequest
-
-        var hashValue: Int {
+        
+        func hash(into hasher: inout Hasher) {
             if let customKey = request._ref.cacheKey {
-                return customKey.hashValue
+                hasher.combine(customKey)
             }
-            return request._ref._urlString?.hashValue ?? 0
+            hasher.combine(request._ref._urlString?.hashValue ?? 0)
         }
 
         static func == (lhs: CacheKey, rhs: CacheKey) -> Bool {
@@ -309,12 +309,12 @@ internal extension ImageRequest {
 
     struct LoadKey: Hashable {
         let request: ImageRequest
-
-        var hashValue: Int {
+        
+        func hash(into hasher: inout Hasher) {
             if let customKey = request._ref.loadKey {
-                return customKey.hashValue
+                hasher.combine(customKey)
             }
-            return request._ref._urlString?.hashValue ?? 0
+            hasher.combine(request._ref._urlString?.hashValue ?? 0)
         }
 
         static func == (lhs: LoadKey, rhs: LoadKey) -> Bool {

--- a/Sources/Internal.swift
+++ b/Sources/Internal.swift
@@ -558,13 +558,14 @@ extension String {
     /// // prints "50334ee0b51600df6397ce93ceed4728c37fee4e"
     /// ```
     var sha1: String? {
-        guard let input = self.data(using: .utf8) else {
-            return nil
+        guard let input = self.data(using: .utf8) else { return nil }
+        
+        let hash = input.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
+            var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+            CC_SHA1(bytes.baseAddress, CC_LONG(input.count), &hash)
+            return hash
         }
-        var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
-        input.withUnsafeBytes {
-            _ = CC_SHA1($0, CC_LONG(input.count), &hash)
-        }
+        
         return hash.map({ String(format: "%02x", $0) }).joined()
     }
 }

--- a/Sources/Internal.swift
+++ b/Sources/Internal.swift
@@ -560,11 +560,18 @@ extension String {
     var sha1: String? {
         guard let input = self.data(using: .utf8) else { return nil }
         
+        #if swift(>=5.0)
         let hash = input.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
             var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
             CC_SHA1(bytes.baseAddress, CC_LONG(input.count), &hash)
             return hash
         }
+        #else
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        input.withUnsafeBytes {
+            _ = CC_SHA1($0, CC_LONG(input.count), &hash)
+        }
+        #endif
         
         return hash.map({ String(format: "%02x", $0) }).joined()
     }


### PR DESCRIPTION
## Summary
- Update for Swift 5 and Xcode 10.2 support

## Notes
- The new `Hashable` updates are outside my comfort zone. There may be a better way to satisfy the new requirements.
    - Seems to me the new `hash(into:)` is a replacement for `hashValue`: https://developer.apple.com/documentation/swift/hashable/2995575-hash