### PR TITLE
Rework ImageRequest

### DIFF
--- a/Demo/Sources/ProgressiveDecodingDemoViewController.swift
+++ b/Demo/Sources/ProgressiveDecodingDemoViewController.swift
@@ -61,7 +61,7 @@ final class ProgressiveDecodingDemoViewController: UIViewController {
         options.transition = .fadeIn(duration: 0.25)
 
         Nuke.loadImage(
-            with: ImageRequest(url: url).processed(with: _ProgressiveBlurImageProcessor()),
+            with: ImageRequest(url: url, processors: [_ProgressiveBlurImageProcessor()]),
             options: options,
             into: imageView,
             progress: { completed, total in

--- a/Demo/Sources/RateLimiterDemoViewController.swift
+++ b/Demo/Sources/RateLimiterDemoViewController.swift
@@ -70,7 +70,7 @@ final class RateLimiterDemoViewController: UICollectionViewController {
         options.pipeline = pipeline
 
         var request = ImageRequest(url: photos[indexPath.row])
-        request.processor = ImageProcessor.Scale(size: imageView.bounds.size)
+        request.processors = [ImageProcessor.Resize(size: imageView.bounds.size)]
 
         Nuke.loadImage(with: request, options: options, into: imageView)
         

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -369,10 +369,7 @@ public /* final */ class ImagePipeline {
         if Configuration.isAnimatedImageDataEnabled && image.animatedImageData != nil {
             return nil // Don't process animated images.
         }
-        var processors = [ImageProcessing]()
-        if let processor = request.processor {
-            processors.append(processor)
-        }
+        var processors = request.processors
         #if !os(macOS)
         if configuration.isDecompressionEnabled {
             processors.append(ImageDecompressor())

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -225,7 +225,7 @@ public /* final */ class ImagePipeline {
 
         // Fast memory cache lookup. We do this asynchronously because we
         // expect users to check memory cache synchronously if needed.
-        if task.request.memoryCacheOptions.isReadAllowed,
+        if task.request.options.memoryCacheOptions.isReadAllowed,
             let response = self.configuration.imageCache?.cachedResponse(for: task.request) {
             DispatchQueue.main.async {
                 guard let delegate = task.delegate else { return }
@@ -244,7 +244,7 @@ public /* final */ class ImagePipeline {
 
             // Store response in memory cache if allowed.
             let request = task.request
-            if case let .value(response, isCompleted) = event, isCompleted && request.memoryCacheOptions.isWriteAllowed {
+            if case let .value(response, isCompleted) = event, isCompleted && request.options.memoryCacheOptions.isWriteAllowed {
                 self.configuration.imageCache?.storeResponse(response, for: request)
             }
 

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -73,6 +73,28 @@ struct ImageProcessorComposition: ImageProcessing, Hashable {
     }
 }
 
+// MARK: - ImageProcessor
+
+public enum ImageProcessor {}
+
+// MARK: - ImageProcessor.Anonymous
+
+extension ImageProcessor {
+    public struct Anonymous: ImageProcessing {
+        public let identifier: String
+        private let closure: (Image) -> Image?
+
+        init(id: String, _ closure: @escaping (Image) -> Image?) {
+            self.identifier = id
+            self.closure = closure
+        }
+
+        public func process(image: Image, context: ImageProcessingContext) -> Image? {
+            return self.closure(image)
+        }
+    }
+}
+
 #if !os(macOS)
 import UIKit
 
@@ -80,19 +102,14 @@ import UIKit
 import WatchKit
 #endif
 
-// MARK: - ImageProcessor
+// MARK: - ImageProcessor.Resize
 
-public enum ImageProcessor {
+extension ImageProcessor {
 
     public enum Unit {
         case points
         case pixels
     }
-}
-
-// MARK: - ImageProcessor.Resize
-
-extension ImageProcessor {
 
     public struct Resize: ImageProcessing, Hashable {
 
@@ -290,24 +307,6 @@ extension ImageProcessor {
 }
 
 #endif
-
-// MARK: - ImageProcessor.Anonymous
-
-extension ImageProcessor {
-    public struct Anonymous: ImageProcessing {
-        public let identifier: String
-        private let closure: (Image) -> Image?
-
-        init(_ identifier: String, _ closure: @escaping (Image) -> Image?) {
-            self.identifier = identifier
-            self.closure = closure
-        }
-
-        public func process(image: Image, context: ImageProcessingContext) -> Image? {
-            return self.closure(image)
-        }
-    }
-}
 
 // MARK: - ImageDecompressor (Internal)
 

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -69,28 +69,7 @@ struct ImageProcessorComposition: ImageProcessing, Hashable {
     }
 
     static func == (lhs: ImageProcessorComposition, rhs: ImageProcessorComposition) -> Bool {
-        guard lhs.processors.count == rhs.processors.count else {
-            return false
-        }
-        // Lazily creates `hashableIdentifiers` because for some processors the
-        // identifiers might be expensive to compute.
-        return zip(lhs.processors, rhs.processors).allSatisfy {
-            $0.hashableIdentifier == $1.hashableIdentifier
-        }
-    }
-}
-
-struct AnonymousImageProcessor: ImageProcessing {
-    public let identifier: String
-    private let closure: (Image) -> Image?
-
-    init(_ identifier: String, _ closure: @escaping (Image) -> Image?) {
-        self.identifier = identifier
-        self.closure = closure
-    }
-
-    func process(image: Image, context: ImageProcessingContext) -> Image? {
-        return self.closure(image)
+        return lhs.processors == rhs.processors
     }
 }
 
@@ -312,6 +291,24 @@ extension ImageProcessor {
 
 #endif
 
+// MARK: - ImageProcessor.Anonymous
+
+extension ImageProcessor {
+    public struct Anonymous: ImageProcessing {
+        public let identifier: String
+        private let closure: (Image) -> Image?
+
+        init(_ identifier: String, _ closure: @escaping (Image) -> Image?) {
+            self.identifier = identifier
+            self.closure = closure
+        }
+
+        public func process(image: Image, context: ImageProcessingContext) -> Image? {
+            return self.closure(image)
+        }
+    }
+}
+
 // MARK: - ImageDecompressor (Internal)
 
 struct ImageDecompressor: ImageProcessing, Hashable {
@@ -532,5 +529,16 @@ func == (lhs: ImageProcessing?, rhs: ImageProcessing?) -> Bool {
     case (.none, .none): return true
     case let (.some(lhs), .some(rhs)): return lhs.hashableIdentifier == rhs.hashableIdentifier
     default: return false
+    }
+}
+
+func == (lhs: [ImageProcessing], rhs: [ImageProcessing]) -> Bool {
+    guard lhs.count == rhs.count else {
+        return false
+    }
+    // Lazily creates `hashableIdentifiers` because for some processors the
+    // identifiers might be expensive to compute.
+    return zip(lhs, rhs).allSatisfy {
+        $0.hashableIdentifier == $1.hashableIdentifier
     }
 }

--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -4,18 +4,12 @@
 
 import Foundation
 
-#if !os(macOS)
-import UIKit
-#endif
+// MARK: - ImageRequest
 
 /// Represents an image request.
 public struct ImageRequest {
 
     // MARK: Parameters of the Request
-
-    var urlString: String? {
-        return ref.urlString
-    }
 
     /// The `URLRequest` used for loading an image.
     public var urlRequest: URLRequest {
@@ -26,29 +20,6 @@ public struct ImageRequest {
                 $0.urlString = newValue.url?.absoluteString
             }
         }
-    }
-
-    /// Processor to be applied to the image. `nil` by default.
-    public var processors: [ImageProcessing] {
-        get { return ref.processors }
-        set { mutate { $0.processors = newValue } }
-    }
-
-    /// The policy to use when reading or writing images to the memory cache.
-    public struct MemoryCacheOptions {
-        /// `true` by default.
-        public var isReadAllowed = true
-
-        /// `true` by default.
-        public var isWriteAllowed = true
-
-        public init() {}
-    }
-
-    /// `MemoryCacheOptions()` (read allowed, write allowed) by default.
-    public var memoryCacheOptions: MemoryCacheOptions {
-        get { return ref.memoryCacheOptions }
-        set { mutate { $0.memoryCacheOptions = newValue } }
     }
 
     /// The execution priority of the request.
@@ -77,50 +48,44 @@ public struct ImageRequest {
         set { mutate { $0.priority = newValue } }
     }
 
-    /// Returns a key that compares requests with regards to caching images.
-    ///
-    /// The default key considers two requests equivalent it they have the same
-    /// `URLRequests` and the same processors. `URLRequests` are compared
-    /// just by their `URLs`.
-    public var cacheKey: AnyHashable? {
-        get { return ref.cacheKey }
-        set { mutate { $0.cacheKey = newValue } }
+    /// The request options.
+    public var options: ImageRequestOptions {
+        get { return ref.options }
+        set { mutate { $0.options = newValue }}
     }
 
-    /// Returns a key that compares requests with regards to loading images.
-    ///
-    /// The default key considers two requests equivalent it they have the same
-    /// `URLRequests` and the same processors. `URLRequests` are compared by
-    /// their `URL`, `cachePolicy`, and `allowsCellularAccess` properties.
-    public var loadKey: AnyHashable? {
-        get { return ref.loadKey }
-        set { mutate { $0.loadKey = newValue } }
-    }
-
-    /// Custom info passed alongside the request.
-    public var userInfo: Any? {
-        get { return ref.userInfo }
-        set { mutate { $0.userInfo = newValue } }
+    /// Processor to be applied to the image. `nil` by default.
+    public var processors: [ImageProcessing] {
+        get { return ref.processors }
+        set { mutate { $0.processors = newValue } }
     }
 
     // MARK: Initializers
 
     /// Initializes a request with the given URL.
-    /// - parameter processor: Custom image processer.
-    public init(url: URL, processors: [ImageProcessing] = []) {
-        self.ref = Container(resource: Resource.url(url), processors: processors)
+    /// - parameter priority: The priority of the request, `.normal` by default.
+    /// - parameter options: Advanced image loading options.
+    /// - parameter processors: Image processors to be applied after the image is loaded.
+    public init(url: URL,
+                priority: ImageRequest.Priority = .normal,
+                options: ImageRequestOptions = .init(),
+                processors: [ImageProcessing] = []) {
+        self.ref = Container(resource: Resource.url(url), priority: priority, options: options, processors: processors)
         self.ref.urlString = url.absoluteString
         // creating `.absoluteString` takes 50% of time of Request creation,
         // it's still faster than using URLs as cache keys
-        self.processors = processors
     }
 
     /// Initializes a request with the given request.
-    /// - parameter processor: Custom image processer.
-    public init(urlRequest: URLRequest, processors: [ImageProcessing] = []) {
-        self.ref = Container(resource: Resource.urlRequest(urlRequest), processors: processors)
+    /// - parameter priority: The priority of the request, `.normal` by default.
+    /// - parameter options: Advanced image loading options.
+    /// - parameter processors: Image processors to be applied after the image is loaded.
+    public init(urlRequest: URLRequest,
+                priority: ImageRequest.Priority = .normal,
+                options: ImageRequestOptions = .init(),
+                processors: [ImageProcessing] = []) {
+        self.ref = Container(resource: Resource.urlRequest(urlRequest), priority: priority, options: options, processors: processors)
         self.ref.urlString = urlRequest.url?.absoluteString
-        self.processors = processors
     }
 
     // CoW:
@@ -134,21 +99,24 @@ public struct ImageRequest {
         closure(ref)
     }
 
+    var urlString: String? {
+        return ref.urlString
+    }
+
     /// Just like many Swift built-in types, `ImageRequest` uses CoW approach to
     /// avoid memberwise retain/releases when `ImageRequest` is passed around.
     private class Container {
         var resource: Resource
         var urlString: String? // memoized absoluteString
+        var priority: ImageRequest.Priority
+        var options: ImageRequestOptions
         var processors: [ImageProcessing]
-        var memoryCacheOptions = MemoryCacheOptions()
-        var priority: ImageRequest.Priority = .normal
-        var cacheKey: AnyHashable?
-        var loadKey: AnyHashable?
-        var userInfo: Any?
 
         /// Creates a resource with a default processor.
-        init(resource: Resource, processors: [ImageProcessing]) {
+        init(resource: Resource, priority: Priority, options: ImageRequestOptions, processors: [ImageProcessing]) {
             self.resource = resource
+            self.priority = priority
+            self.options = options
             self.processors = processors
         }
 
@@ -157,11 +125,8 @@ public struct ImageRequest {
             self.resource = ref.resource
             self.urlString = ref.urlString
             self.processors = ref.processors
-            self.memoryCacheOptions = ref.memoryCacheOptions
+            self.options = ref.options
             self.priority = ref.priority
-            self.cacheKey = ref.cacheKey
-            self.loadKey = ref.loadKey
-            self.userInfo = ref.userInfo
         }
     }
 
@@ -179,13 +144,63 @@ public struct ImageRequest {
     }
 }
 
+// MARK: - ImageRequestOptions (Advanced Options)
+
+public struct ImageRequestOptions {
+    /// The policy to use when reading or writing images to the memory cache.
+    public struct MemoryCacheOptions {
+        /// `true` by default.
+        public var isReadAllowed = true
+
+        /// `true` by default.
+        public var isWriteAllowed = true
+
+        public init(isReadAllowed: Bool = true, isWriteAllowed: Bool = true) {
+            self.isReadAllowed = isReadAllowed
+            self.isWriteAllowed = isWriteAllowed
+        }
+    }
+
+    /// `MemoryCacheOptions()` (read allowed, write allowed) by default.
+    public var memoryCacheOptions: MemoryCacheOptions
+
+    /// Returns a key that compares requests with regards to caching images.
+    ///
+    /// The default key considers two requests equivalent it they have the same
+    /// `URLRequests` and the same processors. `URLRequests` are compared
+    /// just by their `URLs`.
+    public var cacheKey: AnyHashable?
+
+    /// Returns a key that compares requests with regards to loading images.
+    ///
+    /// The default key considers two requests equivalent it they have the same
+    /// `URLRequests` and the same processors. `URLRequests` are compared by
+    /// their `URL`, `cachePolicy`, and `allowsCellularAccess` properties.
+    public var loadKey: AnyHashable?
+
+    /// Custom info passed alongside the request.
+    public var userInfo: Any?
+
+    public init(memoryCacheOptions: MemoryCacheOptions = .init(),
+                cacheKey: AnyHashable? = nil,
+                loadKey: AnyHashable? = nil,
+                userInfo: Any? = nil) {
+        self.memoryCacheOptions = memoryCacheOptions
+        self.cacheKey = cacheKey
+        self.loadKey = loadKey
+        self.userInfo = userInfo
+    }
+}
+
+// MARK: - ImageRequest (Internal)
+
 extension ImageRequest {
     // Uniquely identifies a cache processed image.
     struct CacheKey: Hashable {
         let request: ImageRequest
 
         func hash(into hasher: inout Hasher) {
-            if let customKey = request.ref.cacheKey {
+            if let customKey = request.ref.options.cacheKey {
                 hasher.combine(customKey)
             } else {
                 hasher.combine(request.ref.urlString?.hashValue ?? 0)
@@ -194,7 +209,7 @@ extension ImageRequest {
 
         static func == (lhs: CacheKey, rhs: CacheKey) -> Bool {
             let lhs = lhs.request.ref, rhs = rhs.request.ref
-            if let lhsCustomKey = lhs.cacheKey, let rhsCustomKey = rhs.cacheKey {
+            if let lhsCustomKey = lhs.options.cacheKey, let rhsCustomKey = rhs.options.cacheKey {
                 return lhsCustomKey == rhsCustomKey
             }
             guard lhs.urlString == rhs.urlString else {
@@ -221,7 +236,7 @@ extension ImageRequest {
         let request: ImageRequest
 
         func hash(into hasher: inout Hasher) {
-            if let customKey = request.ref.loadKey {
+            if let customKey = request.ref.options.loadKey {
                 hasher.combine(customKey)
             } else {
                 hasher.combine(request.ref.urlString?.hashValue ?? 0)
@@ -235,7 +250,7 @@ extension ImageRequest {
             }
 
             let lhs = lhs.request.ref, rhs = rhs.request.ref
-            if let lhsCustomKey = lhs.loadKey, let rhsCustomKey = rhs.loadKey {
+            if let lhsCustomKey = lhs.options.loadKey, let rhsCustomKey = rhs.options.loadKey {
                 return lhsCustomKey == rhsCustomKey
             }
             return lhs.urlString == rhs.urlString

--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -106,36 +106,22 @@ public struct ImageRequest {
     // MARK: Initializers
 
     /// Initializes a request with the given URL.
-    public init(url: URL) {
-        ref = Container(resource: Resource.url(url))
-        ref.urlString = url.absoluteString
+    /// - parameter processor: Custom image processer.
+    public init(url: URL, processors: [ImageProcessing] = []) {
+        self.ref = Container(resource: Resource.url(url), processors: processors)
+        self.ref.urlString = url.absoluteString
         // creating `.absoluteString` takes 50% of time of Request creation,
         // it's still faster than using URLs as cache keys
-    }
-
-    /// Initializes a request with the given request.
-    public init(urlRequest: URLRequest) {
-        ref = Container(resource: Resource.urlRequest(urlRequest))
-        ref.urlString = urlRequest.url?.absoluteString
-    }
-
-    #if !os(macOS)
-
-    /// Initializes a request with the given URL.
-    /// - parameter processor: Custom image processer.
-    public init(url: URL, processors: [ImageProcessing]) {
-        self.init(url: url)
         self.processors = processors
     }
 
     /// Initializes a request with the given request.
     /// - parameter processor: Custom image processer.
-    public init(urlRequest: URLRequest, processors: [ImageProcessing]) {
-        self.init(urlRequest: urlRequest)
+    public init(urlRequest: URLRequest, processors: [ImageProcessing] = []) {
+        self.ref = Container(resource: Resource.urlRequest(urlRequest), processors: processors)
+        self.ref.urlString = urlRequest.url?.absoluteString
         self.processors = processors
     }
-
-    #endif
 
     // CoW:
 
@@ -161,9 +147,9 @@ public struct ImageRequest {
         var userInfo: Any?
 
         /// Creates a resource with a default processor.
-        init(resource: Resource) {
+        init(resource: Resource, processors: [ImageProcessing]) {
             self.resource = resource
-            self.processors = [] // TODO: impr perf
+            self.processors = processors
         }
 
         /// Creates a copy.

--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -67,10 +67,10 @@ public struct ImageRequest {
     /// - parameter options: Advanced image loading options.
     /// - parameter processors: Image processors to be applied after the image is loaded.
     public init(url: URL,
+                processors: [ImageProcessing] = [],
                 priority: ImageRequest.Priority = .normal,
-                options: ImageRequestOptions = .init(),
-                processors: [ImageProcessing] = []) {
-        self.ref = Container(resource: Resource.url(url), priority: priority, options: options, processors: processors)
+                options: ImageRequestOptions = .init()) {
+        self.ref = Container(resource: Resource.url(url), processors: processors, priority: priority, options: options)
         self.ref.urlString = url.absoluteString
         // creating `.absoluteString` takes 50% of time of Request creation,
         // it's still faster than using URLs as cache keys
@@ -81,10 +81,10 @@ public struct ImageRequest {
     /// - parameter options: Advanced image loading options.
     /// - parameter processors: Image processors to be applied after the image is loaded.
     public init(urlRequest: URLRequest,
+                processors: [ImageProcessing] = [],
                 priority: ImageRequest.Priority = .normal,
-                options: ImageRequestOptions = .init(),
-                processors: [ImageProcessing] = []) {
-        self.ref = Container(resource: Resource.urlRequest(urlRequest), priority: priority, options: options, processors: processors)
+                options: ImageRequestOptions = .init()) {
+        self.ref = Container(resource: Resource.urlRequest(urlRequest), processors: processors, priority: priority, options: options)
         self.ref.urlString = urlRequest.url?.absoluteString
     }
 
@@ -113,7 +113,7 @@ public struct ImageRequest {
         var processors: [ImageProcessing]
 
         /// Creates a resource with a default processor.
-        init(resource: Resource, priority: Priority, options: ImageRequestOptions, processors: [ImageProcessing]) {
+        init(resource: Resource, processors: [ImageProcessing], priority: Priority, options: ImageRequestOptions) {
             self.resource = resource
             self.priority = priority
             self.options = options

--- a/Sources/ImageView.swift
+++ b/Sources/ImageView.swift
@@ -300,7 +300,7 @@ private final class ImageViewController: ImageTaskDelegate {
         let pipeline = options.pipeline ?? ImagePipeline.shared
 
         // Quick synchronous memory cache lookup
-        if request.memoryCacheOptions.isReadAllowed,
+        if request.options.memoryCacheOptions.isReadAllowed,
             let imageCache = pipeline.configuration.imageCache,
             let response = imageCache.cachedResponse(for: request) {
             handle(result: .success(response), fromMemCache: true, options: options)

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -158,13 +158,13 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // WARNING This is legacy behaviour, don't use it
         let request1 = ImageRequest(
             url: Test.url,
-            options: .init(loadKey: Test.url.absoluteString + "processor=1"),
-            processors: [MockImageProcessor(id: "1")]
+            processors: [MockImageProcessor(id: "1")],
+            options: .init(loadKey: Test.url.absoluteString + "processor=1")
         )
         let request2 = ImageRequest(
             url: Test.url,
-            options: .init(loadKey: Test.url.absoluteString + "processor=2"),
-            processors: [MockImageProcessor(id: "2")]
+            processors: [MockImageProcessor(id: "2")],
+            options: .init(loadKey: Test.url.absoluteString + "processor=2")
         )
 
         // Then both images are loaded and processors are applied
@@ -369,7 +369,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // Given
         let operations = expect(queue).toEnqueueOperationsWithCount(1)
 
-        pipeline.loadImage(with: ImageRequest(url: Test.url, priority: .low, processors: [MockImageProcessor(id: "1")]))
+        pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")], priority: .low))
 
         dataLoader.queue.isSuspended = false
         wait { _ in
@@ -378,7 +378,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // When/Then
         expect(operations.operations.first!).toUpdatePriority(from: .low, to: .high)
-        let task = pipeline.loadImage(with: ImageRequest(url: Test.url, priority: .high, processors: [MockImageProcessor(id: "1")]))
+        let task = pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")], priority: .high))
         wait()
 
         // When/Then
@@ -395,7 +395,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // Given
         let operations = expect(queue).toEnqueueOperationsWithCount(1)
-        pipeline.loadImage(with: ImageRequest(url: Test.url, priority: .low, processors: [MockImageProcessor(id: "1")]))
+        pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")], priority: .low))
         dataLoader.queue.isSuspended = false
         wait()
 
@@ -403,7 +403,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // Note: adding a second task separately because we should guarantee
         // that both are subscribed by the time we start our test.
         expect(operations.operations.first!).toUpdatePriority(from: .low, to: .high)
-        let task = pipeline.loadImage(with: ImageRequest(url: Test.url, priority: .high, processors: [MockImageProcessor(id: "1")]))
+        let task = pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")], priority: .high))
         wait()
 
         // When/Then

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -27,8 +27,8 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // Given requests with the same URLs and same processors
         let processors = ProcessorFactory()
-        let request1 = Test.request.processed(with: processors.make(id: "1"))
-        let request2 = Test.request.processed(with: processors.make(id: "1"))
+        let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
 
         // When loading images for those requests
         // Then the correct proessors are applied.
@@ -56,8 +56,8 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // Given requests with the same URLs but different processors
         let processors = ProcessorFactory()
-        let request1 = Test.request.processed(with: processors.make(id: "1"))
-        let request2 = Test.request.processed(with: processors.make(id: "2"))
+        let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "2")])
 
         // When loading images for those requests
         // Then the correct proessors are applied.
@@ -85,9 +85,9 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // Given requests with the same URLs but different processors where one
         // processor is empty
         let processors = ProcessorFactory()
-        let request1 = Test.request.processed(with: processors.make(id: "1"))
+        let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
         var request2 = Test.request
-        request2.processor = nil
+        request2.processors = []
 
         // When loading images for those requests
         // Then the correct proessors are applied.
@@ -155,11 +155,11 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // When using custom load keys with legacy semantics (those keys were
         // comparing processors
 
-        var request1 = Test.request.processed(with: MockImageProcessor(id: "1"))
+        var request1 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
         // WARNING This is legacy behaviour, don't use it
         request1.loadKey = Test.url.absoluteString + "processor=1"
 
-        var request2 = Test.request.processed(with: MockImageProcessor(id: "2"))
+        var request2 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "2")])
         // WARNING This is legacy behaviour, don't use it
         request2.loadKey = Test.url.absoluteString + "processor=2"
 
@@ -196,9 +196,9 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         let queueObserver = OperationQueueObserver(queue: pipeline.configuration.imageProcessingQueue)
 
         // When
-        expect(pipeline).toLoadImage(with: Test.request.processed(with: processors.make(id: "1")))
-        expect(pipeline).toLoadImage(with: Test.request.processed(with: processors.make(id: "2")))
-        expect(pipeline).toLoadImage(with: Test.request.processed(with: processors.make(id: "1")))
+        expect(pipeline).toLoadImage(with: ImageRequest(url: Test.url, processors: [processors.make(id: "1")]))
+        expect(pipeline).toLoadImage(with: ImageRequest(url: Test.url, processors: [processors.make(id: "2")]))
+        expect(pipeline).toLoadImage(with: ImageRequest(url: Test.url, processors: [processors.make(id: "1")]))
 
         dataLoader.queue.isSuspended = false
 
@@ -215,8 +215,8 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         queue.isSuspended = true
 
         let processors = ProcessorFactory()
-        let request1 = Test.request.processed(with: processors.make(id: "1"))
-        let request2 = Test.request.processed(with: processors.make(id: "1"))
+        let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
 
         let queueObserver = OperationQueueObserver(queue: queue)
 
@@ -259,8 +259,8 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // Given requests with the same URLs but different processors
         let processors = ProcessorFactory()
-        let request1 = Test.request.processed(with: processors.make(id: "1"))
-        let request2 = Test.request.processed(with: processors.make(id: "2"))
+        let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "2")])
 
         // When loading images for those requests
         // Then the correct proessors are applied.
@@ -332,8 +332,8 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         let operations = expect(queue).toEnqueueOperationsWithCount(2)
 
         let processors = ProcessorFactory()
-        let request1 = Test.request.processed(with: processors.make(id: "1"))
-        let request2 = Test.request.processed(with: processors.make(id: "2"))
+        let request1 = ImageRequest(url: Test.url, processors: [processors.make(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [processors.make(id: "2")])
 
         let _ = pipeline.loadImage(with: request1)
         let task2 = pipeline.loadImage(with: request2)
@@ -365,7 +365,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // Given
         let operations = expect(queue).toEnqueueOperationsWithCount(1)
 
-        pipeline.loadImage(with: Test.request.with(processorId: "1").with(priority: .low))
+        pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")]).with(priority: .low))
 
         dataLoader.queue.isSuspended = false
         wait { _ in
@@ -374,7 +374,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // When/Then
         expect(operations.operations.first!).toUpdatePriority(from: .low, to: .high)
-        let task = pipeline.loadImage(with: Test.request.with(processorId: "1").with(priority: .high))
+        let task = pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")]).with(priority: .high))
         wait()
 
         // When/Then
@@ -391,7 +391,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
         // Given
         let operations = expect(queue).toEnqueueOperationsWithCount(1)
-        pipeline.loadImage(with: Test.request.with(processorId: "1").with(priority: .low))
+        pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")]).with(priority: .low))
         dataLoader.queue.isSuspended = false
         wait()
 
@@ -399,7 +399,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
         // Note: adding a second task separately because we should guarantee
         // that both are subscribed by the time we start our test.
         expect(operations.operations.first!).toUpdatePriority(from: .low, to: .high)
-        let task = pipeline.loadImage(with: Test.request.with(processorId: "1").with(priority: .high))
+        let task = pipeline.loadImage(with: ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")]).with(priority: .high))
         wait()
 
         // When/Then

--- a/Tests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/ImagePipelineProgressiveDecodingTests.swift
@@ -182,7 +182,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         }
 
 
-        let request = ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("1", { $0 })])
+        let request = ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous(id: "1", { $0 })])
         pipeline.imageTask(with: request, delegate: delegate).start()
 
         wait()

--- a/Tests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/ImagePipelineProgressiveDecodingTests.swift
@@ -91,8 +91,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
 
         let request = ImageRequest(
             url: Test.url,
-            targetSize: CGSize(width: 45, height: 30),
-            contentMode: .aspectFill
+            processors: [ImageProcessor.Resize(size: CGSize(width: 45, height: 30), unit: .pixels)]
         )
 
         // When/Then
@@ -117,7 +116,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
 
     func testThatPartialImagesAreProcessed() {
         // Given
-        let request = Test.request.processed(with: MockImageProcessor(id: "_image_processor"))
+        let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "_image_processor")])
 
         // When/Then
         delegate.progressiveResponseHandler = { response in
@@ -182,7 +181,9 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
             finalLoaded.fulfill()
         }
 
-        pipeline.imageTask(with: Test.request.processed(key: "1") { $0 }, delegate: delegate).start()
+
+        let request = ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("1", { $0 })])
+        pipeline.imageTask(with: request, delegate: delegate).start()
 
         wait()
     }

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -388,9 +388,8 @@ class ImagePipelineMemoryCacheTests: XCTestCase {
 
     func testCacheWriteDisabled() {
         // Given
-        let request = Test.request.mutated {
-            $0.memoryCacheOptions.isWriteAllowed = false
-        }
+        var request = Test.request
+        request.options.memoryCacheOptions.isWriteAllowed = false
 
         // When
         expect(pipeline).toLoadImage(with: request)
@@ -405,9 +404,8 @@ class ImagePipelineMemoryCacheTests: XCTestCase {
         // Given
         cache.storeResponse(ImageResponse(image: Test.image, urlResponse: nil, scanNumber: nil), for: Test.request)
 
-        let request = Test.request.mutated {
-            $0.memoryCacheOptions.isReadAllowed = false
-        }
+        var request = Test.request
+        request.options.memoryCacheOptions.isReadAllowed = false
 
         // When
         expect(pipeline).toLoadImage(with: request)

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -91,7 +91,7 @@ class ImagePipelineTests: XCTestCase {
             (Test.data(name: "cat", extension: "gif"), Test.urlResponse)
         )
 
-        let processor = ImageProcessor.Anonymous("1") { _ in
+        let processor = ImageProcessor.Anonymous(id: "1") { _ in
             XCTFail()
             return nil
         }
@@ -160,7 +160,7 @@ class ImagePipelineTests: XCTestCase {
         let queue = pipeline.configuration.imageProcessingQueue
         queue.isSuspended = true
 
-        let request = ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("1", { $0 })])
+        let request = ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous(id: "1", { $0 })])
         XCTAssertEqual(request.priority, .normal)
 
         let observer = self.expect(queue).toEnqueueOperationsWithCount(1)
@@ -226,7 +226,7 @@ class ImagePipelineTests: XCTestCase {
 
         let observer = self.expect(queue).toEnqueueOperationsWithCount(1)
 
-        let processor = ImageProcessor.Anonymous("1") {
+        let processor = ImageProcessor.Anonymous(id: "1") {
             XCTFail()
             return $0
         }

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -91,10 +91,11 @@ class ImagePipelineTests: XCTestCase {
             (Test.data(name: "cat", extension: "gif"), Test.urlResponse)
         )
 
-        let request = Test.request.processed(key: "1") { _ in
+        let processor = ImageProcessor.Anonymous("1") { _ in
             XCTFail()
             return nil
         }
+        let request = ImageRequest(url: Test.url, processors: [processor])
 
         // Then
         expect(pipeline).toLoadImage(with: request) { result in
@@ -159,7 +160,7 @@ class ImagePipelineTests: XCTestCase {
         let queue = pipeline.configuration.imageProcessingQueue
         queue.isSuspended = true
 
-        let request = Test.request.processed(key: "1") { $0 }
+        let request = ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("1", { $0 })])
         XCTAssertEqual(request.priority, .normal)
 
         let observer = self.expect(queue).toEnqueueOperationsWithCount(1)
@@ -225,10 +226,11 @@ class ImagePipelineTests: XCTestCase {
 
         let observer = self.expect(queue).toEnqueueOperationsWithCount(1)
 
-        let request = Test.request.processed(key: "1") {
+        let processor = ImageProcessor.Anonymous("1") {
             XCTFail()
             return $0
         }
+        let request = ImageRequest(url: Test.url, processors: [processor])
 
         let task = pipeline.loadImage(with: request) { _ in
             XCTFail()
@@ -306,8 +308,9 @@ class ImagePipelineTests: XCTestCase {
 
     func testDecompressionNotPerformedWhenProcessorWasApplied() {
         // Given request with scaling processor
-        var request = Test.request
-        request.processor = ImageProcessor.Resize(size: CGSize(width: 40, height: 40), contentMode: .aspectFit)
+        let request = ImageRequest(url: Test.url, processors: [
+            ImageProcessor.Resize(size: CGSize(width: 40, height: 40), contentMode: .aspectFit)
+        ])
 
         expect(pipeline).toLoadImage(with: request) { result in
             let image = result.value!.image
@@ -321,8 +324,7 @@ class ImagePipelineTests: XCTestCase {
 
     func testDecompressionPerformedWhenProcessorIsAppliedButDoesnNothing() {
         // Given request with scaling processor
-        var request = Test.request
-        request.processor = MockEmptyImageProcessor()
+        let request = ImageRequest(url: Test.url, processors: [MockEmptyImageProcessor()])
 
         expect(pipeline).toLoadImage(with: request) { result in
             let image = result.value!.image
@@ -456,7 +458,7 @@ class ImagePipelineErrorHandlingTests: XCTestCase {
             return
         }
 
-        let request = Test.request.processed(with: MockFailingProcessor())
+        let request = ImageRequest(url: Test.url, processors: [MockFailingProcessor()])
 
         // When/Then
         expect(pipeline).toFailRequest(request, with: .processingFailed)

--- a/Tests/ImagePreheaterTests.swift
+++ b/Tests/ImagePreheaterTests.swift
@@ -40,8 +40,8 @@ class ImagePreheaterTests: XCTestCase {
         // but different processors (different cacheKey).
         expect(pipeline.queue).toFinishWithEnqueuedOperationCount(2)
 
-        preheater.startPreheating(with: [Test.request.processed(key: "1") { $0 }])
-        preheater.startPreheating(with: [Test.request.processed(key: "2") { $0 }])
+        preheater.startPreheating(with: [ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("1", { $0 })])])
+        preheater.startPreheating(with: [ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("2", { $0 })])])
 
         wait()
     }

--- a/Tests/ImagePreheaterTests.swift
+++ b/Tests/ImagePreheaterTests.swift
@@ -40,8 +40,8 @@ class ImagePreheaterTests: XCTestCase {
         // but different processors (different cacheKey).
         expect(pipeline.queue).toFinishWithEnqueuedOperationCount(2)
 
-        preheater.startPreheating(with: [ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("1", { $0 })])])
-        preheater.startPreheating(with: [ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous("2", { $0 })])])
+        preheater.startPreheating(with: [ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous(id: "1", { $0 })])])
+        preheater.startPreheating(with: [ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous(id: "2", { $0 })])])
 
         wait()
     }

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -31,24 +31,8 @@ class ImageProcessingTests: XCTestCase {
 
     func testThatImageIsProcessed() {
         // Given
-        let request = Test.request.processed(with: MockImageProcessor(id: "processor1"))
+        let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "processor1")])
 
-        // When
-        expect(pipeline).toLoadImage(with: request) { result in
-            // Then
-            let image = result.value?.image
-            XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["processor1"])
-        }
-        wait()
-    }
-
-    func testReplacingDefaultProcessor() {
-        // Given
-        var request = Test.request
-        request.processor = nil
-        request.process(with: MockImageProcessor(id: "processor1"))
-
-        // When
         // When
         expect(pipeline).toLoadImage(with: request) { result in
             // Then
@@ -62,9 +46,13 @@ class ImageProcessingTests: XCTestCase {
 
     func testApplyingMultipleProcessors() {
         // Given
-        let request = Test.request
-            .processed(with: MockImageProcessor(id: "processor1"))
-            .processed(with: MockImageProcessor(id: "processor2"))
+        let request = ImageRequest(
+            url: Test.url,
+            processors: [
+                MockImageProcessor(id: "processor1"),
+                MockImageProcessor(id: "processor2")
+            ]
+        )
 
         // When
         expect(pipeline).toLoadImage(with: request) { result in
@@ -77,8 +65,7 @@ class ImageProcessingTests: XCTestCase {
 
     func testPerformingRequestWithoutProcessors() {
         // Given
-        var request = Test.request
-        request.processor = nil
+        let request = ImageRequest(url: Test.url, processors: [])
 
         // When
         expect(pipeline).toLoadImage(with: request) { result in
@@ -93,52 +80,37 @@ class ImageProcessingTests: XCTestCase {
 
     func testAnonymousProcessorsHaveDifferentIdentifiers() {
         XCTAssertEqual(
-            Test.request.processed(key: "1", { $0 }).processor?.identifier,
-            Test.request.processed(key: "1", { $0 }).processor?.identifier
+            ImageProcessor.Anonymous("1", { $0 }).identifier,
+            ImageProcessor.Anonymous("1", { $0 }).identifier
         )
         XCTAssertNotEqual(
-            Test.request.processed(key: "1", { $0 }).processor?.identifier,
-            Test.request.processed(key: "2", { $0 }).processor?.identifier
+            ImageProcessor.Anonymous("1", { $0 }).identifier,
+            ImageProcessor.Anonymous("2", { $0 }).identifier
         )
     }
 
     func testAnonymousProcessorsHaveDifferentHashableIdentifiers() {
         XCTAssertEqual(
-            Test.request.processed(key: "1", { $0 }).processor?.hashableIdentifier,
-            Test.request.processed(key: "1", { $0 }).processor?.hashableIdentifier
+            ImageProcessor.Anonymous("1", { $0 }).hashableIdentifier,
+            ImageProcessor.Anonymous("1", { $0 }).hashableIdentifier
         )
         XCTAssertNotEqual(
-            Test.request.processed(key: "1", { $0 }).processor?.hashableIdentifier,
-            Test.request.processed(key: "2", { $0 }).processor?.hashableIdentifier
+            ImageProcessor.Anonymous("1", { $0 }).hashableIdentifier,
+            ImageProcessor.Anonymous("2", { $0 }).hashableIdentifier
         )
     }
 
     func testAnonymousProcessorIsApplied() {
         // Given
-        let request = Test.request.processed(key: "1") {
+        let processor = ImageProcessor.Anonymous("1") {
             $0.nk_test_processorIDs = ["1"]
             return $0
         }
-        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
+        let request = ImageRequest(url: Test.url, processors: [processor])
 
         // When
-        let image = request.processor?.process(image: Image(), context: context)
-
-        // Then
-        XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
-    }
-
-    func testAnonymousProcessorIsApplied2() {
-        // Given
-        var request = Test.request
-        request.process(key: "1") {
-            $0.nk_test_processorIDs = ["1"]
-            return $0
-        }
         let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
-
-        // When
-        let image = request.processor?.process(image: Image(), context: context)
+        let image = processor.process(image: Test.image, context: context)
 
         // Then
         XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
@@ -153,72 +125,6 @@ class ImageProcessingTests: XCTestCase {
         XCTAssertEqual(ImageDecompressor(), ImageDecompressor())
     }
 
-    // MARK: - Resizing
-
-    func testUsingProcessorRequestParameter() {
-        // Given
-        let processor = ImageProcessor.Resize(size: CGSize(width: 40, height: 40), contentMode: .aspectFit, upscale: false)
-
-        // When
-        let request = ImageRequest(url: Test.url, processor: processor)
-
-        // Then
-        XCTAssertEqual(processor.identifier, request.processor?.identifier)
-    }
-
-    func testResizingUsingRequestParameters() {
-        // Given
-        let request = ImageRequest(url: Test.url, targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit)
-        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
-
-        // When
-        let image = request.processor!.process(image: Test.image, context: context)
-
-        // Then
-        XCTAssertEqual(image?.cgImage?.width, 40)
-        XCTAssertEqual(image?.cgImage?.height, 30)
-    }
-
-    func testResizingUsingRequestParametersInitWithURLRequest() {
-        // Given
-        let request = ImageRequest(urlRequest: Test.request.urlRequest, targetSize: CGSize(width: 40, height: 40), contentMode: .aspectFit)
-        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
-
-        // When
-        let image = request.processor!.process(image: Test.image, context: context)
-
-        // Then
-        XCTAssertEqual(image?.cgImage?.width, 40)
-        XCTAssertEqual(image?.cgImage?.height, 30)
-    }
-
-    func testResizingShouldNotUpscaleWithoutParamater() {
-        // Given
-        let targetSize = CGSize(width: 960, height: 720)
-        let request = ImageRequest(url: Test.url, targetSize: targetSize, contentMode: .aspectFit)
-        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
-
-        // When
-        let image = request.processor!.process(image: Test.image, context: context)
-
-        // Then
-        XCTAssertEqual(image?.cgImage?.width, 640)
-        XCTAssertEqual(image?.cgImage?.height, 480)
-    }
-
-    func testResizingShouldUpscaleWithParamater() {
-        // Given
-        let targetSize = CGSize(width: 960, height: 720)
-        let request = ImageRequest(url: Test.url, targetSize: targetSize, contentMode: .aspectFit, upscale: true)
-        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
-
-        // When
-        let image = request.processor!.process(image: Test.image, context: context)
-
-        // Then
-        XCTAssertEqual(image?.cgImage?.width, 960)
-        XCTAssertEqual(image?.cgImage?.height, 720)
-    }
     #endif
 }
 

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -80,29 +80,29 @@ class ImageProcessingTests: XCTestCase {
 
     func testAnonymousProcessorsHaveDifferentIdentifiers() {
         XCTAssertEqual(
-            ImageProcessor.Anonymous("1", { $0 }).identifier,
-            ImageProcessor.Anonymous("1", { $0 }).identifier
+            ImageProcessor.Anonymous(id: "1", { $0 }).identifier,
+            ImageProcessor.Anonymous(id: "1", { $0 }).identifier
         )
         XCTAssertNotEqual(
-            ImageProcessor.Anonymous("1", { $0 }).identifier,
-            ImageProcessor.Anonymous("2", { $0 }).identifier
+            ImageProcessor.Anonymous(id: "1", { $0 }).identifier,
+            ImageProcessor.Anonymous(id: "2", { $0 }).identifier
         )
     }
 
     func testAnonymousProcessorsHaveDifferentHashableIdentifiers() {
         XCTAssertEqual(
-            ImageProcessor.Anonymous("1", { $0 }).hashableIdentifier,
-            ImageProcessor.Anonymous("1", { $0 }).hashableIdentifier
+            ImageProcessor.Anonymous(id: "1", { $0 }).hashableIdentifier,
+            ImageProcessor.Anonymous(id: "1", { $0 }).hashableIdentifier
         )
         XCTAssertNotEqual(
-            ImageProcessor.Anonymous("1", { $0 }).hashableIdentifier,
-            ImageProcessor.Anonymous("2", { $0 }).hashableIdentifier
+            ImageProcessor.Anonymous(id: "1", { $0 }).hashableIdentifier,
+            ImageProcessor.Anonymous(id: "2", { $0 }).hashableIdentifier
         )
     }
 
     func testAnonymousProcessorIsApplied() {
         // Given
-        let processor = ImageProcessor.Anonymous("1") {
+        let processor = ImageProcessor.Anonymous(id: "1") {
             $0.nk_test_processorIDs = ["1"]
             return $0
         }

--- a/Tests/ImageRequestTests.swift
+++ b/Tests/ImageRequestTests.swift
@@ -30,7 +30,7 @@ class ImageRequestTests: XCTestCase {
         request.loadKey = "1"
         request.cacheKey = "2"
         request.userInfo = "3"
-        request.processor = MockImageProcessor(id: "4")
+        request.processors = [MockImageProcessor(id: "4")]
         request.priority = .high
 
         // When
@@ -43,7 +43,7 @@ class ImageRequestTests: XCTestCase {
         XCTAssertEqual(copy.loadKey, "1")
         XCTAssertEqual(copy.cacheKey, "2")
         XCTAssertEqual(copy.userInfo as? String, "3")
-        XCTAssertEqual((copy.processor as? MockImageProcessor)?.identifier, "4")
+        XCTAssertEqual((copy.processors.first as? MockImageProcessor)?.identifier, "4")
         XCTAssertEqual(copy.priority, .high)
     }
 
@@ -83,14 +83,14 @@ class ImageRequestCacheKeyTests: XCTestCase {
     }
 
     func testRequestsWithTheSameProcessorsAreEquivalent() {
-        let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
-        let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
+        let request1 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
         AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
     
     func testRequestsWithDifferentProcessorsAreNotEquivalent() {
-        let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
-        let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "2"))
+        let request1 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "2")])
         XCTAssertNotEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
 
@@ -102,9 +102,7 @@ class ImageRequestCacheKeyTests: XCTestCase {
 
     func testSettingDefaultProcessorManually() {
         let request1 = ImageRequest(url: Test.url)
-        let request2 = ImageRequest(url: Test.url).mutated {
-            $0.processor = request1.processor
-        }
+        let request2 = ImageRequest(url: Test.url, processors: request1.processors)
         AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
 
@@ -154,14 +152,14 @@ class ImageRequestLoadKeyTests: XCTestCase {
     }
 
     func testRequestsWithTheSameProcessorsAreEquivalent() {
-        let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
-        let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
+        let request1 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
         AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
     }
 
     func testRequestsWithDifferentProcessorsAreEquivalent() {
-        let request1 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "1"))
-        let request2 = ImageRequest(url: Test.url).processed(with: MockImageProcessor(id: "2"))
+        let request1 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        let request2 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "2")])
         AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
     }
 

--- a/Tests/ImageRequestTests.swift
+++ b/Tests/ImageRequestTests.swift
@@ -26,10 +26,10 @@ class ImageRequestTests: XCTestCase {
     func testCopyOnWrite() {
         // Given
         var request = ImageRequest(url: URL(string: "http://test.com/1.png")!)
-        request.memoryCacheOptions.isReadAllowed = false
-        request.loadKey = "1"
-        request.cacheKey = "2"
-        request.userInfo = "3"
+        request.options.memoryCacheOptions.isReadAllowed = false
+        request.options.loadKey = "1"
+        request.options.cacheKey = "2"
+        request.options.userInfo = "3"
         request.processors = [MockImageProcessor(id: "4")]
         request.priority = .high
 
@@ -39,10 +39,10 @@ class ImageRequestTests: XCTestCase {
         copy.urlRequest = URLRequest(url: URL(string: "http://test.com/2.png")!)
 
         // Then
-        XCTAssertEqual(copy.memoryCacheOptions.isReadAllowed, false)
-        XCTAssertEqual(copy.loadKey, "1")
-        XCTAssertEqual(copy.cacheKey, "2")
-        XCTAssertEqual(copy.userInfo as? String, "3")
+        XCTAssertEqual(copy.options.memoryCacheOptions.isReadAllowed, false)
+        XCTAssertEqual(copy.options.loadKey, "1")
+        XCTAssertEqual(copy.options.cacheKey, "2")
+        XCTAssertEqual(copy.options.userInfo as? String, "3")
         XCTAssertEqual((copy.processors.first as? MockImageProcessor)?.identifier, "4")
         XCTAssertEqual(copy.priority, .high)
     }
@@ -110,25 +110,25 @@ class ImageRequestCacheKeyTests: XCTestCase {
 
     func testRequestsWithSameCustomKeysAreEquivalent() {
         var request1 = ImageRequest(url: Test.url)
-        request1.cacheKey = "1"
+        request1.options.cacheKey = "1"
         var request2 = ImageRequest(url: Test.url)
-        request2.cacheKey = "1"
+        request2.options.cacheKey = "1"
         AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
 
     func testRequestsWithSameCustomKeysButDifferentURLsAreEquivalent() {
         var request1 = ImageRequest(url: URL(string: "https://example.com/photo1.jpg")!)
-        request1.cacheKey = "1"
+        request1.options.cacheKey = "1"
         var request2 = ImageRequest(url: URL(string: "https://example.com/photo2.jpg")!)
-        request2.cacheKey = "1"
+        request2.options.cacheKey = "1"
         AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
 
     func testRequestsWithDifferentCustomKeysAreNotEquivalent() {
         var request1 = ImageRequest(url: Test.url)
-        request1.cacheKey = "1"
+        request1.options.cacheKey = "1"
         var request2 = ImageRequest(url: Test.url)
-        request2.cacheKey = "2"
+        request2.options.cacheKey = "2"
         XCTAssertNotEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
 }
@@ -181,25 +181,25 @@ class ImageRequestLoadKeyTests: XCTestCase {
 
     func testRequestsWithSameCustomKeysAreEquivalent() {
         var request1 = ImageRequest(url: Test.url)
-        request1.loadKey = "1"
+        request1.options.loadKey = "1"
         var request2 = ImageRequest(url: Test.url)
-        request2.loadKey = "1"
+        request2.options.loadKey = "1"
         AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
     }
 
     func testRequestsWithSameCustomKeysButDifferentURLsAreEquivalent() {
         var request1 = ImageRequest(url: URL(string: "https://example.com/photo1.jpg")!)
-        request1.loadKey = "1"
+        request1.options.loadKey = "1"
         var request2 = ImageRequest(url: URL(string: "https://example.com/photo2.jpg")!)
-        request2.loadKey = "1"
+        request2.options.loadKey = "1"
         AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
     }
 
     func testRequestsWithDifferentCustomKeysAreNotEquivalent() {
         var request1 = ImageRequest(url: Test.url)
-        request1.loadKey = "1"
+        request1.options.loadKey = "1"
         var request2 = ImageRequest(url: Test.url)
-        request2.loadKey = "2"
+        request2.options.loadKey = "2"
         XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
     }
 }

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -121,7 +121,7 @@ class ImageViewTests: XCTestCase {
 
         // When requesting the image with memory cache read disabled
         var request = Test.request
-        request.memoryCacheOptions.isReadAllowed = false
+        request.options.memoryCacheOptions.isReadAllowed = false
         Nuke.loadImage(with: request, into: imageView)
 
         // Expect image to not be displayed, loaded asyncrounously instead

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -12,10 +12,6 @@ extension ImageRequest {
         return request
     }
 
-    func with(processorId: String) -> ImageRequest {
-        return processed(with: MockImageProcessor(id: processorId))
-    }
-
     func with(priority: Priority) -> ImageRequest {
         var request = self
         request.priority = priority

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -5,20 +5,6 @@
 import Foundation
 import Nuke
 
-extension ImageRequest {
-    func mutated(_ closure: (inout ImageRequest) -> Void) -> ImageRequest {
-        var request = self
-        closure(&request)
-        return request
-    }
-
-    func with(priority: Priority) -> ImageRequest {
-        var request = self
-        request.priority = priority
-        return request
-    }
-}
-
 extension ImagePipeline.Error: Equatable {
     public static func == (lhs: ImagePipeline.Error, rhs: ImagePipeline.Error) -> Bool {
         switch (lhs, rhs) {

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import Nuke
 
 class ImageViewPerformanceTests: XCTestCase {
-    private let dummyCacheRequest = ImageRequest(url: URL(string: "http://test.com/9999999)")!, targetSize: CGSize(width: 2, height: 2), contentMode: .aspectFill)
+    private let dummyCacheRequest = ImageRequest(url: URL(string: "http://test.com/9999999)")!, processors: [ImageProcessor.Resize(size: CGSize(width: 2, height: 2))])
 
     override func setUp() {
         // Store something in memory cache to avoid going through an optimized empty Dictionary path
@@ -39,7 +39,7 @@ class ImageViewPerformanceTests: XCTestCase {
 
         measure {
             for url in urls {
-                let request = ImageRequest(url: url, targetSize: CGSize(width: 0, height: 0), contentMode: .aspectFill)
+                let request = ImageRequest(url: url, processors: [ImageProcessor.Resize(size: CGSize(width: 1, height: 1))])
                 Nuke.loadImage(with: request, into: view)
             }
         }
@@ -52,7 +52,7 @@ class ImageViewPerformanceTests: XCTestCase {
 
         measure {
             for url in urls {
-                let request = ImageRequest(url: url, targetSize: CGSize(width: 0, height: 0), contentMode: .aspectFill)
+                let request = ImageRequest(url: url, processors: [ImageProcessor.Resize(size: CGSize(width: 1, height: 1))])
                 Nuke.loadImage(with: request, into: view)
             }
         }
@@ -84,7 +84,7 @@ class ImagePipelinePerfomanceTests: XCTestCase {
             var finished: Int = 0
             for url in urls {
                 var request = ImageRequest(url: url)
-                request.processor = nil // Remove processing time from equation
+                request.processors = [] // Remove processing time from equation
 
                 loader.loadImage(with: url) { _ in
                     finished += 1
@@ -173,7 +173,7 @@ class RequestPerformanceTests: XCTestCase {
 
 class ImageProcessingPerformanceTests: XCTestCase {
     func testCreatingProcessorIdentifiers() {
-        let decompressor = ImageScalingProcessor(targetSize: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)
+        let decompressor = ImageProcessor.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)
 
         measure {
             for _ in 0..<25_000 {
@@ -184,8 +184,8 @@ class ImageProcessingPerformanceTests: XCTestCase {
 
     func testComparingTwoProcessorCompositions() {
 
-        let lhs = ImageProcessorComposition([MockImageProcessor(id: "123"), ImageScalingProcessor(targetSize: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
-        let rhs = ImageProcessorComposition([MockImageProcessor(id: "124"), ImageScalingProcessor(targetSize: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
+        let lhs = ImageProcessorComposition([MockImageProcessor(id: "123"), ImageProcessor.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
+        let rhs = ImageProcessorComposition([MockImageProcessor(id: "124"), ImageProcessor.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
 
         measure {
             for _ in 0..<25_000 {


### PR DESCRIPTION
## Changes

- Move advanced options into separate `ImageRequestOptions` struct
- Remove the entire zoo of processing API, leaves a single one - `processors: [ImageProcessing]`
- Initializers now accept every single option that request might have

## Examples

Settings processor:

```swift
let request = ImageRequest(url: URL(string: "http://..."), processors: [
    ImageProcessor.Resize(size: CGSize(width: 44, height: 44))
])
```

Setting priority:

```swift
let request = ImageRequest(url: URL(string: "http://..."), priority: .high)
```

Setting everything:

```swift
let request = ImageRequest(
    url: URL(string: "http://..."),
    processors: [
        ImageProcessor.Resize(size: CGSize(width: 44, height: 44), crop: true),
        ImageProcessor.RoundedCorners(radius: 16)
    ],
    priority: .high,
    options: .init(
        memoryCacheOptions: .init(
            isReadAllowed: false,
            isWriteAllowed: false
        ),
        cacheKey: "1",
        loadKey: "2",
        userInfo: "hello"
    )
)
```