### PR TITLE
Adopt Result type

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Use `ImagePipeline` directly to load images without a view.
 ```swift
 let task = ImagePipeline.shared.loadImage(
     with: url,
-    progress: { _, completed, total in
+    progress: { completed, total in
         print("progress updated")
     },
-    completion: { response, error in
+    completion: { result in
         print("task completed")
     }
 )
@@ -277,8 +277,8 @@ let task = ImagePipeline.shared.loadImage(
     progress: { response, _, _ in
         imageView.image = response?.image
     },
-    completion: { response, _ in
-        imageView.image = response?.image
+    completion: { result in
+        imageView.image = try? result.get().image
     }
 )
 ```

--- a/Sources/ImagePreheater.swift
+++ b/Sources/ImagePreheater.swift
@@ -98,12 +98,12 @@ public final class ImagePreheater {
         let imageTask: ImageTask
         switch destination {
         case .diskCache:
-            imageTask = pipeline.loadData(with: request) { [weak self] _, _, _ in
+            imageTask = pipeline.loadData(with: request) { [weak self] _ in
                 self?._remove(task)
                 finish()
             }
         case .memoryCache:
-            imageTask = pipeline.loadImage(with: request) { [weak self] _, _ in
+            imageTask = pipeline.loadImage(with: request) { [weak self] _ in
                 self?._remove(task)
                 finish()
             }

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -9,7 +9,7 @@ import Foundation
 /// All methods of the delegates are called on the main thread.
 public protocol ImageTaskDelegate: class {
     /// Called when the task finishes loading the image.
-    func imageTask(_ task: ImageTask, didCompleteWithResponse response: ImageResponse?, error: ImagePipeline.Error?)
+    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>)
 
     /// Called periodically during the lifetime of a task when progress is updated.
     func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64)
@@ -59,7 +59,7 @@ public /* final */ class ImageTask: Hashable {
     private(set) var _progress: Progress?
 
     /// A completion handler to be called when task finishes or fails.
-    public typealias Completion = (_ response: ImageResponse?, _ error: ImagePipeline.Error?) -> Void
+    public typealias Completion = (_ result: Result<ImageResponse, ImagePipeline.Error>) -> Void
 
     /// A progress handler to be called periodically during the lifetime of a task.
     public typealias ProgressHandler = (_ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void
@@ -154,8 +154,8 @@ final class ImageTaskAnonymousDelegate: ImageTaskDelegate {
         self.completionHandler = completion
     }
 
-    func imageTask(_ task: ImageTask, didCompleteWithResponse response: ImageResponse?, error: ImagePipeline.Error?) {
-        completionHandler?(response, error)
+    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
+        completionHandler?(result)
     }
 
     func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64) {

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -74,3 +74,33 @@ func _createChunks(for data: Data, size: Int) -> [Data] {
     }
     return chunks
 }
+
+// MARK: - Result extension
+
+extension Result {
+    var isSuccess: Bool {
+        return value != nil
+    }
+
+    var isFailure: Bool {
+        return error != nil
+    }
+
+    var value: Success? {
+        switch self {
+        case let .success(value):
+            return value
+        case .failure:
+            return nil
+        }
+    }
+
+    var error: Failure? {
+        switch self {
+        case .success:
+            return nil
+        case let .failure(error):
+            return error
+        }
+    }
+}

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -32,11 +32,13 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // When loading images for those requests
         // Then the correct proessors are applied.
-        expect(pipeline).toLoadImage(with: request1) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
+        expect(pipeline).toLoadImage(with: request1) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
         }
-        expect(pipeline).toLoadImage(with: request2) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
+        expect(pipeline).toLoadImage(with: request2) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
         }
 
         dataLoader.queue.isSuspended = false
@@ -59,11 +61,13 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // When loading images for those requests
         // Then the correct proessors are applied.
-        expect(pipeline).toLoadImage(with: request1) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
+        expect(pipeline).toLoadImage(with: request1) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
         }
-        expect(pipeline).toLoadImage(with: request2) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["2"])
+        expect(pipeline).toLoadImage(with: request2) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["2"])
         }
 
         dataLoader.queue.isSuspended = false
@@ -87,11 +91,13 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // When loading images for those requests
         // Then the correct proessors are applied.
-        expect(pipeline).toLoadImage(with: request1) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
+        expect(pipeline).toLoadImage(with: request1) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
         }
-        expect(pipeline).toLoadImage(with: request2) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], [])
+        expect(pipeline).toLoadImage(with: request2) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], [])
         }
 
         dataLoader.queue.isSuspended = false
@@ -158,11 +164,13 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         request2.loadKey = Test.url.absoluteString + "processor=2"
 
         // Then both images are loaded and processors are applied
-        expect(pipeline).toLoadImage(with: request1) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
+        expect(pipeline).toLoadImage(with: request1) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
         }
-        expect(pipeline).toLoadImage(with: request2) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["2"])
+        expect(pipeline).toLoadImage(with: request2) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["2"])
         }
 
         dataLoader.queue.isSuspended = false
@@ -219,17 +227,18 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
             // When loading image with the same request and processing for
             // the first request has already started
-            self.pipeline.loadImage(with: request2) { response, _ in
+            self.pipeline.loadImage(with: request2) { result in
+                let image = result.value?.image
                 // Then the image is still loaded and processors is applied
-                XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
-                XCTAssertNotNil(response)
+                XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
                 expectation.fulfill()
             }
             queue.isSuspended = false
         }
 
-        expect(pipeline).toLoadImage(with: request1) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
+        expect(pipeline).toLoadImage(with: request1) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
         }
 
         wait { _ in
@@ -255,11 +264,13 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // When loading images for those requests
         // Then the correct proessors are applied.
-        expect(pipeline).toLoadImage(with: request1) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["1"])
+        expect(pipeline).toLoadImage(with: request1) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
         }
-        expect(pipeline).toLoadImage(with: request2) { response, _ in
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["2"])
+        expect(pipeline).toLoadImage(with: request2) { result in
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["2"])
         }
         wait()
 
@@ -294,7 +305,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
     func testCancellatioOnlyCancelOneTask() {
         dataLoader.queue.isSuspended = true
 
-        let task1 = pipeline.loadImage(with: Test.request) { _, _ in
+        let task1 = pipeline.loadImage(with: Test.request) { _ in
             XCTFail()
         }
 

--- a/Tests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/ImagePipelineProgressiveDecodingTests.swift
@@ -68,8 +68,8 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
             XCTFail("Expected partial images to never be produced")
         }
 
-        delegate.completion = { response, _ in
-            XCTAssertNotNil(response, "Expected the final image to be produced")
+        delegate.completion = { result in
+            XCTAssertTrue(result.isSuccess, "Expected the final image to be produced")
             finalLoaded.fulfill()
         }
 
@@ -102,9 +102,9 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
             XCTAssertEqual(image.cgImage?.height, 30, "Expected progressive image to be resized")
         }
 
-        delegate.completion = { response, _ in
-            XCTAssertNotNil(response, "Expected the final image to be produced")
-            let image = response?.image
+        delegate.completion = { result in
+            XCTAssertTrue(result.isSuccess, "Expected the final image to be produced")
+            let image = result.value?.image
             XCTAssertEqual(image?.cgImage?.width, 45, "Expected the final image to be resized")
             XCTAssertEqual(image?.cgImage?.height, 30, "Expected the final image to be resized")
         }
@@ -125,8 +125,8 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
             XCTAssertEqual(image.nk_test_processorIDs.count, 1)
             XCTAssertEqual(image.nk_test_processorIDs.first, "_image_processor")
         }
-        delegate.completion = { response, _ in
-            let image = response?.image
+        delegate.completion = { result in
+            let image = result.value?.image
             XCTAssertEqual(image?.nk_test_processorIDs.count, 1)
             XCTAssertEqual(image?.nk_test_processorIDs.first, "_image_processor")
         }
@@ -148,8 +148,8 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         delegate.progressiveResponseHandler = { _ in
             XCTFail("Expected partial images to never be produced")
         }
-        delegate.completion = { response, _ in
-            XCTAssertNotNil(response)
+        delegate.completion = { result in
+            XCTAssertTrue(result.isSuccess)
             expectFinalImageProduced.fulfill()
         }
         pipeline.imageTask(with: Test.request, delegate: delegate).start()
@@ -177,8 +177,8 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         delegate.progressiveResponseHandler = { _ in
             XCTFail("Expected partial images to never be produced")
         }
-        delegate.completion = { response, _ in
-            XCTAssertNotNil(response)
+        delegate.completion = { result in
+            XCTAssertTrue(result.isSuccess)
             finalLoaded.fulfill()
         }
 
@@ -214,8 +214,8 @@ private struct TestExpectationProgressivePipeline {
             self.dataLoader.resume()
         }
 
-        self.delegate.completion = { response, error in
-            XCTAssertNotNil(response)
+        self.delegate.completion = { result in
+            XCTAssertTrue(result.isSuccess)
             expectFinalImageProduced.fulfill()
         }
 

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -34,9 +34,10 @@ class ImageProcessingTests: XCTestCase {
         let request = Test.request.processed(with: MockImageProcessor(id: "processor1"))
 
         // When
-        expect(pipeline).toLoadImage(with: request) { response, _ in
+        expect(pipeline).toLoadImage(with: request) { result in
             // Then
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["processor1"])
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["processor1"])
         }
         wait()
     }
@@ -49,9 +50,10 @@ class ImageProcessingTests: XCTestCase {
 
         // When
         // When
-        expect(pipeline).toLoadImage(with: request) { response, _ in
+        expect(pipeline).toLoadImage(with: request) { result in
             // Then
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["processor1"])
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["processor1"])
         }
         wait()
     }
@@ -65,9 +67,10 @@ class ImageProcessingTests: XCTestCase {
             .processed(with: MockImageProcessor(id: "processor2"))
 
         // When
-        expect(pipeline).toLoadImage(with: request) { response, _ in
+        expect(pipeline).toLoadImage(with: request) { result in
             // Then
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], ["processor1", "processor2"])
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["processor1", "processor2"])
         }
         wait()
     }
@@ -78,9 +81,10 @@ class ImageProcessingTests: XCTestCase {
         request.processor = nil
 
         // When
-        expect(pipeline).toLoadImage(with: request) { response, _ in
+        expect(pipeline).toLoadImage(with: request) { result in
             // Then
-            XCTAssertEqual(response?.image.nk_test_processorIDs ?? [], [])
+            let image = result.value?.image
+            XCTAssertEqual(image?.nk_test_processorIDs ?? [], [])
         }
         wait()
     }

--- a/Tests/ImageTaskMetricsTests.swift
+++ b/Tests/ImageTaskMetricsTests.swift
@@ -48,7 +48,7 @@ class ImageTaskMetricsTests: XCTestCase {
 
         dataLoader.queue.isSuspended = true
 
-        let task = pipeline.loadImage(with: Test.request) { _, _ in
+        let task = pipeline.loadImage(with: Test.request) { _ in
             XCTFail()
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(10)) {

--- a/Tests/ImageViewIntegrationTests.swift
+++ b/Tests/ImageViewIntegrationTests.swift
@@ -48,7 +48,7 @@ class ImageViewIntegrationTests: XCTestCase {
     func testImageLoadedWithURL() {
         // When
         let expectation = self.expectation(description: "Image loaded")
-        Nuke.loadImage(with: url, into: imageView) { response, _ in
+        Nuke.loadImage(with: url, into: imageView) { _ in
             expectation.fulfill()
         }
         wait()

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -42,7 +42,7 @@ class ImageViewTests: XCTestCase {
     func testImageLoadedWithURL() {
         // When requesting an image with URL
         let expectation = self.expectation(description: "Image loaded")
-        Nuke.loadImage(with: Test.url, into: imageView) { response, _ in
+        Nuke.loadImage(with: Test.url, into: imageView) { _ in
             expectation.fulfill()
         }
         wait()
@@ -136,10 +136,10 @@ class ImageViewTests: XCTestCase {
         Nuke.loadImage(
             with: Test.request,
             into: imageView,
-            completion: { response, _ in
+            completion: { result in
                 // Expect completion to be called  on the main thread
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(response)
+                XCTAssertTrue(result.isSuccess)
                 didCallCompletion = true
                 expectation.fulfill()
             }
@@ -158,10 +158,10 @@ class ImageViewTests: XCTestCase {
         Nuke.loadImage(
             with: Test.request,
             into: imageView,
-            completion: { response, _ in
+            completion: { result in
                 // Expect completion to be called syncrhonously on the main thread
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(response)
+                XCTAssertTrue(result.isSuccess)
                 didCallCompletion = true
             }
         )
@@ -246,7 +246,7 @@ class ImageViewTests: XCTestCase {
         mockPipeline.isCancellationEnabled = false
 
         // Given an image view which is in the process of loading the image
-        Nuke.loadImage(with: Test.request, into: imageView) { _, _ in
+        Nuke.loadImage(with: Test.request, into: imageView) { _ in
             // Expect completion to never get called, we're already displaying
             // the image B by that point.
             XCTFail("Enexpected completion")
@@ -278,7 +278,7 @@ class ImageViewTests: XCTestCase {
         mockCache[requestB] = imageB
 
         // Given an image view which is in the process of loading the image A.
-        Nuke.loadImage(with: requestA, into: imageView) { _, _ in
+        Nuke.loadImage(with: requestA, into: imageView) { _ in
             // Expect completion to never get called, we're already displaying
             // the image B by that point.
             XCTFail("Enexpected completion for requestA")

--- a/Tests/MockImagePipeline.swift
+++ b/Tests/MockImagePipeline.swift
@@ -76,7 +76,7 @@ class MockImagePipeline: ImagePipeline {
                 NotificationCenter.default.post(name: MockImagePipeline.DidFinishTask, object: self)
 
                 guard !task.isCancelled else { return }
-                delegate?.imageTask(task, didCompleteWithResponse: Test.response, error: nil)
+                delegate?.imageTask(task, didCompleteWithResult: .success(Test.response))
                 _ = anonymous // retain the delegates
             }
         }
@@ -95,7 +95,7 @@ class MockImagePipeline: ImagePipeline {
 final class MockImageTaskDelegate: ImageTaskDelegate {
     var progressHandler: ((_ total: Int64, _ completed: Int64) -> Void)?
     var progressiveResponseHandler: ((ImageResponse) -> Void)?
-    var completion: ((ImageResponse?, ImagePipeline.Error?) -> Void)?
+    var completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)?
     var next: ImageTaskDelegate?
 
     func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64) {
@@ -108,8 +108,8 @@ final class MockImageTaskDelegate: ImageTaskDelegate {
         next?.imageTask(task, didProduceProgressiveResponse: response)
     }
 
-    func imageTask(_ task: ImageTask, didCompleteWithResponse response: ImageResponse?, error: ImagePipeline.Error?) {
-        completion?(response, error)
-        next?.imageTask(task, didCompleteWithResponse: response, error: error)
+    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
+        completion?(result)
+        next?.imageTask(task, didCompleteWithResult: result)
     }
 }

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -86,7 +86,7 @@ class ImagePipelinePerfomanceTests: XCTestCase {
                 var request = ImageRequest(url: url)
                 request.processor = nil // Remove processing time from equation
 
-                loader.loadImage(with: url) { _, _ in
+                loader.loadImage(with: url) { _ in
                     finished += 1
                     if finished == urls.count {
                         expectation.fulfill()

--- a/Tests/ThreadSafetyTests.swift
+++ b/Tests/ThreadSafetyTests.swift
@@ -45,7 +45,7 @@ class ThreadSafetyTests: XCTestCase {
                 let request = ImageRequest(url: URL(string: "\(Test.url)/\(rnd(30))")!)
                 let shouldCancel = rnd(3) == 0
 
-                let task = pipeline.loadImage(with: request) { _, _ in
+                let task = pipeline.loadImage(with: request) { _ in
                     if shouldCancel {
                         // do nothing, we don't expect completion on cancel
                     } else {
@@ -201,7 +201,7 @@ final class RandomizedTests: XCTestCase {
 
                 let shouldCancel = every(3)
 
-                let task = pipeline.loadImage(with: request) { _, _ in
+                let task = pipeline.loadImage(with: request) { _ in
                     if shouldCancel {
                         // do nothing, we don't expect completion on cancel
                     } else {

--- a/Tests/XCTestCase+Nuke.swift
+++ b/Tests/XCTestCase+Nuke.swift
@@ -16,40 +16,42 @@ struct TestExpectationImagePipeline {
     let test: XCTestCase
     let pipeline: ImagePipeline
 
-    func toLoadImage(with request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((ImageResponse?, ImagePipeline.Error?) -> Void)? = nil) {
+    func toLoadImage(with request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) {
         let expectation = test.expectation(description: "Image loaded for \(request)")
-        pipeline.loadImage(with: request, progress: progress)  { response, error in
-            completion?(response, error)
+        pipeline.loadImage(with: request, progress: progress) { result in
+            completion?(result)
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(response)
+            XCTAssertTrue(result.isSuccess)
             expectation.fulfill()
         }
     }
 
-    func toFailRequest(_ request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((ImageResponse?, ImagePipeline.Error?) -> Void)? = nil) {
+    func toFailRequest(_ request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) {
         let expectation = test.expectation(description: "Image request failed \(request)")
-        pipeline.loadImage(with: request, progress: progress) { response, error in
-            completion?(response, error)
+        pipeline.loadImage(with: request, progress: progress) { result in
+            completion?(result)
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNil(response)
-            XCTAssertNotNil(error)
+            XCTAssertTrue(result.isFailure)
             expectation.fulfill()
         }
     }
 
     func toFailRequest(_ request: ImageRequest, with expectedError: ImagePipeline.Error, file: StaticString = #file, line: UInt = #line) {
-        toFailRequest(request) { (_, error) in
-            XCTAssertEqual(error, expectedError, file: file, line: line)
+        toFailRequest(request) { result in
+            XCTAssertEqual(result.error, expectedError, file: file, line: line)
         }
     }
 
     func toLoadData(with request: ImageRequest) {
         let expectation = test.expectation(description: "Data loaded for \(request)")
-        pipeline.loadData(with: request, progress: nil) { data, urlResponse, error in
+        pipeline.loadData(with: request, progress: nil) { result in
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(data)
-            XCTAssertNotNil(urlResponse)
-            XCTAssertNil(error)
+            switch result {
+            case .success:
+                break
+            case let .failure(error):
+                XCTFail("Failed to load data with error: \(error)")
+            }
             expectation.fulfill()
         }
     }
@@ -62,17 +64,16 @@ extension XCTestCase {
             with: request,
             options: options,
             into: imageView,
-            completion: { response, error in
+            completion: { result in
                 XCTAssertTrue(Thread.isMainThread)
-                completion?(response, error)
+                completion?(result)
                 expectation.fulfill()
         })
     }
 
     func expectToLoadImage(with request: ImageRequest, options: ImageLoadingOptions = ImageLoadingOptions.shared, into imageView: ImageDisplayingView) {
-        expectToFinishLoadingImage(with: request, options: options, into: imageView) { response, error in
-            XCTAssertNotNil(response)
-            XCTAssertNil(error)
+        expectToFinishLoadingImage(with: request, options: options, into: imageView) { result in
+            XCTAssertTrue(result.isSuccess)
         }
     }
 }


### PR DESCRIPTION
Adopt `Result` type introduced in Swift 5