### PR TITLE
Swift PM: Add tools version to enable Xcode build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,12 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "Nuke",
-    exclude: ["Tests"] // excluding until all module layouts get supported
+    products: [
+        .library(name: "Nuke", targets: ["Nuke"]),
+    ],
+    targets: [
+        .target(name: "Nuke", path: "Sources")
+    ]
 )


### PR DESCRIPTION
Hi Alexander, it looks like your `master` branch is ready for tools v5. Proposed changes make a package working on Mac. Thanks!