### PR TITLE
Remove Swift 4.2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,6 @@ matrix:
       env: DESTINATION="OS=10.3.1,name=iPhone SE" RUN_TESTS="YES" SWIFT_VERSION="5.0"
 
     - osx_image: xcode10.2
-      env: DESTINATION="OS=12.2,name=iPhone X" RUN_TESTS="YES" SWIFT_VERSION="4.2"
-    - osx_image: xcode10.2
-      env: DESTINATION="OS=11.4,name=iPhone X" RUN_TESTS="YES" SWIFT_VERSION="4.2"
-    - osx_image: xcode10.2
-      env: DESTINATION="OS=10.3.1,name=iPhone SE" RUN_TESTS="YES" SWIFT_VERSION="4.2"
-
-    - osx_image: xcode10.1
-      env: DESTINATION="OS=11.4,name=iPhone X" RUN_TESTS="YES" SWIFT_VERSION="4.2"
-
-    - osx_image: xcode10.2
       env: DESTINATION="OS=12.2,name=Apple TV 4K" RUN_TESTS="YES" SWIFT_VERSION="5.0"
     - osx_image: xcode10.2
       env: DESTINATION="OS=11.3,name=Apple TV 4K" RUN_TESTS="YES" SWIFT_VERSION="5.0"

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -754,7 +754,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -779,7 +778,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -806,7 +804,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/Nuke iOS Performance Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nuke Tests Host.app/Nuke Tests Host";
 			};
 			name = Debug;
@@ -833,7 +830,6 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/Nuke iOS Performance Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nuke Tests Host.app/Nuke Tests Host";
 			};
 			name = Release;
@@ -885,7 +881,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -931,7 +927,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/README.md
+++ b/README.md
@@ -503,10 +503,11 @@ If you'd like to contribute, please feel free to create a PR.
 <a name="h_requirements"></a>
 # Requirements
 
-| Nuke                 | Swift                     | Xcode                | Platforms                                           |
-|------------------    |-----------------------    |------------------    |-------------------------------------------------    |
-| Nuke 7.6             | Swift 4.2 – 5.0           | Xcode 10.1 – 10.2     | iOS 10.0 / watchOS 3.0 / macOS 10.12 / tvOS 10.0      |
-| Nuke 7.2 – 7.5.2     | Swift 4.0 – 4.2     | Xcode 9.2 – 10.1     |  iOS 9.0 / watchOS 2.0 / macOS 10.10 / tvOS 9.0     | 
+| Nuke              | Swift             | Xcode              | Platforms                                         |
+|-------------------|-------------------|--------------------|---------------------------------------------------|
+| Nuke 8            | Swift 5.0         | Xcode 10.1 – 10.2  | iOS 10.0 / watchOS 3.0 / macOS 10.12 / tvOS 10.0  |
+| Nuke 7.6 – 7.6.3  | Swift 4.2 – 5.0   | Xcode 10.1 – 10.2  | iOS 10.0 / watchOS 3.0 / macOS 10.12 / tvOS 10.0  |
+| Nuke 7.2 – 7.5.2  | Swift 4.0 – 4.2   | Xcode 9.2 – 10.1   | iOS 9.0 / watchOS 2.0 / macOS 10.10 / tvOS 9.0    | 
 
 # License
 

--- a/Sources/Internal.swift
+++ b/Sources/Internal.swift
@@ -617,18 +617,11 @@ extension String {
             return nil
         }
 
-        #if swift(>=5.0)
         let hash = input.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
             var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
             CC_SHA1(bytes.baseAddress, CC_LONG(input.count), &hash)
             return hash
         }
-        #else
-        var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
-        input.withUnsafeBytes {
-            _ = CC_SHA1($0, CC_LONG(input.count), &hash)
-        }
-        #endif
 
         return hash.map({ String(format: "%02x", $0) }).joined()
     }


### PR DESCRIPTION
Swift 5.0 and Swift 4.2 are source compatible so I expect most project to be updated to Swift 5.0 by the time Nuke 8 is released. In the meantime, I'm going to save a lot of time by not maintaining both versions and it would make it easier to adopt Swift 5 features.