### PR TITLE
ImageProcessing String identifiers

### DIFF
--- a/Demo/Sources/Helpers/Utilities.swift
+++ b/Demo/Sources/Helpers/Utilities.swift
@@ -64,7 +64,7 @@ extension UIImage {
 
 /// Blurs image using CIGaussianBlur filter. Only blurs first scans of the
 /// progressive JPEG.
-struct _ProgressiveBlurImageProcessor: ImageProcessing {
+struct _ProgressiveBlurImageProcessor: ImageProcessing, Hashable {
     func process(image: Image, context: ImageProcessingContext) -> Image? {
         // CoreImage is too slow on simulator.
         #if targetEnvironment(simulator)
@@ -90,7 +90,9 @@ struct _ProgressiveBlurImageProcessor: ImageProcessing {
         #endif
     }
 
-    static func == (lhs: _ProgressiveBlurImageProcessor, rhs: _ProgressiveBlurImageProcessor) -> Bool {
-        return true
+    let identifier: String = "_ProgressiveBlurImageProcessor"
+
+    var hashableIdentifier: AnyHashable {
+        return self
     }
 }

--- a/Documentation/Guides/Core Image Integration Guide.md
+++ b/Documentation/Guides/Core Image Integration Guide.md
@@ -69,11 +69,11 @@ let processedImage = image.applyFilter(filter)
 
 # Core Image in Nuke
 
-Here's an example of a blur filter that implements Nuke's `Processing` protocol and uses our new extensions:
+Here's an example of a blur filter that implements Nuke's `ImageProcessing` protocol and uses our new extensions:
 
 ```swift
 /// Blurs image using CIGaussianBlur filter.
-struct GaussianBlur: ImageProcessing {
+struct GaussianBlur: ImageProcessing, Hashable {
     private let radius: Int
 
     /// Initializes the receiver with a blur radius.
@@ -86,9 +86,12 @@ struct GaussianBlur: ImageProcessing {
         return image.applyFilter(filter: CIFilter(name: "CIGaussianBlur", withInputParameters: ["inputRadius" : radius]))
     }
 
-    /// Compares two filters based on their radius.
-    static func ==(lhs: GaussianBlur, rhs: GaussianBlur) -> Bool {
-        return lhs.radius == rhs.radius
+    var identifier: String {
+        return "GaussianBlur\(radius)"
+    }
+    
+    var hashableIdentifier: AnyHashable {
+        return self
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ ImageRequest(url: url).process(key: "circularAvatar") {
 }
 ```
 
-All those APIs are built on top of `ImageProcessing` protocol which you can also use to implement custom processors. Keep in mind that `ImageProcessing` also requires `Equatable` conformance which helps Nuke identify images in memory cache.
+All those APIs are built on top of `ImageProcessing` protocol which you can also use to implement custom processors.
 
 > See [Core Image Integration Guide](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Core%20Image%20Integration%20Guide.md) for info about using Core Image with Nuke
 

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -63,9 +63,6 @@ public /* final */ class ImagePipeline: ImageTaskManaging {
         /// Image decoding queue. Default maximum concurrent task count is 1.
         public var imageDecodingQueue = OperationQueue()
 
-        /// This is here just for backward compatibility with `Loader`.
-        var imageProcessor: (Image, ImageRequest) -> AnyImageProcessor? = { $1.processor }
-
         /// Image processing queue. Default maximum concurrent task count is 2.
         public var imageProcessingQueue = OperationQueue()
 
@@ -372,20 +369,20 @@ public /* final */ class ImagePipeline: ImageTaskManaging {
         configuration.imageProcessingQueue.addOperation(operation)
     }
 
-    private func processor(for image: Image, request: ImageRequest) -> AnyImageProcessor? {
+    private func processor(for image: Image, request: ImageRequest) -> ImageProcessing? {
         if Configuration.isAnimatedImageDataEnabled && image.animatedImageData != nil {
             return nil // Don't process animated images.
         }
-        var processors = [AnyImageProcessor]()
-        if let processor = configuration.imageProcessor(image, request) {
+        var processors = [ImageProcessing]()
+        if let processor = request.processor {
             processors.append(processor)
         }
         #if !os(macOS)
         if configuration.isDecompressionEnabled {
-            processors.append(AnyImageProcessor(ImageDecompression()))
+            processors.append(ImageDecompression())
         }
         #endif
-        return processors.isEmpty ? nil : AnyImageProcessor(ImageProcessorComposition(processors))
+        return processors.isEmpty ? nil : ImageProcessorComposition(processors)
     }
 
     // MARK: - Image Decoding

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -81,26 +81,6 @@ class ImagePipelineTests: XCTestCase {
         wait()
     }
 
-    // MARK: - Configuration
-
-    func testOverridingProcessor() {
-        // Given
-        let pipeline = ImagePipeline {
-            $0.dataLoader = dataLoader
-            $0.imageProcessor = { _, _ in
-                AnyImageProcessor(MockImageProcessor(id: "processorFromOptions"))
-            }
-        }
-        let request = Test.request.processed(with: MockImageProcessor(id: "processorFromRequest"))
-
-        // Then
-        expect(pipeline).toLoadImage(with: request) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs.count, 1)
-            XCTAssertEqual(response?.image.nk_test_processorIDs.first, "processorFromOptions")
-        }
-        wait()
-    }
-
     // MARK: - Animated Images
 
     func testAnimatedImagesArentProcessed() {
@@ -326,7 +306,7 @@ class ImagePipelineTests: XCTestCase {
     func testDecompressionNotPerformedWhenProcessorWasApplied() {
         // Given request with scaling processor
         var request = Test.request
-        request.processor = AnyImageProcessor(ImageScalingProcessor(targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit))
+        request.processor = ImageScalingProcessor(targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit)
 
         expect(pipeline).toLoadImage(with: request) { response, _ in
             let image = response!.image
@@ -341,7 +321,7 @@ class ImagePipelineTests: XCTestCase {
     func testDecompressionPerformedWhenProcessorIsAppliedButDoesnNothing() {
         // Given request with scaling processor
         var request = Test.request
-        request.processor = AnyImageProcessor(MockEmptyImageProcessor())
+        request.processor = MockEmptyImageProcessor()
 
         expect(pipeline).toLoadImage(with: request) { response, _ in
             let image = response!.image

--- a/Tests/ImageRequestTests.swift
+++ b/Tests/ImageRequestTests.swift
@@ -30,7 +30,7 @@ class ImageRequestTests: XCTestCase {
         request.loadKey = "1"
         request.cacheKey = "2"
         request.userInfo = "3"
-        request.processor = AnyImageProcessor(MockImageProcessor(id: "4"))
+        request.processor = MockImageProcessor(id: "4")
         request.priority = .high
 
         // When
@@ -43,7 +43,7 @@ class ImageRequestTests: XCTestCase {
         XCTAssertEqual(copy.loadKey, "1")
         XCTAssertEqual(copy.cacheKey, "2")
         XCTAssertEqual(copy.userInfo as? String, "3")
-        XCTAssertEqual(copy.processor, AnyImageProcessor(MockImageProcessor(id: "4")))
+        XCTAssertEqual((copy.processor as? MockImageProcessor)?.identifier, "4")
         XCTAssertEqual(copy.priority, .high)
     }
 
@@ -85,14 +85,12 @@ class ImageRequestCacheKeyTests: XCTestCase {
     func testRequestsWithTheSameProcessorsAreEquivalent() {
         let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
         let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
-        XCTAssertEqual(MockImageProcessor(id: "1"), MockImageProcessor(id: "1"))
         AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
     
     func testRequestsWithDifferentProcessorsAreNotEquivalent() {
         let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
         let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "2"))
-        XCTAssertNotEqual(MockImageProcessor(id: "1"), MockImageProcessor(id: "2"))
         XCTAssertNotEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
 
@@ -158,14 +156,12 @@ class ImageRequestLoadKeyTests: XCTestCase {
     func testRequestsWithTheSameProcessorsAreEquivalent() {
         let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
         let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
-        XCTAssertEqual(MockImageProcessor(id: "1"), MockImageProcessor(id: "1"))
         AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
     }
 
     func testRequestsWithDifferentProcessorsAreEquivalent() {
         let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
         let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "2"))
-        XCTAssertNotEqual(MockImageProcessor(id: "1"), MockImageProcessor(id: "2"))
         AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
     }
 
@@ -173,6 +169,14 @@ class ImageRequestLoadKeyTests: XCTestCase {
         let request1 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .reloadRevalidatingCacheData, timeoutInterval: 50))
         let request2 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 0))
         XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+    }
+
+    func testMockImageProcessorCorrectlyImplementsIdentifiers() {
+        XCTAssertEqual(MockImageProcessor(id: "1").identifier, MockImageProcessor(id: "1").identifier)
+        XCTAssertEqual(MockImageProcessor(id: "1").hashableIdentifier, MockImageProcessor(id: "1").hashableIdentifier)
+
+        XCTAssertNotEqual(MockImageProcessor(id: "1").identifier, MockImageProcessor(id: "2").identifier)
+        XCTAssertNotEqual(MockImageProcessor(id: "1").hashableIdentifier, MockImageProcessor(id: "2").hashableIdentifier)
     }
 
     // MARK: - Custom Load Key

--- a/Tests/MockImageProcessor.swift
+++ b/Tests/MockImageProcessor.swift
@@ -23,38 +23,37 @@ private struct AssociatedKeys {
 // MARK: - MockImageProcessor
 
 class MockImageProcessor: ImageProcessing {
-    let id: String
+    var identifier: String
+
     init(id: String) {
-        self.id = id
+        self.identifier = id
     }
     func process(image: Image, context: ImageProcessingContext) -> Image? {
         var processorIDs: [String] = image.nk_test_processorIDs
-        processorIDs.append(id)
+        processorIDs.append(identifier)
         let processedImage = Image()
         processedImage.nk_test_processorIDs = processorIDs
         return processedImage
-    }
-
-    static func == (lhs: MockImageProcessor, rhs: MockImageProcessor) -> Bool {
-        return lhs.id == rhs.id
     }
 }
 
 // MARK: - MockFailingProcessor
 
-class MockFailingProcessor: Nuke.ImageProcessing {
+class MockFailingProcessor: ImageProcessing {
     func process(image: Image, context: ImageProcessingContext) -> Image? {
         return nil
     }
 
-    static func ==(lhs: MockFailingProcessor, rhs: MockFailingProcessor) -> Bool {
-        return true
+    var identifier: String {
+        return "MockFailingProcessor"
     }
 }
 
 // MARK: - MockEmptyImageProcessor
 
 class MockEmptyImageProcessor: ImageProcessing {
+    let identifier = "MockEmptyImageProcessor"
+
     func process(image: Image, context: ImageProcessingContext) -> Image? {
         return image
     }

--- a/Tests/ThreadSafetyTests.swift
+++ b/Tests/ThreadSafetyTests.swift
@@ -179,9 +179,7 @@ final class RandomizedTests: XCTestCase {
             request.priority = every(2) ? .high : .normal
             if every(3) {
                 let size = every(2) ? CGSize(width: 40, height: 40) : CGSize(width: 60, height: 60)
-                request.processor = AnyImageProcessor(
-                    ImageScalingProcessor(targetSize: size, contentMode: .aspectFit)
-                )
+                request.processor = ImageScalingProcessor(targetSize: size, contentMode: .aspectFit)
             }
             if every(10) {
                 request.loadKey = url


### PR DESCRIPTION
## Introduction

One of the prerequisites for [#227: Caching Processed Images](https://github.com/kean/Nuke/pull/227) is that we should be able to generate cache keys based on the applied image processors. This isn't possible in the current `ImageProcessing` infrastructure.

In order to make #227 possible we change the way we identify image processors. Instead of conforming to `Equatable` each image processor will now return a `String` identifier.

## Performance

Unfortunately, `String` identifiers are slow. Even doing simple `identifier = "ImageDecompressor\(targetSize)\(contentMode)\(upscale)"` makes the primary `Nuke.loadImage(with:into:)` function _twice_ as slow which is unacceptable. In order to compensate that, each image processors will also be able to (optionally) return a `hashableIdentifier: AnyHashable` which is just as fast as the existing `Equatable`-based solution. For example, existing `ImageDecompressor` now conforms to `Hashable` and simply returns `self` in `var hashableIdentifier: AnyHashable`. There is no performance regressions as the result of this change.

## Side Effects

One of the side effects of getting rid of `Equatable` protocol is that using `ImageProcessing` protocol becomes much easier. We no longer need `AnyImageProcessor` so instead of doing this:

```swift
request.processor = AnyImageProcessor(ImageDecompressor(targetSize: size, contentMode: .aspectFit))
```

You can now simply do this:

```swift
request.processor = ImageDecompressor(targetSize: size, contentMode: .aspectFit)
```

## Changes

- `ImageProcessing` protocol no longer inherits from `Equatable` but has new `identifier` property
- Add `hashableIdentifier` property to `ImageProcessing` protocol for performance optimizations
- Remove `AnyImageProcessor` - type-erased processor which we no longer need
- Update `ImageRequest` API to use new `ImageProcessing` protocol