### PR TITLE
Enable processing deduplication by default

### DIFF
--- a/Sources/ImagePipelineConfiguration.swift
+++ b/Sources/ImagePipelineConfiguration.swift
@@ -74,16 +74,19 @@ extension ImagePipeline {
         ///
         /// If the value is set to `true`, you must also provide `dataCache`
         /// instance in the configuration.
+        //
+        /// - WARNING: When enabled every intermediate processed image will be
+        /// stored in disk data cache if it is enabled. To avoid storing
+        /// unwanted intermediate images, use `ImageProcessor.Composition` to
+        /// compose multiple processors into a single one.
         public var isDataCachingForProcessedImagesEnabled = false
 
-        /// `true` by default. If `true` the pipeline will combine the requests
-        /// with the same `loadKey` into a single request. The request only gets
-        /// cancelled when all the registered requests are.
-        public var isDeduplicationEnabled = true
-
-        /// `false` by default. An experimental feature. When enabled, pipeline
-        /// will avoid any duplicated work when processing images. For example,
-        /// let't take this two requests:
+        /// `true` by default. If `true` the pipeline will try to avoid any
+        /// duplicated work when loading images. The work only gets cancelled
+        /// when all the registered requests are. The pipeline also automatically
+        /// manages the priority of the deduplicated work.
+        ///
+        /// Let't take this two requests for example:
         ///
         /// ```swift
         /// let url = URL(string: "http://example.com/image")
@@ -99,10 +102,7 @@ extension ImagePipeline {
         /// Nuke will load the image data only once, resize the image once and
         /// apply the blur also only once. There is no duplicated work done at
         /// any stage.
-        ///
-        /// - WARNING: When enabled each intermediate processed image will be
-        /// stored in disk data cache if it is enabled.
-        public var isProcessingDeduplicationEnabled = false
+        public var isDeduplicationEnabled = true
 
         /// `true` by default. It `true` the pipeline will rate limits the requests
         /// to prevent trashing of the underlying systems (e.g. `URLSession`).

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -492,7 +492,6 @@ class ImagePipelineProcessingDeduplicationTests: XCTestCase {
         pipeline = ImagePipeline {
             $0.dataLoader = dataLoader
             $0.imageCache = nil
-            $0.isProcessingDeduplicationEnabled = true
         }
     }
 
@@ -602,7 +601,7 @@ class ImagePipelineProcessingDeduplicationTests: XCTestCase {
     func testThatProcessingDeduplicationCanBeDisabled() {
         // Given
         pipeline = pipeline.reconfigured {
-            $0.isProcessingDeduplicationEnabled = false
+            $0.isDeduplicationEnabled = false
         }
 
         // Given requests with the same URLs but different processors

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -121,7 +121,7 @@ class ImageProcessorCompositionTest: XCTestCase {
 
     func testAppliesAllProcessors() {
         // Given
-        let processor = ImageProcessorComposition([
+        let processor = ImageProcessor.Composition([
             MockImageProcessor(id: "1"),
             MockImageProcessor(id: "2")]
         )
@@ -135,8 +135,8 @@ class ImageProcessorCompositionTest: XCTestCase {
 
     func testIdenfitiers() {
         // Given different processors
-        let lhs = ImageProcessorComposition([MockImageProcessor(id: "1")])
-        let rhs = ImageProcessorComposition([MockImageProcessor(id: "2")])
+        let lhs = ImageProcessor.Composition([MockImageProcessor(id: "1")])
+        let rhs = ImageProcessor.Composition([MockImageProcessor(id: "2")])
 
         // Then
         XCTAssertNotEqual(lhs.identifier, rhs.identifier)
@@ -145,8 +145,8 @@ class ImageProcessorCompositionTest: XCTestCase {
 
     func testIdentifiersDifferentProcessorCount() {
         // Given processors with different processor count
-        let lhs = ImageProcessorComposition([MockImageProcessor(id: "1")])
-        let rhs = ImageProcessorComposition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
+        let lhs = ImageProcessor.Composition([MockImageProcessor(id: "1")])
+        let rhs = ImageProcessor.Composition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
 
         // Then
         XCTAssertNotEqual(lhs.identifier, rhs.identifier)
@@ -155,8 +155,8 @@ class ImageProcessorCompositionTest: XCTestCase {
 
     func testIdenfitiersEqualProcessors() {
         // Given processors with equal processors
-        let lhs = ImageProcessorComposition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
-        let rhs = ImageProcessorComposition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
+        let lhs = ImageProcessor.Composition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
+        let rhs = ImageProcessor.Composition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
 
         // Then
         XCTAssertEqual(lhs.identifier, rhs.identifier)
@@ -165,8 +165,8 @@ class ImageProcessorCompositionTest: XCTestCase {
 
     func testIdentifiersWithSameProcessorsButInDifferentOrder() {
         // Given processors with equal processors but in different order
-        let lhs = ImageProcessorComposition([MockImageProcessor(id: "2"), MockImageProcessor(id: "1")])
-        let rhs = ImageProcessorComposition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
+        let lhs = ImageProcessor.Composition([MockImageProcessor(id: "2"), MockImageProcessor(id: "1")])
+        let rhs = ImageProcessor.Composition([MockImageProcessor(id: "1"), MockImageProcessor(id: "2")])
 
         // Then
         XCTAssertNotEqual(lhs.identifier, rhs.identifier)
@@ -175,8 +175,8 @@ class ImageProcessorCompositionTest: XCTestCase {
 
     func testIdenfitiersEmptyProcessors() {
         // Given empty processors
-        let lhs = ImageProcessorComposition([])
-        let rhs = ImageProcessorComposition([])
+        let lhs = ImageProcessor.Composition([])
+        let rhs = ImageProcessor.Composition([])
 
         // Then
         XCTAssertEqual(lhs.identifier, rhs.identifier)

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -184,8 +184,8 @@ class ImageProcessingPerformanceTests: XCTestCase {
 
     func testComparingTwoProcessorCompositions() {
 
-        let lhs = ImageProcessorComposition([MockImageProcessor(id: "123"), ImageProcessor.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
-        let rhs = ImageProcessorComposition([MockImageProcessor(id: "124"), ImageProcessor.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
+        let lhs = ImageProcessor.Composition([MockImageProcessor(id: "123"), ImageProcessor.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
+        let rhs = ImageProcessor.Composition([MockImageProcessor(id: "124"), ImageProcessor.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
 
         measure {
             for _ in 0..<25_000 {


### PR DESCRIPTION
Enable processing deduplication by default

- Enable processing deduplication by default
- Remove `isProcessingDeduplicationEnabled` option from `ImagePipeline.Configuration`
- Make `ImageProcessor.Composition` public