### PR TITLE
Caching Processed Images

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		0CE3992D1D4697CE00A87D47 /* ImagePipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE3992C1D4697CE00A87D47 /* ImagePipelineTests.swift */; };
 		0CE5F6832156386B0046609F /* ResumableDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE5F681215638300046609F /* ResumableDataTests.swift */; };
 		0CE745751D4767B900123F65 /* MockImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE745741D4767B900123F65 /* MockImageDecoder.swift */; };
+		0CF1754C22913F9800A8946E /* ImagePipelineConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */; };
 		0CF4DE7D1D412A9E00170289 /* ImagePreheater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF4DE7C1D412A9E00170289 /* ImagePreheater.swift */; };
 /* End PBXBuildFile section */
 
@@ -188,6 +189,7 @@
 		0CE5F78720A22ABF00BC3283 /* Nuke 6 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 6 Migration Guide.md"; sourceTree = "<group>"; };
 		0CE5F78820A22ABF00BC3283 /* Nuke 7 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 7 Migration Guide.md"; sourceTree = "<group>"; };
 		0CE745741D4767B900123F65 /* MockImageDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockImageDecoder.swift; sourceTree = "<group>"; };
+		0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineConfiguration.swift; sourceTree = "<group>"; };
 		0CF4DE7C1D412A9E00170289 /* ImagePreheater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagePreheater.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -240,6 +242,7 @@
 				0C0FD5DF1CA47FE1002A78FB /* ImageView.swift */,
 				0C0FD5D91CA47FE1002A78FB /* ImageRequest.swift */,
 				0C0FD5D31CA47FE1002A78FB /* ImagePipeline.swift */,
+				0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */,
 				0C86AB69228B3B5100A81BA1 /* ImageTask.swift */,
 				0C367A9420B9D0D0002342A5 /* ImageTaskMetrics.swift */,
 				0C0FD5D71CA47FE1002A78FB /* ImageCache.swift */,
@@ -664,6 +667,7 @@
 				0C367A9520B9D0D0002342A5 /* ImageTaskMetrics.swift in Sources */,
 				0CB26802208F2565004C83F4 /* DataCache.swift in Sources */,
 				0C0FD6041CA47FE1002A78FB /* ImageRequest.swift in Sources */,
+				0CF1754C22913F9800A8946E /* ImagePipelineConfiguration.swift in Sources */,
 				0C86AB6A228B3B5100A81BA1 /* ImageTask.swift in Sources */,
 				0C7150091FC9724C00B880AC /* Internal.swift in Sources */,
 				0CE2D9BA2084FDDD00934B28 /* ImageDecoding.swift in Sources */,

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -114,6 +114,23 @@ extension ImageDecoder {
     }
 }
 
+extension ImageDecoding {
+    func decode(_ data: Data, urlResponse: URLResponse?, isFinal: Bool) -> ImageResponse? {
+        func decode() -> Image? {
+            return self.decode(data: data, isFinal: isFinal)
+        }
+        guard let image = autoreleasepool(invoking: decode) else {
+            return nil
+        }
+        #if !os(macOS)
+        ImageDecompressor.setDecompressionNeeded(true, for: image)
+        #endif
+
+        let scanNumber: Int? = (self as? ImageDecoder)?.numberOfScans
+        return ImageResponse(image: image, urlResponse: urlResponse, scanNumber: scanNumber)
+    }
+}
+
 // MARK: - ImageDecoderRegistry
 
 /// A register of image codecs (only decoding).
@@ -147,8 +164,8 @@ public final class ImageDecoderRegistry {
 /// Image decoding context used when selecting which decoder to use.
 public struct ImageDecodingContext {
     public let request: ImageRequest
-    let urlResponse: URLResponse?
     public let data: Data
+    public let urlResponse: URLResponse?
 }
 
 // MARK: - Image Formats

--- a/Sources/ImagePipelineConfiguration.swift
+++ b/Sources/ImagePipelineConfiguration.swift
@@ -1,0 +1,127 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+extension ImagePipeline {
+    public struct Configuration {
+        // MARK: - Dependencies
+
+        /// Image cache used by the pipeline.
+        public var imageCache: ImageCaching?
+
+        /// Data loader used by the pipeline.
+        public var dataLoader: DataLoading
+
+        /// Data cache used by the pipeline.
+        public var dataCache: DataCaching?
+
+        /// Default implementation uses shared `ImageDecoderRegistry` to create
+        /// a decoder that matches the context.
+        public var makeImageDecoder: (ImageDecodingContext) -> ImageDecoding = {
+            return ImageDecoderRegistry.shared.decoder(for: $0)
+        }
+
+        /// Returns `ImageEncoder()` by default.
+        public var makeImageEncoder: (ImageEncodingContext) -> ImageEncoding = { _ in
+            return ImageEncoder()
+        }
+
+        // MARK: - Operation Queues
+
+        /// Data loading queue. Default maximum concurrent task count is 6.
+        public var dataLoadingQueue = OperationQueue()
+
+        /// Data caching queue. Default maximum concurrent task count is 2.
+        public var dataCachingQueue = OperationQueue()
+
+        /// Image decoding queue. Default maximum concurrent task count is 1.
+        public var imageDecodingQueue = OperationQueue()
+
+        /// Image encodign queue. Default maximum concurrent task count is 1.
+        public var imageEncodingQueue = OperationQueue()
+
+        /// Image processing queue. Default maximum concurrent task count is 2.
+        public var imageProcessingQueue = OperationQueue()
+
+        #if !os(macOS)
+        /// Image decompressing queue. Default maximum concurrent task count is 2.
+        public var imageDecompressingQueue = OperationQueue()
+        #endif
+
+        // MARK: - Options
+
+        #if !os(macOS)
+        /// Decompresses the loaded images. `true` by default.
+        ///
+        /// Decompressing compressed image formats (such as JPEG) can significantly
+        /// improve drawing performance as it allows a bitmap representation to be
+        /// created in a background rather than on the main thread.
+        public var isDecompressionEnabled = true
+        #endif
+
+        /// `true` by default. If `true`, original image data provided by
+        /// `dataLoader` will be stored in a custom `dataCache` provided in the
+        /// configuration.
+        ///
+        /// If the value is set to `true`, you must also provide `dataCache`
+        /// instance in the configuration.
+        public var isDataCacheForOriginalDataEnabled = true
+
+        /// `false` by default. If `true`, the images for which one or more
+        /// processors were specified will be encoded and stored in data cache.
+        ///
+        /// If the value is set to `true`, you must also provide `dataCache`
+        /// instance in the configuration.
+        public var isDataCacheForProcessedDataEnabled = false
+
+        /// `true` by default. If `true` the pipeline will combine the requests
+        /// with the same `loadKey` into a single request. The request only gets
+        /// cancelled when all the registered requests are.
+        public var isDeduplicationEnabled = true
+
+        /// `true` by default. It `true` the pipeline will rate limits the requests
+        /// to prevent trashing of the underlying systems (e.g. `URLSession`).
+        /// The rate limiter only comes into play when the requests are started
+        /// and cancelled at a high rate (e.g. scrolling through a collection view).
+        public var isRateLimiterEnabled = true
+
+        /// `false` by default. If `true` the pipeline will try to produce a new
+        /// image each time it receives a new portion of data from data loader.
+        /// The decoder used by the image loading session determines whether
+        /// to produce a partial image or not.
+        public var isProgressiveDecodingEnabled = false
+
+        /// If the data task is terminated (either because of a failure or a
+        /// cancellation) and the image was partially loaded, the next load will
+        /// resume where it was left off. Supports both validators (`ETag`,
+        /// `Last-Modified`). The resumable downloads are enabled by default.
+        public var isResumableDataEnabled = true
+
+        /// If `true` pipeline will detects GIFs and set `animatedImageData`
+        /// (`UIImage` property). It will also disable processing of such images,
+        /// and alter the way cache cost is calculated. However, this will not
+        /// enable actual animated image rendering. To do that take a look at
+        /// satellite projects (FLAnimatedImage and Gifu plugins for Nuke).
+        /// `false` by default (to preserve resources).
+        public static var isAnimatedImageDataEnabled = false
+
+        /// Creates default configuration.
+        /// - parameter dataLoader: `DataLoader()` by default.
+        /// - parameter imageCache: `Cache.shared` by default.
+        public init(dataLoader: DataLoading = DataLoader(), imageCache: ImageCaching? = ImageCache.shared) {
+            self.dataLoader = dataLoader
+            self.imageCache = imageCache
+
+            self.dataLoadingQueue.maxConcurrentOperationCount = 6
+            self.dataCachingQueue.maxConcurrentOperationCount = 2
+            self.imageDecodingQueue.maxConcurrentOperationCount = 1
+            self.imageEncodingQueue.maxConcurrentOperationCount = 1
+            self.imageProcessingQueue.maxConcurrentOperationCount = 2
+            #if !os(macOS)
+            self.imageDecompressingQueue.maxConcurrentOperationCount = 2
+            #endif
+        }
+    }
+}

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -310,24 +310,12 @@ extension ImageProcessor {
 
 // MARK: - ImageDecompressor (Internal)
 
-struct ImageDecompressor: ImageProcessing, Hashable {
-    let identifier: String = "ImageDecompressor"
+struct ImageDecompressor {
 
-    var hashableIdentifier: AnyHashable {
-        return self
-    }
-
-    func process(image: Image, context: ImageProcessingContext) -> Image? {
-        guard ImageDecompressor.isDecompressionNeeded(for: image) ?? false else {
-            return image // Image doesn't require decompression
-        }
+    func decompress(image: Image) -> Image {
         let output = ImageProcessor.decompress(image)
         ImageDecompressor.setDecompressionNeeded(false, for: output)
         return output
-    }
-
-    public static func == (lhs: ImageDecompressor, rhs: ImageDecompressor) -> Bool {
-        return true
     }
 
     // MARK: Managing Decompression State
@@ -437,15 +425,6 @@ extension ImageProcessor {
         return draw(image)
     }
 
-    static func isOpaque(_ image: CGImage) -> Bool {
-        let alpha = image.alphaInfo
-        return alpha == .none || alpha == .noneSkipFirst || alpha == .noneSkipLast
-    }
-
-    static func isTransparent(_ image: CGImage) -> Bool {
-        return !isOpaque(image)
-    }
-
     static func drawInCircle(_ image: UIImage) -> UIImage? {
         guard let cgImage = image.cgImage else {
             return nil
@@ -520,6 +499,17 @@ extension ImageProcessor {
 }
 
 #endif
+
+extension ImageProcessor {
+    static func isOpaque(_ image: CGImage) -> Bool {
+        let alpha = image.alphaInfo
+        return alpha == .none || alpha == .noneSkipFirst || alpha == .noneSkipLast
+    }
+
+    static func isTransparent(_ image: CGImage) -> Bool {
+        return !isOpaque(image)
+    }
+}
 
 // A special version of `==` which is optimized to not create hashable identifiers
 // when not necessary (e.g. one processor is `nil` and another one isn't.

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -23,10 +23,10 @@ enum Test {
 
     static let data: Data = Test.data(name: "fixture", extension: "jpeg")
 
-    static let image: Image = {
+    static var image: Image {
         let data = Test.data(name: "fixture", extension: "jpeg")
         return Nuke.ImageDecoder().decode(data: data, isFinal: true)!
-    }()
+    }
 
     static let request = ImageRequest(
         url: Test.url

--- a/Tests/ImageDecoderRegistryTests.swift
+++ b/Tests/ImageDecoderRegistryTests.swift
@@ -58,7 +58,7 @@ final class ImageDecoderRegistryTests: XCTestCase {
 private func _mockImageDecodingContext() -> ImageDecodingContext {
     return ImageDecodingContext(
         request: Test.request,
-        urlResponse: nil,
-        data: Test.data(name: "fixture", extension: "jpeg")
+        data: Test.data(name: "fixture", extension: "jpeg"),
+        urlResponse: nil
     )
 }

--- a/Tests/ImagePipelineDataCachingTests.swift
+++ b/Tests/ImagePipelineDataCachingTests.swift
@@ -89,3 +89,167 @@ class ImagePipelineDataCachingTests: XCTestCase {
         wait() // Wait till operation is created
     }
 }
+
+#if !os(macOS)
+class ImagePipelineProcessedDataCachingTests: XCTestCase {
+    var dataLoader: MockDataLoader!
+    var dataCache: MockDataCache!
+    var pipeline: ImagePipeline!
+    var processorFactory: MockProcessorFactory!
+    var request: ImageRequest!
+
+    override func setUp() {
+        super.setUp()
+
+        dataCache = MockDataCache()
+        dataLoader = MockDataLoader()
+
+        pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.dataCache = dataCache
+            $0.isDataCacheForOriginalDataEnabled = true
+            $0.isDataCacheForProcessedDataEnabled = true
+            $0.imageCache = nil
+        }
+
+        processorFactory = MockProcessorFactory()
+
+        request = ImageRequest(url: Test.url, processors: [processorFactory.make(id: "1")])
+    }
+
+    // MARK: - Basics
+
+    func testProcessedImageLoadedFromDataCache() {
+        // Given processed image data stored in data cache
+        dataLoader.queue.isSuspended = true
+        dataCache.store[Test.url.absoluteString + "1"] = Test.data
+
+        // When/Then
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // Then
+        XCTAssertEqual(processorFactory.numberOfProcessorsApplied, 0, "Expected no processors to be applied")
+    }
+
+    func testProcessedImageIsDecompressed() {
+        // Given processed image data stored in data cache
+        dataLoader.queue.isSuspended = true
+        dataCache.store[Test.url.absoluteString + "1"] = Test.data
+
+        // When/Then
+        expect(pipeline).toLoadImage(with: request) { result in
+            guard let image = result.value?.image else {
+                return XCTFail("Expected image to be loaded")
+            }
+
+            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
+            XCTAssertEqual(isDecompressionNeeded, false, "Expected image to be decompressed")
+        }
+        wait()
+    }
+
+    func testProcessedImageNotDecompressedWhenDecompressionDisabled() {
+        // Given pipeline with decompression disabled
+        var configuration = pipeline.configuration
+        configuration.isDecompressionEnabled = false
+        let pipeline = ImagePipeline(configuration: configuration)
+
+        // Given processed image data stored in data cache
+        dataLoader.queue.isSuspended = true
+        dataCache.store[Test.url.absoluteString + "1"] = Test.data
+
+        // When/Then
+        expect(pipeline).toLoadImage(with: request) { result in
+            guard let image = result.value?.image else {
+                return XCTFail("Expected image to be loaded")
+            }
+
+            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
+            XCTAssertEqual(isDecompressionNeeded, true, "Expected image to still be marked as non decompressed")
+        }
+        wait()
+    }
+
+    func testBothProcessedAndOriginalImageDataStoredInDataCache() {
+        // When
+        pipeline.configuration.imageEncodingQueue.isSuspended = true
+        expect(pipeline).toLoadImage(with: request)
+        expect(pipeline.configuration.imageEncodingQueue).toFinishWithEnqueuedOperationCount(1)
+
+        // Then
+        wait { _ in
+            XCTAssertNotNil(self.dataCache.cachedData(for: Test.url.absoluteString), "Expected original image data to be stored")
+            XCTAssertNotNil(self.dataCache.cachedData(for: Test.url.absoluteString + "1"), "Expected processed image data to be stored")
+            XCTAssertEqual(self.dataCache.store.count, 2)
+        }
+    }
+
+    func testOriginalDataNotStoredWhenStorageDisabled() {
+        // Given
+        var configuration = pipeline.configuration
+        configuration.isDataCacheForOriginalDataEnabled = false
+        let pipeline = ImagePipeline(configuration: configuration)
+
+        // When
+        pipeline.configuration.imageEncodingQueue.isSuspended = true
+        expect(pipeline).toLoadImage(with: request)
+        expect(pipeline.configuration.imageEncodingQueue).toFinishWithEnqueuedOperationCount(1)
+
+        // Then
+        wait { _ in
+            XCTAssertNotNil(self.dataCache.cachedData(for: Test.url.absoluteString + "1"), "Expected processed image data to be stored")
+            XCTAssertEqual(self.dataCache.store.count, 1)
+        }
+    }
+
+    func testProcessedDataNotStoredWhenStorageDisabled() {
+        // Given
+        var configuration = pipeline.configuration
+        configuration.isDataCacheForProcessedDataEnabled = false
+        let pipeline = ImagePipeline(configuration: configuration)
+
+        // When
+        expect(pipeline).toLoadImage(with: request)
+
+        // Then
+        wait { _ in
+            XCTAssertNotNil(self.dataCache.cachedData(for: Test.url.absoluteString), "Expected original image data to be stored")
+            XCTAssertEqual(self.dataCache.store.count, 1)
+        }
+    }
+
+    func testSetCustomImageEncoder() {
+        struct MockImageEncoder: ImageEncoding {
+            let closure: (Image) -> Data?
+
+            func encode(image: Image) -> Data? {
+                return closure(image)
+            }
+        }
+
+        // Given
+        var configuration = pipeline.configuration
+        var isCustomEncoderCalled = false
+        let encoder = MockImageEncoder { _ in
+            isCustomEncoderCalled = true
+            return nil
+        }
+        configuration.makeImageEncoder = { _ in
+            return encoder
+        }
+        let pipeline = ImagePipeline(configuration: configuration)
+
+        // When
+        pipeline.configuration.imageEncodingQueue.isSuspended = true
+        expect(pipeline).toLoadImage(with: request)
+        expect(pipeline.configuration.imageEncodingQueue).toFinishWithEnqueuedOperationCount(1)
+
+        // Then
+        wait { _ in
+            XCTAssertTrue(isCustomEncoderCalled)
+            XCTAssertNil(self.dataCache.cachedData(for: Test.url.absoluteString + "1"), "Expected processed image data to not be stored")
+        }
+    }
+}
+#endif

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -26,7 +26,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         dataLoader.queue.isSuspended = true
 
         // Given requests with the same URLs and same processors
-        let processors = ProcessorFactory()
+        let processors = MockProcessorFactory()
         let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
         let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
 
@@ -55,7 +55,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         dataLoader.queue.isSuspended = true
 
         // Given requests with the same URLs but different processors
-        let processors = ProcessorFactory()
+        let processors = MockProcessorFactory()
         let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
         let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "2")])
 
@@ -84,8 +84,9 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // Given requests with the same URLs but different processors where one
         // processor is empty
-        let processors = ProcessorFactory()
+        let processors = MockProcessorFactory()
         let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
+
         var request2 = Test.request
         request2.processors = []
 
@@ -196,7 +197,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // Given
         // Make sure we don't start processing when some requests haven't
         // started yet.
-        let processors = ProcessorFactory()
+        let processors = MockProcessorFactory()
         let queueObserver = OperationQueueObserver(queue: pipeline.configuration.imageProcessingQueue)
 
         // When
@@ -218,7 +219,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         let queue = pipeline.configuration.imageProcessingQueue
         queue.isSuspended = true
 
-        let processors = ProcessorFactory()
+        let processors = MockProcessorFactory()
         let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
         let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
 
@@ -262,7 +263,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         }
 
         // Given requests with the same URLs but different processors
-        let processors = ProcessorFactory()
+        let processors = MockProcessorFactory()
         let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
         let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "2")])
 
@@ -335,7 +336,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // When/Then
         let operations = expect(queue).toEnqueueOperationsWithCount(2)
 
-        let processors = ProcessorFactory()
+        let processors = MockProcessorFactory()
         let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
         let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "2")])
 
@@ -476,28 +477,5 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         wait { _ in
             XCTAssertEqual(self.dataLoader.createdTaskCount, 2)
         }
-    }
-}
-
-/// Helps with counting processors.
-private final class ProcessorFactory {
-    var numberOfProcessorsApplied: Int = 0
-    let lock = NSLock()
-
-    private final class Processor: MockImageProcessor {
-        var factory: ProcessorFactory!
-
-        override func process(image: Image, context: ImageProcessingContext) -> Image? {
-            factory.lock.sync {
-                factory.numberOfProcessorsApplied += 1
-            }
-            return super.process(image: image, context: context)
-        }
-    }
-
-    func make(id: String) -> MockImageProcessor {
-        let processor = Processor(id: id)
-        processor.factory = self
-        return processor
     }
 }

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -258,7 +258,7 @@ class ImagePipelineTests: XCTestCase {
         // has decompression disabled
         let pipeline = ImagePipeline {
             $0.dataLoader = MockDataLoader()
-            $0.imageDecoder = { _ in
+            $0.makeImageDecoder = { _ in
                 MockAnonymousImageDecoder { _, _ in
                     return image
                 }
@@ -270,7 +270,9 @@ class ImagePipelineTests: XCTestCase {
 
         // When
         expect(pipeline).toLoadImage(with: Test.request) { result in
-            let output = result.value!.image
+            guard let output = result.value?.image else {
+                return XCTFail("Expected image to be loaded")
+            }
 
             XCTAssertTrue(output === image)
 
@@ -286,7 +288,7 @@ class ImagePipelineTests: XCTestCase {
         // Given the pipeline which returns a predefined image
         let pipeline = ImagePipeline {
             $0.dataLoader = MockDataLoader()
-            $0.imageDecoder = { _ in
+            $0.makeImageDecoder = { _ in
                 MockAnonymousImageDecoder { _, _ in
                     return image
                 }
@@ -296,7 +298,9 @@ class ImagePipelineTests: XCTestCase {
 
         // When
         expect(pipeline).toLoadImage(with: Test.request) { result in
-            let output = result.value!.image
+            guard let output = result.value?.image else {
+                return XCTFail("Expected image to be loaded")
+            }
 
             XCTAssertTrue(output !== image)
 
@@ -313,7 +317,9 @@ class ImagePipelineTests: XCTestCase {
         ])
 
         expect(pipeline).toLoadImage(with: request) { result in
-            let image = result.value!.image
+            guard let image = result.value?.image else {
+                return XCTFail("Expected image to be loaded")
+            }
 
             // Expect decompression to not be performed
             let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
@@ -322,12 +328,14 @@ class ImagePipelineTests: XCTestCase {
         wait()
     }
 
-    func testDecompressionPerformedWhenProcessorIsAppliedButDoesnNothing() {
+    func testDecompressionPerformedWhenProcessorIsAppliedButDoesNothing() {
         // Given request with scaling processor
         let request = ImageRequest(url: Test.url, processors: [MockEmptyImageProcessor()])
 
         expect(pipeline).toLoadImage(with: request) { result in
-            let image = result.value!.image
+            guard let image = result.value?.image else {
+                return XCTFail("Expected image to be loaded")
+            }
 
             // Expect decompression to be performed (processor was applied but it did nothing)
             let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
@@ -438,7 +446,7 @@ class ImagePipelineErrorHandlingTests: XCTestCase {
         // Given
         let pipeline = ImagePipeline {
             $0.dataLoader = MockDataLoader()
-            $0.imageDecoder = { _ in
+            $0.makeImageDecoder = { _ in
                 return MockFailingDecoder()
             }
             $0.imageCache = nil

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -115,17 +115,6 @@ class ImageProcessingTests: XCTestCase {
         // Then
         XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
     }
-
-    #if !os(macOS)
-
-    // MARK: - Decompression
-
-    func testTwoDifferentDecompressorsAreEqual() {
-        XCTAssertEqual(ImageDecompressor().hashValue, ImageDecompressor().hashValue)
-        XCTAssertEqual(ImageDecompressor(), ImageDecompressor())
-    }
-
-    #endif
 }
 
 class ImageProcessorCompositionTest: XCTestCase {
@@ -138,7 +127,7 @@ class ImageProcessorCompositionTest: XCTestCase {
         )
 
         // When
-        let image = processor.process(image: Image(), context: dummyProcessingContext)
+        let image = processor.process(image: Test.image, context: dummyProcessingContext)
 
         // Then
         XCTAssertEqual(image?.nk_test_processorIDs, ["1", "2"])

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -91,7 +91,8 @@ class ImageViewTests: XCTestCase {
 
     func testViewPreparedForReuseDisabled() {
         // Given an image view displaying an image
-        imageView.image = Test.image
+        let image = Test.image
+        imageView.image = image
 
         // When requesting the new image with prepare for reuse disabled
         var options = ImageLoadingOptions()
@@ -99,20 +100,21 @@ class ImageViewTests: XCTestCase {
         Nuke.loadImage(with: Test.request, options: options, into: imageView)
 
         // Expect the original image to still be displayed
-        XCTAssertEqual(imageView.image, Test.image)
+        XCTAssertEqual(imageView.image, image)
     }
 
     // MARK: - Memory Cache
 
     func testMemoryCacheUsed() {
         // Given the requested image stored in memory cache
-        mockCache[Test.request] = Test.image
+        let image = Test.image
+        mockCache[Test.request] = image
 
         // When requesting the new image
         Nuke.loadImage(with: Test.request, into: imageView)
 
         // Expect image to be displayed immediatelly
-        XCTAssertEqual(imageView.image, Test.image)
+        XCTAssertEqual(imageView.image, image)
     }
 
     func testMemoryCacheDisabled() {


### PR DESCRIPTION
## Introduction

- As a user, I would like to store processed images on disk, not the original ones, because recreating the processed ones is expensive and storing the original ones is wasteful
- As a user, I would like to store both processed and original images on disk so that I could create different variations of the same image by applying different processors, on demand

## Technical Solution

Extend `ImagePipeline` to support caching processed images and allow users to configure the pipeline to store only the original image data, or only the processed image data, or both.

The are multiple prerequisites for making this work.

### [#229 Decoupling Image Decompression](https://github.com/kean/Nuke/pull/229) ✅

Decompression is currently part of image processing which it shouldn't be because now in the case when we have processed image data, we will need to decompress it but we won't need to process it again.

### [#228 Generating Keys](https://github.com/kean/Nuke/pull/228) ✅

In Nuke 7 `ImagePipeline` simply uses `request.urlString` as a cache key which isn't enough for image processing. We need to be able to append image processors to these keys.

### [#233 Encoding Images](https://github.com/kean/Nuke/pull/233) ✅

Nuke currently provides image decoding infrastrucure: `ImageDecoding`, `ImageDecoder`, `ImageDecoderRegistry`. But it would now also need to be able to encode processed images.

### [#235 ImagePipeline v2](https://github.com/kean/Nuke/pull/235) ✅

The first version of `ImagePipeline` introduced in Nuke 7 has some technical debt which needs to be addressed. The primary reason for adding tech debt was introduction of progressive decoding without rethinking the existing solution.

Before [#227 Caching Processing Image](https://github.com/kean/Nuke/pull/227) can be implemented this tech debt needs to be addressed.

### Data Caching ✅

This one probably doesn't require any changes, we can use the existing `DataCaching` protocol for caching data:

```swift
public protocol DataCaching {
    func cachedData(for key: String) -> Data?
    func storeData(_ data: Data, for key: String)
}
```

## Future Improvements

Allow user to change disk cache options per request: