### PR TITLE
Add deprecated APIs

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0C3261F51FEBC232009276AC /* MockDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068C1BCA888800089D7F /* MockDataLoader.swift */; };
 		0C3261F61FEBC232009276AC /* MockImagePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01287F1D43E85100668A1F /* MockImagePipeline.swift */; };
 		0C3261F71FEBC232009276AC /* MockImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE745741D4767B900123F65 /* MockImageDecoder.swift */; };
+		0C42D4C722A286260094CB5A /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42D4C422A283140094CB5A /* Deprecated.swift */; };
 		0C49232920BACA81001DFCC8 /* XCTestCase+Nuke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C49232820BACA81001DFCC8 /* XCTestCase+Nuke.swift */; };
 		0C4AF1EB1FE85539002F86CB /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */; };
 		0C505B6C2286F3AD006D5399 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C505B6B2286F3AD006D5399 /* Task.swift */; };
@@ -123,6 +124,7 @@
 		0C1E620A1D6F817700AD5CF5 /* ImageRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRequestTests.swift; sourceTree = "<group>"; };
 		0C2A8CF620970B790013FD65 /* ImagePipelineResumableDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineResumableDataTests.swift; sourceTree = "<group>"; };
 		0C2A8CFA20970D8D0013FD65 /* ImagePipelineProgressiveDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineProgressiveDecodingTests.swift; sourceTree = "<group>"; };
+		0C42D4C422A283140094CB5A /* Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecated.swift; sourceTree = "<group>"; };
 		0C49232820BACA81001DFCC8 /* XCTestCase+Nuke.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Nuke.swift"; sourceTree = "<group>"; };
 		0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTest.swift; sourceTree = "<group>"; };
 		0C4B6A341E36630E00E86B21 /* Nuke 5 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 5 Migration Guide.md"; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				0CB26801208F2565004C83F4 /* DataCache.swift */,
 				0C505B6B2286F3AD006D5399 /* Task.swift */,
 				0C7150081FC9724C00B880AC /* Internal.swift */,
+				0C42D4C422A283140094CB5A /* Deprecated.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -658,6 +661,7 @@
 				0CF1754C22913F9800A8946E /* ImagePipelineConfiguration.swift in Sources */,
 				0C86AB6A228B3B5100A81BA1 /* ImageTask.swift in Sources */,
 				0C7150091FC9724C00B880AC /* Internal.swift in Sources */,
+				0C42D4C722A286260094CB5A /* Deprecated.swift in Sources */,
 				0CE2D9BA2084FDDD00934B28 /* ImageDecoding.swift in Sources */,
 				0CF4DE7D1D412A9E00170289 /* ImagePreheater.swift in Sources */,
 			);

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -1,0 +1,262 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+// MARK: - ImageRequest (Deprecated)
+
+extension ImageRequest {
+
+    @available(*, deprecated, message: "Please use `var processors: [ImageProcessing]` instead")
+    public var processor: ImageProcessing? {
+        get { return processors.first }
+        set {
+            guard let newValue = newValue else {
+                processors = []
+                return
+            }
+            processors = [newValue]
+        }
+    }
+
+    @available(*, deprecated, message: "Please use `ImageRequestOptions` instead, it now contains all the advanced options")
+    public var memoryCacheOptions: ImageRequestOptions.MemoryCacheOptions {
+        get { return options.memoryCacheOptions }
+        set { options.memoryCacheOptions = newValue }
+    }
+
+    @available(*, deprecated, message: "Please use `ImageRequestOptions` instead, it now contains all the advanced options")
+    public var cacheKey: AnyHashable? {
+        get { return options.cacheKey }
+        set { options.cacheKey = newValue }
+    }
+
+    @available(*, deprecated, message: "Please use `ImageRequestOptions` instead, it now contains all the advanced options")
+    public var loadKey: AnyHashable? {
+        get { return options.loadKey }
+        set { options.loadKey = newValue }
+    }
+
+    @available(*, deprecated, message: "Please use `ImageRequestOptions` instead, it now contains all the advanced options")
+    public var userInfo: Any? {
+        get { return options.userInfo }
+        set { options.userInfo = newValue }
+    }
+
+    @available(*, deprecated, message: "Please use the new unified initializer `ImageRequest.init(url:processors:priority:options:)` instead")
+    public init(url: URL, processor: ImageProcessing) {
+        self = ImageRequest(url: url, processors: [processor])
+    }
+
+    @available(*, deprecated, message: "Please use the new unified initializer `ImageRequest.init(urlRequest:processors:priority:options:)` instead")
+    public init(urlRequest: URLRequest, processor: ImageProcessing) {
+        self = ImageRequest(urlRequest: urlRequest, processors: [processor])
+    }
+}
+
+extension ImageRequest {
+
+    @available(*, deprecated, message: "Please use the new unified initializer `ImageRequest.init(urlRequest:processors:priority:options:)` instead or set processors via new `var processors: [ImageProcessing]` property.")
+    public mutating func process(with processor: ImageProcessing) {
+        processors.append(processor)
+    }
+
+    @available(*, deprecated, message: "Please use the new unified initializer `ImageRequest.init(urlRequest:processors:priority:options:)` instead or set processors via new `var processors: [ImageProcessing]` property.")
+    public func processed(with processor: ImageProcessing) -> ImageRequest {
+        var request = self
+        request.process(with: processor)
+        return request
+    }
+
+    @available(*, deprecated, message: "Please use `ImageProcessor.Anonymous` instead. Key must also be a `String` now")
+    public mutating func process(key: String, _ closure: @escaping (Image) -> Image?) {
+        process(with: ImageProcessor.Anonymous(id: key, closure))
+    }
+
+    @available(*, deprecated, message: "Please use `ImageProcessor.Anonymous` instead. Key must also be a `String` now")
+    public func processed(key: String, _ closure: @escaping (Image) -> Image?) -> ImageRequest {
+        return processed(with: ImageProcessor.Anonymous(id: key, closure))
+    }
+}
+
+#if !os(macOS)
+import UIKit
+
+extension ImageRequest {
+    @available(*, deprecated, message: "Please use the new unified initializer `ImageRequest.init(url:processors:priority:options:)` with `ImageProcessor.Resize` instead. Target size for `ImageProcessor.Resize` is in points by default, not pixels! For more info see https://github.com/kean/Nuke/pull/229.")
+    public init(url: URL, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode, upscale: Bool = false) {
+        self.init(url: url, processor: ImageDecompressor(targetSize: targetSize, contentMode: contentMode, upscale: upscale))
+    }
+
+    @available(*, deprecated, message: "Please use the new unified initializer `ImageRequest.init(urlRequest:processors:priority:options:)` with `ImageProcessor.Resize`instead. Target size for `ImageProcessor.Resize` is in points by default, not pixels! For more info see https://github.com/kean/Nuke/pull/229.")
+    public init(urlRequest: URLRequest, targetSize: CGSize, contentMode: ImageDecompressor.ContentMode, upscale: Bool = false) {
+        self.init(urlRequest: urlRequest, processor: ImageDecompressor(targetSize: targetSize, contentMode: contentMode,upscale: upscale))
+    }
+}
+#endif
+
+// MARK: - ImageDecompressor (Deprecated)
+
+#if !os(macOS)
+import UIKit
+
+/// Decompresses and (optionally) scales down input images. Maintains
+/// original aspect ratio.
+///
+/// Decompressing compressed image formats (such as JPEG) can significantly
+/// improve drawing performance as it allows a bitmap representation to be
+/// created in a background rather than on the main thread.
+@available(*, deprecated, message: "Decompression now runs automatically after all processors were applied and only if still needed. To disable decompression use `ImagePipeline.Configuration.isDecompressionEnabled`. If you were using `ImageDecompressor` to resize image please use `ImageProcessor.Resize`. Please be aware that the target size for `ImageProcessor.Resize` is in points by default, not pixels like in `ImageDecompressor`! For more info see https://github.com/kean/Nuke/pull/229.")
+public struct ImageDecompressor: ImageProcessing {
+    public var identifier: String {
+        return resize.identifier
+    }
+
+    public var hashableIdentifier: AnyHashable {
+        return resize.hashableIdentifier
+    }
+
+    /// An option for how to resize the image.
+    public enum ContentMode {
+        /// Scales the image so that it completely fills the target size.
+        /// Doesn't clip images.
+        case aspectFill
+
+        /// Scales the image so that it fits the target size.
+        case aspectFit
+    }
+
+    /// Size to pass to disable resizing.
+    public static let MaximumSize = CGSize(
+        width: CGFloat.greatestFiniteMagnitude,
+        height: CGFloat.greatestFiniteMagnitude
+    )
+
+    private let resize: ImageProcessor.Resize
+
+    /// Initializes `Decompressor` with the given parameters.
+    /// - parameter targetSize: Size in pixels. `MaximumSize` by default.
+    /// - parameter contentMode: An option for how to resize the image
+    /// to the target size. `.aspectFill` by default.
+    public init(targetSize: CGSize = MaximumSize, contentMode: ContentMode = .aspectFill, upscale: Bool = false) {
+        self.resize = ImageProcessor.Resize(size: targetSize, unit: .pixels, contentMode: .init(contentMode), crop: false, upscale: upscale)
+    }
+
+    public func process(image: Image, context: ImageProcessingContext) -> Image? {
+        return resize.process(image: image, context: context)
+    }
+
+    /// Returns true if both have the same `targetSize` and `contentMode`.
+    public static func == (lhs: ImageDecompressor, rhs: ImageDecompressor) -> Bool {
+        return lhs.resize == rhs.resize
+    }
+
+    #if !os(watchOS)
+    /// Returns target size in pixels for the given view. Takes main screen
+    /// scale into the account.
+    public static func targetSize(for view: UIView) -> CGSize { // in pixels
+        let scale = UIScreen.main.scale
+        let size = view.bounds.size
+        return CGSize(width: size.width * scale, height: size.height * scale)
+    }
+    #endif
+}
+
+@available(*, deprecated)
+extension ImageProcessor.Resize.ContentMode {
+    init(_ contentMode: ImageDecompressor.ContentMode) {
+        switch contentMode {
+        case .aspectFill: self = .aspectFill
+        case .aspectFit: self = .aspectFit
+        }
+    }
+}
+
+#endif
+
+// MARK: - AnyImageProcessor (Deprecated)
+
+@available(*, deprecated, message: "The new `ImageProcessing` protocol now longer has Self requirement which were previously needed due to `Equatable`, `AnyImageProcessor` is no longer needed")
+public struct AnyImageProcessor {}
+
+// MARK: - ImageTaskMetrics (Deprecated)
+
+extension ImagePipeline {
+    @available(*, deprecated, message: "Please use os_signposts instead. For more info see `ImagePipeline.Configuration.isSignpostLoggingEnabled`")
+    public var didFinishCollectingMetrics: ((ImageTask, ImageTaskMetrics) -> Void)? {
+        set {}
+        get { return nil }
+    }
+}
+
+@available(*, deprecated, message: "Please use os_signposts instead. For more info see `ImagePipeline.Configuration.isSignpostLoggingEnabled`")
+public struct ImageTaskMetrics: CustomDebugStringConvertible {
+    public let taskId: Int
+    public internal(set) var wasCancelled: Bool = false
+    public internal(set) var session: SessionMetrics?
+
+    public let startDate: Date
+    public internal(set) var processStartDate: Date?
+    public internal(set) var processEndDate: Date?
+    public internal(set) var endDate: Date? // failed or completed
+    public var totalDuration: TimeInterval? {
+        guard let endDate = endDate else { return nil }
+        return endDate.timeIntervalSince(startDate)
+    }
+
+    /// Returns `true` is the task wasn't the one that initiated image loading.
+    public internal(set) var wasSubscibedToExistingSession: Bool = false
+    public internal(set) var isMemoryCacheHit: Bool = false
+
+    init(taskId: Int, startDate: Date) {
+        self.taskId = taskId; self.startDate = startDate
+    }
+
+    public var debugDescription: String {
+        return "Deprecated, please use os_signposts instead. For more info see `ImagePipeline.Configuration.isSignpostLoggingEnabled`"
+    }
+
+    public final class SessionMetrics: CustomDebugStringConvertible {
+        public let sessionId: Int
+        public internal(set) var wasCancelled: Bool = false
+        public let startDate = Date()
+
+        public internal(set) var checkDiskCacheStartDate: Date?
+        public internal(set) var checkDiskCacheEndDate: Date?
+
+        public internal(set) var loadDataStartDate: Date?
+        public internal(set) var loadDataEndDate: Date?
+
+        public internal(set) var decodeStartDate: Date?
+        public internal(set) var decodeEndDate: Date?
+
+        @available(*, deprecated, message: "Please use the same property on `ImageTaskMetrics` instead.")
+        public internal(set) var processStartDate: Date?
+
+        @available(*, deprecated, message: "Please use the same property on `ImageTaskMetrics` instead.")
+        public internal(set) var processEndDate: Date?
+
+        public internal(set) var endDate: Date? // failed or completed
+        public var totalDuration: TimeInterval? {
+            guard let endDate = endDate else { return nil }
+            return endDate.timeIntervalSince(startDate)
+        }
+
+        public internal(set) var wasResumed: Bool?
+        public internal(set) var resumedDataCount: Int?
+        public internal(set) var serverConfirmedResume: Bool?
+
+        public internal(set) var downloadedDataCount: Int?
+        public var totalDownloadedDataCount: Int? {
+            guard let downloaded = self.downloadedDataCount else { return nil }
+            return downloaded + (resumedDataCount ?? 0)
+        }
+
+        init(sessionId: Int) { self.sessionId = sessionId }
+
+        public var debugDescription: String {
+            return "Deprecated, please use os_signposts instead. For more info see `ImagePipeline.Configuration.isSignpostLoggingEnabled`"
+        }
+    }
+}

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -123,7 +123,7 @@ extension ImageDecoding {
             return nil
         }
         #if !os(macOS)
-        ImageDecompressor.setDecompressionNeeded(true, for: image)
+        ImageDecompression.setDecompressionNeeded(true, for: image)
         #endif
 
         let scanNumber: Int? = (self as? ImageDecoder)?.numberOfScans

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -223,7 +223,7 @@ public /* final */ class ImagePipeline {
         job.send(value: response, isCompleted: isCompleted) // There is no decompression on macOS
         #else
         guard configuration.isDecompressionEnabled &&
-            ImageDecompressor.isDecompressionNeeded(for: response.image) ?? false &&
+            ImageDecompression.isDecompressionNeeded(for: response.image) ?? false &&
             !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
                 storeResponse(response, for: request, isCompleted: isCompleted)
                 job.send(value: response, isCompleted: isCompleted)
@@ -245,7 +245,7 @@ public /* final */ class ImagePipeline {
             if #available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
                 os_signpost(.begin, log: self.log, name: "Decompress Image", signpostID: signpost.signpostID, "%{public}s image", "\(isCompleted ? "Final" : "Progressive")")
             }
-            let response = response.map { ImageDecompressor().decompress(image: $0) } ?? response
+            let response = response.map { ImageDecompression().decompress(image: $0) } ?? response
             signpost.log(.end, name: "Decompress Image")
 
             self.queue.async {

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -17,7 +17,7 @@ public protocol ImageProcessing {
     /// The default implementation simply returns `var identifier: String` but
     /// can be overridden as a performance optimization - creating and comparing
     /// strings is _expensive_ so you can opt-in to return something which is
-    /// fast to create and to compare. See `ImageDecompressor` to example.
+    /// fast to create and to compare. See `ImageProcessor.Resize` to example.
     var hashableIdentifier: AnyHashable { get }
 }
 
@@ -45,7 +45,7 @@ extension ImageProcessor {
         public let identifier: String
         private let closure: (Image) -> Image?
 
-        init(id: String, _ closure: @escaping (Image) -> Image?) {
+        public init(id: String, _ closure: @escaping (Image) -> Image?) {
             self.identifier = id
             self.closure = closure
         }
@@ -312,13 +312,13 @@ extension ImageProcessor {
 
 #endif
 
-// MARK: - ImageDecompressor (Internal)
+// MARK: - ImageDecompression (Internal)
 
-struct ImageDecompressor {
+struct ImageDecompression {
 
     func decompress(image: Image) -> Image {
         let output = ImageProcessor.decompress(image)
-        ImageDecompressor.setDecompressionNeeded(false, for: output)
+        ImageDecompression.setDecompressionNeeded(false, for: output)
         return output
     }
 

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -4,29 +4,6 @@
 
 import Foundation
 
-// MARK: - ImageTaskDelegate
-
-/// All methods of the delegates are called on the main thread.
-public protocol ImageTaskDelegate: class {
-    /// Called when the task finishes loading the image.
-    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>)
-
-    /// Called periodically during the lifetime of a task when progress is updated.
-    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64)
-
-    /// Called periodically when new scans of progressive image are loaded and
-    /// processed.
-    ///
-    /// To enable progressive image decoding, see `ImagePipeline.Configuration`
-    /// `isProgressiveDecodingEnabled`.
-    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse)
-}
-
-public extension ImageTaskDelegate {
-    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64) {}
-    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse) {}
-}
-
 // MARK: - ImageTask
 
 /// A task performed by the `ImagePipeline`. The pipeline maintains a strong
@@ -120,6 +97,29 @@ public /* final */ class ImageTask: Hashable {
     public static func == (lhs: ImageTask, rhs: ImageTask) -> Bool {
         return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
+}
+
+// MARK: - ImageTaskDelegate
+
+/// All methods of the delegates are called on the main thread.
+public protocol ImageTaskDelegate: class {
+    /// Called when the task finishes loading the image.
+    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>)
+
+    /// Called periodically during the lifetime of a task when progress is updated.
+    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64)
+
+    /// Called periodically when new scans of progressive image are loaded and
+    /// processed.
+    ///
+    /// To enable progressive image decoding, see `ImagePipeline.Configuration`
+    /// `isProgressiveDecodingEnabled`.
+    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse)
+}
+
+public extension ImageTaskDelegate {
+    func imageTask(_ task: ImageTask, didUpdateProgress completedUnitCount: Int64, totalUnitCount: Int64) {}
+    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse) {}
 }
 
 // MARK: - ImageResponse

--- a/Tests/ImagePipelineDataCachingTests.swift
+++ b/Tests/ImagePipelineDataCachingTests.swift
@@ -143,7 +143,7 @@ class ImagePipelineProcessedDataCachingTests: XCTestCase {
                 return XCTFail("Expected image to be loaded")
             }
 
-            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
+            let isDecompressionNeeded = ImageDecompression.isDecompressionNeeded(for: image)
             XCTAssertEqual(isDecompressionNeeded, false, "Expected image to be decompressed")
         }
         wait()
@@ -165,7 +165,7 @@ class ImagePipelineProcessedDataCachingTests: XCTestCase {
                 return XCTFail("Expected image to be loaded")
             }
 
-            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
+            let isDecompressionNeeded = ImageDecompression.isDecompressionNeeded(for: image)
             XCTAssertEqual(isDecompressionNeeded, true, "Expected image to still be marked as non decompressed")
         }
         wait()

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -276,7 +276,7 @@ class ImagePipelineTests: XCTestCase {
 
             XCTAssertTrue(output === image)
 
-            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: output)
+            let isDecompressionNeeded = ImageDecompression.isDecompressionNeeded(for: output)
             XCTAssertEqual(isDecompressionNeeded, true)
         }
         wait()
@@ -304,7 +304,7 @@ class ImagePipelineTests: XCTestCase {
 
             XCTAssertTrue(output !== image)
 
-            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: output)
+            let isDecompressionNeeded = ImageDecompression.isDecompressionNeeded(for: output)
             XCTAssertEqual(isDecompressionNeeded, false)
         }
         wait()
@@ -322,7 +322,7 @@ class ImagePipelineTests: XCTestCase {
             }
 
             // Expect decompression to not be performed
-            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
+            let isDecompressionNeeded = ImageDecompression.isDecompressionNeeded(for: image)
             XCTAssertNil(isDecompressionNeeded)
         }
         wait()
@@ -338,7 +338,7 @@ class ImagePipelineTests: XCTestCase {
             }
 
             // Expect decompression to be performed (processor was applied but it did nothing)
-            let isDecompressionNeeded = ImageDecompressor.isDecompressionNeeded(for: image)
+            let isDecompressionNeeded = ImageDecompression.isDecompressionNeeded(for: image)
             XCTAssertEqual(isDecompressionNeeded, false)
         }
         wait()


### PR DESCRIPTION
Add all of the APIs deprecated in Nuke 8 to ease the migration.