### PR TITLE
Add ImageTaskDelegate

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		0C7C06981BCA888800089D7F /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068D1BCA888800089D7F /* Helpers.swift */; };
 		0C7C06991BCA888800089D7F /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068E1BCA888800089D7F /* XCTestCaseExtensions.swift */; };
 		0C8684FF20BDD578009FF7CC /* ImagePipelineProgressiveDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2A8CFA20970D8D0013FD65 /* ImagePipelineProgressiveDecodingTests.swift */; };
+		0C86AB6A228B3B5100A81BA1 /* ImageTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C86AB69228B3B5100A81BA1 /* ImageTask.swift */; };
 		0C8D7BD31D9DBF1600D12EB7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD21D9DBF1600D12EB7 /* AppDelegate.swift */; };
 		0C8D7BD51D9DBF1600D12EB7 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD41D9DBF1600D12EB7 /* ViewController.swift */; };
 		0C8D7BD81D9DBF1600D12EB7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD61D9DBF1600D12EB7 /* Main.storyboard */; };
@@ -146,6 +147,7 @@
 		0C7C068C1BCA888800089D7F /* MockDataLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataLoader.swift; sourceTree = "<group>"; };
 		0C7C068D1BCA888800089D7F /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		0C7C068E1BCA888800089D7F /* XCTestCaseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtensions.swift; sourceTree = "<group>"; };
+		0C86AB69228B3B5100A81BA1 /* ImageTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTask.swift; sourceTree = "<group>"; };
 		0C8D74201D9D6EEB0036349E /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		0C8D7BD01D9DBF1600D12EB7 /* Nuke Tests Host.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Nuke Tests Host.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C8D7BD21D9DBF1600D12EB7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 				0C0FD5DF1CA47FE1002A78FB /* ImageView.swift */,
 				0C0FD5D91CA47FE1002A78FB /* ImageRequest.swift */,
 				0C0FD5D31CA47FE1002A78FB /* ImagePipeline.swift */,
+				0C86AB69228B3B5100A81BA1 /* ImageTask.swift */,
 				0C367A9420B9D0D0002342A5 /* ImageTaskMetrics.swift */,
 				0C0FD5D71CA47FE1002A78FB /* ImageCache.swift */,
 				0C0FD5D81CA47FE1002A78FB /* ImageProcessing.swift */,
@@ -657,6 +660,7 @@
 				0C367A9520B9D0D0002342A5 /* ImageTaskMetrics.swift in Sources */,
 				0CB26802208F2565004C83F4 /* DataCache.swift in Sources */,
 				0C0FD6041CA47FE1002A78FB /* ImageRequest.swift in Sources */,
+				0C86AB6A228B3B5100A81BA1 /* ImageTask.swift in Sources */,
 				0C7150091FC9724C00B880AC /* Internal.swift in Sources */,
 				0CE2D9BA2084FDDD00934B28 /* ImageDecoding.swift in Sources */,
 				0CF4DE7D1D412A9E00170289 /* ImagePreheater.swift in Sources */,

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -1,0 +1,161 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+// MARK: - ImageTaskDelegate
+
+/// All methods of the delegates are called on the main thread.
+public protocol ImageTaskDelegate: class {
+    /// Called when the task finishes loading the image.
+    func imageTask(_ task: ImageTask, didCompleteWithResponse response: ImageResponse?, error: ImagePipeline.Error?)
+
+    /// Called periodically during the lifetime of a task when progress is updated.
+    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64)
+
+    /// Called periodically when new scans of progressive image are loaded and
+    /// processed.
+    ///
+    /// To enable progressive image decoding, see `ImagePipeline.Configuration`
+    /// `isProgressiveDecodingEnabled`.
+    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse)
+}
+
+public extension ImageTaskDelegate {
+    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64) {}
+    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse) {}
+}
+
+// MARK: - ImageTask
+
+/// A task performed by the `ImagePipeline`. The pipeline maintains a strong
+/// reference to the task until the request finishes or fails; you do not need
+/// to maintain a reference to the task unless it is useful to do so for your
+/// app’s internal bookkeeping purposes.
+public /* final */ class ImageTask: Hashable {
+    /// An identifier uniquely identifies the task within a given pipeline. Only
+    /// unique within this pipeline.
+    public let taskId: Int
+
+    weak var delegate: ImageTaskDelegate?
+    weak var pipeline: ImageTaskManaging?
+
+    /// The original request with which the task was created.
+    public let request: ImageRequest
+    var priority: ImageRequest.Priority
+
+    /// The number of bytes that the task has received.
+    public internal(set) var completedUnitCount: Int64 = 0
+
+    /// A best-guess upper bound on the number of bytes the client expects to send.
+    public internal(set) var totalUnitCount: Int64 = 0
+
+    /// Returns a progress object for the task. The object is created lazily.
+    public var progress: Progress {
+        if _progress == nil { _progress = Progress() }
+        return _progress!
+    }
+    private(set) var _progress: Progress?
+
+    /// A completion handler to be called when task finishes or fails.
+    public typealias Completion = (_ response: ImageResponse?, _ error: ImagePipeline.Error?) -> Void
+
+    /// A progress handler to be called periodically during the lifetime of a task.
+    public typealias ProgressHandler = (_ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void
+
+    // internal stuff associated with a task
+    var metrics: ImageTaskMetrics?
+
+    // `true` is the task is ready to be started
+    var isStartNeeded = true
+
+    init(taskId: Int, request: ImageRequest) {
+        self.taskId = taskId
+        self.request = request
+        self.priority = request.priority
+    }
+
+    /// Starts executing the task.
+    public func start() {
+        pipeline?.imageTaskStartCalled(self)
+    }
+
+    /// Marks task as being cancelled.
+    ///
+    /// The pipeline will immediately cancel any work associated with a task
+    /// unless there is an equivalent outstanding task running (see
+    /// `ImagePipeline.Configuration.isDeduplicationEnabled` for more info).
+    public func cancel() {
+        delegate = nil // Zeroing weak references is always thread-safe
+        pipeline?.imageTaskCancelCalled(self)
+        pipeline = nil // Zeroing weak references is always thread-safe
+    }
+
+    /// Update s priority of the task even if the task is already running.
+    public func setPriority(_ priority: ImageRequest.Priority) {
+        pipeline?.imageTaskUpdatePriorityCalled(self, priority: priority)
+    }
+
+    // MARK: - Hashable
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self).hashValue)
+    }
+
+    public static func == (lhs: ImageTask, rhs: ImageTask) -> Bool {
+        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    }
+}
+
+protocol ImageTaskManaging: class {
+    func imageTaskStartCalled(_ task: ImageTask)
+    func imageTaskCancelCalled(_ task: ImageTask)
+    func imageTaskUpdatePriorityCalled(_ task: ImageTask, priority: ImageRequest.Priority)
+}
+
+// MARK: - ImageResponse
+
+/// Represents an image response.
+public final class ImageResponse {
+    public let image: Image
+    public let urlResponse: URLResponse?
+    // the response is only nil when new disk cache is enabled (it only stores
+    // data for now, but this might change in the future).
+    public let scanNumber: Int?
+
+    public init(image: Image, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
+        self.image = image
+        self.urlResponse = urlResponse
+        self.scanNumber = scanNumber
+    }
+
+    func map(_ transformation: (Image) -> Image?) -> ImageResponse? {
+        return autoreleasepool {
+            guard let output = transformation(image) else {
+                return nil
+            }
+            return ImageResponse(image: output, urlResponse: urlResponse, scanNumber: scanNumber)
+        }
+    }
+}
+
+// MARK: - ImageTaskAnonymousDelegate
+
+final class ImageTaskAnonymousDelegate: ImageTaskDelegate {
+    let completionHandler: ImageTask.Completion?
+    let progressHandler: ImageTask.ProgressHandler?
+
+    init(progress: ImageTask.ProgressHandler?, completion: ImageTask.Completion?) {
+        self.progressHandler = progress
+        self.completionHandler = completion
+    }
+
+    func imageTask(_ task: ImageTask, didCompleteWithResponse response: ImageResponse?, error: ImagePipeline.Error?) {
+        completionHandler?(response, error)
+    }
+
+    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64) {
+        progressHandler?(completedUnitCount, totalUnitCount)
+    }
+}

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -448,7 +448,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
             pipeline.loadImage(
                 with: request,
-                progress: { _, completed, total in
+                progress: { completed, total in
                     XCTAssertTrue(Thread.isMainThread)
                     expectedProgress.received((completed, total))
                 }

--- a/Tests/ImagePipelineResumableDataTests.swift
+++ b/Tests/ImagePipelineResumableDataTests.swift
@@ -44,7 +44,7 @@ class ImagePipelineResumableDataTests: XCTestCase {
         let expectedProgressInitial = expectProgress(
             [(3799, 22789), (7598, 22789), (11397, 22789)]
         )
-        expect(pipeline).toFailRequest(Test.request, progress: { (_, completed, total) in
+        expect(pipeline).toFailRequest(Test.request, progress: { completed, total in
             expectedProgressInitial.received((completed, total))
         })
         wait()
@@ -54,7 +54,7 @@ class ImagePipelineResumableDataTests: XCTestCase {
         let expectedProgersRemaining = expectProgress(
             [(15196, 22789), (18995, 22789), (22789, 22789)]
         )
-        expect(pipeline).toLoadImage(with: Test.request, progress: { (_, completed, total) in
+        expect(pipeline).toLoadImage(with: Test.request, progress: { completed, total in
             expectedProgersRemaining.received((completed, total))
         })
         wait()

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -175,7 +175,7 @@ class ImageViewTests: XCTestCase {
         Nuke.loadImage(
             with: Test.request,
             into: imageView,
-            progress: { _, completed, total in
+            progress: { completed, total in
                 // Expect progress to be reported, on the main thread
                 XCTAssertTrue(Thread.isMainThread)
                 expectedProgress.received((completed, total))

--- a/Tests/MockImagePipeline.swift
+++ b/Tests/MockImagePipeline.swift
@@ -5,17 +5,22 @@
 import Foundation
 @testable import Nuke
 
-private class _MockImageTask: ImageTask {
+private class MockImageTask: ImageTask {
+    fileprivate var onStart: () -> Void = {}
     fileprivate var isCancelled = false
-    fileprivate var _cancel: () -> Void = {}
+    fileprivate var onCancel: () -> Void = {}
 
     init(request: ImageRequest) {
         super.init(taskId: 0, request: request)
     }
 
+    override func start() {
+        onStart()
+    }
+
     override func cancel() {
         isCancelled = true
-        _cancel()
+        onCancel()
     }
 }
 
@@ -35,17 +40,34 @@ class MockImagePipeline: ImagePipeline {
 
     @discardableResult
     override func loadImage(with request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ImageTask.Completion? = nil) -> ImageTask {
-        let task = _MockImageTask(request: request)
+        let task = MockImageTask(request: request)
+        let delegate = MockImageTaskDelegate()
+        delegate.progressHandler = { progress?($0, $1) }
+        delegate.completion = completion
+        loadImage(for: task, delegate: delegate, anonymous: delegate)
+        return task
+    }
 
+    override func imageTask(with request: ImageRequest, delegate: ImageTaskDelegate) -> ImageTask {
+        let task = MockImageTask(request: request)
+        task.onStart = { [weak self, weak delegate] in
+            guard let self = self, let delegate = delegate else { return }
+            self.loadImage(for: task, delegate: delegate)
+        }
+        return task
+    }
+
+    private func loadImage(for task: MockImageTask, delegate: ImageTaskDelegate, anonymous: MockImageTaskDelegate? = nil) {
         createdTaskCount += 1
 
         NotificationCenter.default.post(name: MockImagePipeline.DidStartTask, object: self)
 
-        let operation = BlockOperation {
+        let operation = BlockOperation { [weak delegate] in
             for (completed, total) in [(10, 20), (20, 20)] as [(Int64, Int64)] {
                 DispatchQueue.main.async {
                     guard !task.isCancelled else { return }
-                    progress?(nil, completed, total)
+                    delegate?.imageTask(task, didUpdateProgress: completed, totalUnitCount: total)
+                    _ = anonymous // retain the delegates
                 }
             }
 
@@ -54,18 +76,40 @@ class MockImagePipeline: ImagePipeline {
                 NotificationCenter.default.post(name: MockImagePipeline.DidFinishTask, object: self)
 
                 guard !task.isCancelled else { return }
-                completion?(Test.response, nil)
+                delegate?.imageTask(task, didCompleteWithResponse: Test.response, error: nil)
+                _ = anonymous // retain the delegates
             }
         }
-        self.queue.addOperation(operation)
 
         if isCancellationEnabled {
-            task._cancel = { [weak operation] in
+            task.onCancel = { [weak operation] in
                 operation?.cancel()
                 NotificationCenter.default.post(name: MockImagePipeline.DidCancelTask, object: self)
             }
         }
 
-        return task
+        self.queue.addOperation(operation)
+    }
+}
+
+final class MockImageTaskDelegate: ImageTaskDelegate {
+    var progressHandler: ((_ total: Int64, _ completed: Int64) -> Void)?
+    var progressiveResponseHandler: ((ImageResponse) -> Void)?
+    var completion: ((ImageResponse?, ImagePipeline.Error?) -> Void)?
+    var next: ImageTaskDelegate?
+
+    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64) {
+        progressHandler?(completedUnitCount, totalUnitCount)
+        next?.imageTask(task, didUpdateProgress: completedUnitCount, totalUnitCount: totalUnitCount)
+    }
+
+    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse) {
+        progressiveResponseHandler?(response)
+        next?.imageTask(task, didProduceProgressiveResponse: response)
+    }
+
+    func imageTask(_ task: ImageTask, didCompleteWithResponse response: ImageResponse?, error: ImagePipeline.Error?) {
+        completion?(response, error)
+        next?.imageTask(task, didCompleteWithResponse: response, error: error)
     }
 }


### PR DESCRIPTION
The progressive images were added in the existing `ImageTask` progress handler as a quick solution in Nuke 7. Now it's time to address this.

## Changes

- Extend `ImagePipeline` API with a new method:

```swift
public func imageTask(with request: ImageRequest, delegate: ImageTaskDelegate) -> ImageTask
```

Unlike the existing `loadImage(with:)` method, the new method isn't marked with `@discardableResult`. This is because the task created by the method isn't started yet. So after you set everything up, you should call `task.start()`.

- Add `ImageTaskDelegate`:

```swift
public protocol ImageTaskDelegate: class {
    /// Called when the task finishes loading the image.
    func imageTask(_ task: ImageTask, didCompleteWithResponse response: ImageResponse?, error: ImagePipeline.Error?)

    /// Called periodically during the lifetime of a task when progress is updated.
    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64)

    /// Called periodically when new scans of progressive image are loaded and
    /// processed.
    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse)
}
```

- Change the existing progress handler signature from `(_ response: ImageResponse?, _ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void` to `(completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void`

## Why

There are three primary reasons:

- Progressive disclosure of features. Very few users use progressive images. But previously _everyone_ using progress handler had to also understand what this extra optional `response` argument was. Now it's not longer there.
- Performance. With these changes we get 20% performance improvement of `Nuke.loadImage(with:into:)` method.
- Simplified cancellation implementation. Now instead of having an atomic isCancelled property we can simply set the delegate to `nil` (weak references are also atomic in certain scenarios including reading and writing to zero concurrently).

## Alternative Considered

- Keep the existing solution

The performance boost and the potential to simplify cancellation were too significant to miss on this opportunity.

- Keep the progress handler as is

Very few users need progressive images so I think it's worth drawing a line between where the convenience `loadImage(with:completion:)` API stops and an advanced `ImageTaskDelegate` API starts.

- Add a delegate but make it internal

Users looking into how `Nuke.loadImage(with:into:)` API would be confused by the use of the internal API
