### PR TITLE
Decoupling Image Decompression

### DIFF
--- a/Demo/Sources/RateLimiterDemoViewController.swift
+++ b/Demo/Sources/RateLimiterDemoViewController.swift
@@ -73,7 +73,7 @@ final class RateLimiterDemoViewController: UICollectionViewController {
         options.pipeline = pipeline
 
         Nuke.loadImage(
-            with: ImageRequest(url: photos[indexPath.row], targetSize: ImageDecompressor.targetSize(for: imageView), contentMode: .aspectFill),
+            with: ImageRequest(url: photos[indexPath.row], targetSize: ImageScalingProcessor.targetSize(for: imageView), contentMode: .aspectFill),
             options: options,
             into: imageView
         )

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ By default, the data is loaded using [`URLSession`](https://developer.apple.com/
 
 > See [Image Caching Guide](https://kean.github.io/post/image-caching) to learn more.
 
-When the data is loaded the pipeline decodes the data (creates `UIImage` object from `Data`). Then it applies a default image processor - `ImageDecompressor` - to force data decompression in a background. The processed image is then stored in the memory cache and returned in the completion closure.
+When the data is loaded the pipeline decodes the data (creates `UIImage` object from `Data`). Then it applies the processors specified in the request. It then decompressed the image in the backgound (if there were no processors or the processors did nothing). The processed image is then stored in the memory cache and returned in the completion closure.
 
 > When you create `UIImage` object form data, the data doesn't get decoded immediately. It's decoded the first time it's used - for example, when you display the image in an image view. Decoding is a resource-intensive operation, if you do it on the main thread you might see dropped frames, especially for image formats like JPEG.
 >

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -134,7 +134,7 @@ class ImageProcessingTests: XCTestCase {
     #if !os(macOS)
     func testUsingProcessorRequestParameter() {
         // Given
-        let processor = ImageDecompressor(targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit, upscale: false)
+        let processor = ImageScalingProcessor(targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit, upscale: false)
 
         // When
         let request = ImageRequest(url: Test.url, processor: processor)

--- a/Tests/MockImageDecoder.swift
+++ b/Tests/MockImageDecoder.swift
@@ -24,3 +24,15 @@ class MockImageDecoder: ImageDecoding {
         return decoder.decode(data: data, isFinal: isFinal)
     }
 }
+
+class MockAnonymousImageDecoder: ImageDecoding {
+    let closure: (Data, Bool) -> Image?
+
+    init(_ closure: @escaping (Data, Bool) -> Image?) {
+        self.closure = closure
+    }
+
+    func decode(data: Data, isFinal: Bool) -> Image? {
+        return closure(data, isFinal)
+    }
+}

--- a/Tests/MockImageProcessor.swift
+++ b/Tests/MockImageProcessor.swift
@@ -51,3 +51,15 @@ class MockFailingProcessor: Nuke.ImageProcessing {
         return true
     }
 }
+
+// MARK: - MockEmptyImageProcessor
+
+class MockEmptyImageProcessor: ImageProcessing {
+    func process(image: Image, context: ImageProcessingContext) -> Image? {
+        return image
+    }
+
+    static func == (lhs: MockEmptyImageProcessor, rhs: MockEmptyImageProcessor) -> Bool {
+        return true
+    }
+}

--- a/Tests/ThreadSafetyTests.swift
+++ b/Tests/ThreadSafetyTests.swift
@@ -261,7 +261,7 @@ final class RandomizedTests: XCTestCase {
             if every(3) {
                 let size = every(2) ? CGSize(width: 40, height: 40) : CGSize(width: 60, height: 60)
                 request.processor = AnyImageProcessor(
-                    ImageDecompressor(targetSize: size, contentMode: .aspectFit)
+                    ImageScalingProcessor(targetSize: size, contentMode: .aspectFit)
                 )
             }
             if every(10) {


### PR DESCRIPTION
In the existing solution, `ImageDecompressor` is the default image processor of each `ImageRequest` which was done mostly to reduce the implementation efforts. But to make [#227: Caching Processed Images](https://github.com/kean/Nuke/pull/227) possible, decompression needs to change. At least one of the new scenarios to support is the following: we read the processed image data from disk, no processors need to be applied, but the decompression needs to run.

## Problems with the Current Solution

In the current solution, each request has a default processor - `ImageDecompressor`. The responsibility to decide when to decompress lies on the user and it's easy to make mistakes. Let's look at the following example:

```swift
let request = ImageRequest(url: url)
    .processed(by: ImageDecompressor(targetSize: CGSize(width: 40, height: 40)))
```

There are at least two problems with this code:

1) `ImageDecompressor` is also used for scaling (it's very efficient to decompress and scale at the same time for certain formats like JPEG) but it's not clear why you would use `ImageDecompressor` for scaling and not, let's say, `ImageScalingProcessor` (which doesn't exist). This was partially mitigated by the addition of convenience `ImageRequest` initializers `public init(url: URL, targetSize: CGSize, contentMode: ImageScalingProcessor.ContentMode, upscale: Bool = false)` but at the cost of increasing API surface and adding two ways to do the same thing.
2) `processed(by:)` appends a new processor to the default one which is `ImageDecompressor`. The pipeline will apply two decompressors: the first one will decompress the full-size image and the second one will scale it – this is extremely inefficient.

## Proposed Solution

The proposed new public behavior is conceptually much simpler:

- The default `ImageRequest` processor is always `nil`
- The decompression is performed automatically and _only_ if needed, there is no need to worry about it, it just works

## When to Decompress

We need to decompress only freshly decoded images which don't require any processing. It includes the following scenarios:

- Processed image data was loaded from disk (this is the new scenario from https://github.com/kean/Nuke/pull/227 which wasn't implemented yet).
- Original image data was loaded from disk/network and no processors are set on the request
- Original image data was loaded from disk/network and the processor is set on the request but does nothing. This is a very real scenario. For example, you set processor to `ImageScalingProcessor` with a target size 200x200 but the image is already 180x180 and doesn't need any processing. The pipeline needs to be smart enough to run decompression in this scenario.

## Changes

- The default `processor` of each `ImageRequest` is now `nil`
- `ImagePipeline` now decompresses images by default, the behavior can be disabled via new `isDecompressionEnabled` pipeline configuration option
- Rename `ImageDecompressor` to `ImageScalingProcessor` (the name might change in the next pull requests)