### PR TITLE
Add new loadData method to ImagePipeline

### DIFF
--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -97,15 +97,6 @@ public struct ImageRequest {
         set { mutate { $0.loadKey = newValue } }
     }
 
-    /// If decoding is disabled, when the image data is loaded, the pipeline is
-    /// not going to create an image from it and will produce the `.decodingFailed`
-    /// error instead. `false` by default.
-    var isDecodingDisabled: Bool {
-        // This only used by `ImagePreheater` right now
-        get { return ref.isDecodingDisabled }
-        set { mutate { $0.isDecodingDisabled = newValue } }
-    }
-
     /// Custom info passed alongside the request.
     public var userInfo: Any? {
         get { return ref.userInfo }
@@ -182,7 +173,6 @@ public struct ImageRequest {
         var priority: ImageRequest.Priority = .normal
         var cacheKey: AnyHashable?
         var loadKey: AnyHashable?
-        var isDecodingDisabled: Bool = false
         var userInfo: Any?
 
         /// Creates a resource with a default processor.
@@ -199,7 +189,6 @@ public struct ImageRequest {
             self.priority = ref.priority
             self.cacheKey = ref.cacheKey
             self.loadKey = ref.loadKey
-            self.isDecodingDisabled = ref.isDecodingDisabled
             self.userInfo = ref.userInfo
         }
     }

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -97,6 +97,15 @@ public /* final */ class ImageTask: Hashable {
         pipeline?.imageTaskUpdatePriorityCalled(self, priority: priority)
     }
 
+    // MARK: - Internal
+
+    func setProgress(_ progress: TaskProgress) {
+        completedUnitCount = progress.completed
+        totalUnitCount = progress.total
+        _progress?.completedUnitCount = progress.completed
+        _progress?.totalUnitCount = progress.total
+    }
+
     // MARK: - Hashable
 
     public func hash(into hasher: inout Hasher) {

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -397,38 +397,18 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         wait()
     }
 
-    // MARK: - Disabling Decoding
+    // MARK: - Loading Data
 
-    func testThatWhenAllRequestsHaveDecodingDisabledDecodingFails() {
+    func testThatLoadsDataOnceWhenLoadingDataAndLoadingImage() {
         dataLoader.queue.isSuspended = true
 
-        // Given two requests with decoding disabled
-        let request1 = Test.request.mutated { $0.isDecodingDisabled = true }
-        let request2 = Test.request.mutated { $0.isDecodingDisabled = true }
-
-        // When the image data is loaded
-        // Expect the pipeline to skip decoding and fail with .decodingFailed error
-        expect(pipeline).toFailRequest(request1, with: .decodingFailed)
-        expect(pipeline).toFailRequest(request2, with: .decodingFailed)
+        expect(pipeline).toLoadImage(with: Test.request)
+        expect(pipeline).toLoadData(with: Test.request)
 
         dataLoader.queue.isSuspended = false
         wait()
-    }
 
-    func testThatWhenOneOfTheRequestsHasDecodingDisabledImageIsStillProduced() {
-        dataLoader.queue.isSuspended = true
-
-        // Given only one request with decoding disabled
-        let request1 = Test.request.mutated { $0.isDecodingDisabled = true }
-        let request2 = Test.request.mutated { $0.isDecodingDisabled = false }
-
-        // When the image data is loaded
-        // Expect the pipeline to still decode the image and return the response
-        expect(pipeline).toFailRequest(request1, with: .decodingFailed)
-        expect(pipeline).toLoadImage(with: request2)
-
-        dataLoader.queue.isSuspended = false
-        wait()
+        XCTAssertEqual(dataLoader.createdTaskCount, 1)
     }
 
     // MARK: - Misc

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -354,30 +354,6 @@ class ImagePipelineTests: XCTestCase {
     }
 
     #endif
-
-    // MARK: Disabling Decoding
-
-    func testDisablingDecoding() {
-        // Given the pipeline successfully returning image data
-        let pipeline = ImagePipeline {
-            $0.dataLoader = MockDataLoader()
-            $0.imageDecoder = { _ in
-                XCTFail("The pipeline tried to decode the image data")
-                return ImageDecoder()
-            }
-            $0.imageCache = nil
-        }
-
-        // Given the request with disabled decoding
-        let request = Test.request.mutated {
-            $0.isDecodingDisabled = true
-        }
-
-        // When the image data is loaded
-        // Expect pipeline to skip decoding and return .decodingFailded error
-        expect(pipeline).toFailRequest(request, with: .decodingFailed)
-        wait()
-    }
 }
 
 /// Test how well image pipeline interacts with memory cache.

--- a/Tests/XCTestCase+Nuke.swift
+++ b/Tests/XCTestCase+Nuke.swift
@@ -42,6 +42,17 @@ struct TestExpectationImagePipeline {
             XCTAssertEqual(error, expectedError, file: file, line: line)
         }
     }
+
+    func toLoadData(with request: ImageRequest) {
+        let expectation = test.expectation(description: "Data loaded for \(request)")
+        pipeline.loadData(with: request, progress: nil) { data, urlResponse, error in
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertNotNil(data)
+            XCTAssertNotNil(urlResponse)
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+    }
 }
 
 extension XCTestCase {


### PR DESCRIPTION
# Introduction

[Nuke 7.4](https://github.com/kean/Nuke/releases/tag/7.4) contained a new prefetching option: `ImagePreheater.Destination`. In order to implement `.diskCache` destination a new private `.isDecodingDisabled` option was added to `ImageRequest`. With this option enabled, the pipeline after loading data will stop at decoding step and return `.decodingFailed` error instead.

The primary issue with `.isDecodingDisabled` – apart from being a bit confusing – was the fact that is was private and users couldn't use it in their own prefetching implementations. To address this we introduce new `loadData` method to `ImagePipeline` which became possible after merging [#235 ImagePipeline v2](https://github.com/kean/Nuke/pull/235).