### PR TITLE
Swift PM: Include platform for code compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "Nuke",
+    platforms: [
+        .macOS(.v10_12)
+    ],
     products: [
         .library(name: "Nuke", targets: ["Nuke"]),
     ],


### PR DESCRIPTION
Hey Alexander, it’s me again. Other changes in 7.6 require macOS 10.12, but Xcode uses 10.10 by default. This is a small fix which helps to get rid of all compiler errors related to modern APIs. Thanks!