### PR TITLE
Improve image view extensions

### DIFF
--- a/Demo/Sources/AnimatedImageUsingVideoViewController.swift
+++ b/Demo/Sources/AnimatedImageUsingVideoViewController.swift
@@ -123,7 +123,7 @@ private extension Image {
 // MARK: - VideoCell
 
 /// - warning: This is proof of concept, please don't use in production.
-private final class VideoCell: UICollectionViewCell, Nuke.ImageDisplaying {
+private final class VideoCell: UICollectionViewCell, Nuke.Nuke_ImageDisplaying {
     private var requestId: Int = 0
     private var videoURL: URL?
     var storage: TemporaryVideoStorage!
@@ -164,7 +164,7 @@ private final class VideoCell: UICollectionViewCell, Nuke.ImageDisplaying {
         player = nil
     }
 
-    func display(image: Image?) {
+    func nuke_display(image: Image?) {
         prepareForReuse()
 
         guard let data = image?.animatedImageData else {

--- a/Demo/Sources/AnimatedImageUsingVideoViewController.swift
+++ b/Demo/Sources/AnimatedImageUsingVideoViewController.swift
@@ -56,9 +56,8 @@ final class AnimatedImageUsingVideoViewController: UICollectionViewController, U
         ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
 
         cell.activityIndicator.startAnimating()
-        Nuke.loadImage(
+        cell.nk.setImage(
             with: imageURLs[indexPath.row],
-            into: cell,
             completion: { [weak cell] _ in
                 cell?.activityIndicator.stopAnimating()
         })

--- a/Demo/Sources/AnimatedImageViewController.swift
+++ b/Demo/Sources/AnimatedImageViewController.swift
@@ -80,10 +80,9 @@ final class AnimatedImageViewController: UICollectionViewController, UICollectio
             ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
 
             cell.activityIndicator.startAnimating()
-            Nuke.loadImage(
+            cell.imageView.nk.setImage(
                 with: imageURLs[indexPath.row],
                 options: ImageLoadingOptions(transition: .fadeIn(duration: 0.33)),
-                into: cell.imageView,
                 completion: { [weak cell] _ in
                     cell?.activityIndicator.stopAnimating()
             })

--- a/Demo/Sources/AnimatedImageViewController.swift
+++ b/Demo/Sources/AnimatedImageViewController.swift
@@ -130,7 +130,7 @@ final class AnimatedImageCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        imageView.display(image: nil)
+        imageView.nuke_display(image: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -139,7 +139,7 @@ final class AnimatedImageCell: UICollectionViewCell {
 }
 
 extension FLAnimatedImageView {
-    @objc open override func display(image: Image?) {
+    @objc open override func nuke_display(image: Image?) {
         guard image != nil else {
             self.animatedImage = nil
             self.image = nil

--- a/Demo/Sources/BasicDemoViewController.swift
+++ b/Demo/Sources/BasicDemoViewController.swift
@@ -58,7 +58,7 @@ class BasicDemoViewController: UICollectionViewController {
         let request = makeRequest(with: photos[indexPath.row])
         var options = ImageLoadingOptions(transition: .fadeIn(duration: 0.25))
         options.pipeline = self.pipeline
-        Nuke.loadImage(with: request, options: options, into: imageView)
+        imageView.nk.setImage(with: request, options: options)
 
         return cell
     }

--- a/Demo/Sources/PrefetchingDemoViewController.swift
+++ b/Demo/Sources/PrefetchingDemoViewController.swift
@@ -56,10 +56,9 @@ final class PrefetchingDemoViewController: UICollectionViewController, UICollect
         let imageView = self.imageView(for: cell)
         let imageURL = photos[indexPath.row]
 
-        Nuke.loadImage(
+        imageView.nk.setImage(
             with: imageURL,
-            options: ImageLoadingOptions(transition: .fadeIn(duration: 0.33)),
-            into: imageView
+            options: ImageLoadingOptions(transition: .fadeIn(duration: 0.33))
         )
 
         return cell

--- a/Demo/Sources/ProgressiveDecodingDemoViewController.swift
+++ b/Demo/Sources/ProgressiveDecodingDemoViewController.swift
@@ -60,10 +60,9 @@ final class ProgressiveDecodingDemoViewController: UIViewController {
         options.pipeline = pipeline
         options.transition = .fadeIn(duration: 0.25)
 
-        Nuke.loadImage(
+        imageView.nk.setImage(
             with: ImageRequest(url: url, processors: [_ProgressiveBlurImageProcessor()]),
             options: options,
-            into: imageView,
             progress: { completed, total in
                 container.updateProgress(completed: completed, total: total)
         })

--- a/Demo/Sources/RateLimiterDemoViewController.swift
+++ b/Demo/Sources/RateLimiterDemoViewController.swift
@@ -72,7 +72,7 @@ final class RateLimiterDemoViewController: UICollectionViewController {
         var request = ImageRequest(url: photos[indexPath.row])
         request.processors = [ImageProcessor.Resize(size: imageView.bounds.size)]
 
-        Nuke.loadImage(with: request, options: options, into: imageView)
+        imageView.nk.setImage(with: request, options: options)
         
         return cell
     }

--- a/Documentation/Guides/Performance Guide.md
+++ b/Documentation/Guides/Performance Guide.md
@@ -1,6 +1,6 @@
 ### Create `URL`s in a Background
 
-`URL` initializer is expensive because it parses the input string. It might take more time than the call to `Nuke.loadImage(with:into)` itself. Make sure to create the `URL` objects in a background. For example, it might be a good idea to create `URL` when parsing JSON to create your model objects.
+`URL` initializer is expensive because it parses the input string. It might take more time than the call to `imageView.nk.setImage(with:)` itself. Make sure to create the `URL` objects in a background. For example, it might be a good idea to create `URL` when parsing JSON to create your model objects.
 
 
 ### Avoiding Decompression on the Main Thread

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0C3261F61FEBC232009276AC /* MockImagePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01287F1D43E85100668A1F /* MockImagePipeline.swift */; };
 		0C3261F71FEBC232009276AC /* MockImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE745741D4767B900123F65 /* MockImageDecoder.swift */; };
 		0C42D4C722A286260094CB5A /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42D4C422A283140094CB5A /* Deprecated.swift */; };
+		0C42D4C922A2BB850094CB5A /* DeprecatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42D4C822A2BB850094CB5A /* DeprecatedTests.swift */; };
 		0C49232920BACA81001DFCC8 /* XCTestCase+Nuke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C49232820BACA81001DFCC8 /* XCTestCase+Nuke.swift */; };
 		0C4AF1EB1FE85539002F86CB /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */; };
 		0C505B6C2286F3AD006D5399 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C505B6B2286F3AD006D5399 /* Task.swift */; };
@@ -125,6 +126,7 @@
 		0C2A8CF620970B790013FD65 /* ImagePipelineResumableDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineResumableDataTests.swift; sourceTree = "<group>"; };
 		0C2A8CFA20970D8D0013FD65 /* ImagePipelineProgressiveDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineProgressiveDecodingTests.swift; sourceTree = "<group>"; };
 		0C42D4C422A283140094CB5A /* Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecated.swift; sourceTree = "<group>"; };
+		0C42D4C822A2BB850094CB5A /* DeprecatedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedTests.swift; sourceTree = "<group>"; };
 		0C49232820BACA81001DFCC8 /* XCTestCase+Nuke.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Nuke.swift"; sourceTree = "<group>"; };
 		0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTest.swift; sourceTree = "<group>"; };
 		0C4B6A341E36630E00E86B21 /* Nuke 5 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 5 Migration Guide.md"; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 				0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */,
 				0CB2EFD52110F52C00F7C63F /* RateLimiterTests.swift */,
 				0C0F7BF02287F6EE0034E656 /* TaskTests.swift */,
+				0C42D4C822A2BB850094CB5A /* DeprecatedTests.swift */,
 				0C5D81871D46A385000ECCB6 /* ThreadSafetyTests.swift */,
 				0C8D74201D9D6EEB0036349E /* PerformanceTests.swift */,
 				0C7C069B1BCA889000089D7F /* Extensions */,
@@ -609,6 +612,7 @@
 				0C4AF1EB1FE85539002F86CB /* LinkedListTest.swift in Sources */,
 				0CB2EFD62110F52C00F7C63F /* RateLimiterTests.swift in Sources */,
 				0C7C06971BCA888800089D7F /* MockDataLoader.swift in Sources */,
+				0C42D4C922A2BB850094CB5A /* DeprecatedTests.swift in Sources */,
 				0C1ECA501D52811D009063A9 /* ImageViewTests.swift in Sources */,
 				0C1ECA451D52667B009063A9 /* ImageProcessingTests.swift in Sources */,
 				0C6D0A8820E574400037B68F /* MockDataCache.swift in Sources */,

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		0C0FD5FC1CA47FE1002A78FB /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0FD5D71CA47FE1002A78FB /* ImageCache.swift */; };
 		0C0FD6001CA47FE1002A78FB /* ImageProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0FD5D81CA47FE1002A78FB /* ImageProcessing.swift */; };
 		0C0FD6041CA47FE1002A78FB /* ImageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0FD5D91CA47FE1002A78FB /* ImageRequest.swift */; };
-		0C0FD61C1CA47FE1002A78FB /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0FD5DF1CA47FE1002A78FB /* ImageView.swift */; };
+		0C0FD61C1CA47FE1002A78FB /* ImageViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0FD5DF1CA47FE1002A78FB /* ImageViewExtensions.swift */; };
 		0C179C7B2283597F008AB488 /* ImageEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C179C7A2283597F008AB488 /* ImageEncoding.swift */; };
 		0C1E620B1D6F817700AD5CF5 /* ImageRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1E620A1D6F817700AD5CF5 /* ImageRequestTests.swift */; };
 		0C1ECA421D526461009063A9 /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C06871BCA888800089D7F /* ImageCacheTests.swift */; };
@@ -118,7 +118,7 @@
 		0C0FD5D71CA47FE1002A78FB /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		0C0FD5D81CA47FE1002A78FB /* ImageProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageProcessing.swift; sourceTree = "<group>"; };
 		0C0FD5D91CA47FE1002A78FB /* ImageRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRequest.swift; sourceTree = "<group>"; };
-		0C0FD5DF1CA47FE1002A78FB /* ImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		0C0FD5DF1CA47FE1002A78FB /* ImageViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewExtensions.swift; sourceTree = "<group>"; };
 		0C179C772282AC50008AB488 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		0C179C7A2283597F008AB488 /* ImageEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageEncoding.swift; sourceTree = "<group>"; };
 		0C1E620A1D6F817700AD5CF5 /* ImageRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRequestTests.swift; sourceTree = "<group>"; };
@@ -235,7 +235,7 @@
 		0C096C7B1BAE9ADD007FE380 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				0C0FD5DF1CA47FE1002A78FB /* ImageView.swift */,
+				0C0FD5DF1CA47FE1002A78FB /* ImageViewExtensions.swift */,
 				0C0FD5D91CA47FE1002A78FB /* ImageRequest.swift */,
 				0C0FD5D31CA47FE1002A78FB /* ImagePipeline.swift */,
 				0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */,
@@ -655,7 +655,7 @@
 				0C0FD5E01CA47FE1002A78FB /* DataLoader.swift in Sources */,
 				0C505B6C2286F3AD006D5399 /* Task.swift in Sources */,
 				0C179C7B2283597F008AB488 /* ImageEncoding.swift in Sources */,
-				0C0FD61C1CA47FE1002A78FB /* ImageView.swift in Sources */,
+				0C0FD61C1CA47FE1002A78FB /* ImageViewExtensions.swift in Sources */,
 				0CB26802208F2565004C83F4 /* DataCache.swift in Sources */,
 				0C0FD6041CA47FE1002A78FB /* ImageRequest.swift in Sources */,
 				0CF1754C22913F9800A8946E /* ImagePipelineConfiguration.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ More information is available in [**Documentation**](https://github.com/kean/Nuk
 
 #### Load Image into Image View
 
-You can load an image into an image view with a single line of code.
+You can load an image and dispay in an image view with a single line of code:
 
 ```swift
-Nuke.loadImage(with: url, into: imageView)
+imageView.nk.setImage(with: url)
 ```
 
 <br/>
@@ -72,7 +72,7 @@ When you request a new image for the view, the previous outstanding request gets
 ```swift
 func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     ...
-    Nuke.loadImage(with: url, into: cell.imageView)
+    cell.imageView.nk.setImage(with: url)
     ...
 }
 ```
@@ -82,13 +82,12 @@ func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath:
 Use an  `options` parameter (`ImageLoadingOptions`)  to customize the way images are loaded and displayed. You can provide a placeholder, select one of the built-in transitions or provide a custom one. When using transitions, be aware that UIKit may keep a reference to the image, preventing it from being removed for long animations or loading many transitions at once.
 
 ```swift
-Nuke.loadImage(
+imageView.nk.setImage(
     with: url,
     options: ImageLoadingOptions(
         placeholder: UIImage(named: "placeholder"),
         transition: .fadeIn(duration: 0.33)
-    ),
-    into: imageView
+    )
 )
 ```
 
@@ -105,7 +104,7 @@ let options = ImageLoadingOptions(
     )
 )
 
-Nuke.loadImage(with: url, options: options, into: imageView)
+imageView.nk.setImage(with: url, options: options)
 ```
 
 To make all image views in the app share the same behavior modify `ImageLoadingOptions.shared`.
@@ -126,7 +125,7 @@ request.memoryCacheOptions.isWriteAllowed = false
 // Update the request priority:
 request.priority = .high
 
-Nuke.loadImage(with: request, into: imageView)
+imageView.nk.setImage(with: request)
 ```
 
 #### Process an Image
@@ -389,7 +388,7 @@ ImagePipeline {
 
 ### Image Pipeline Overview
 
-Here's what happens when you call `Nuke.loadImage(with: url, into: imageView` method.
+Here's what happens when you perform a call like `imageView.nk.setImage(with: url)`.
 
 First, Nuke synchronously checks if the image is available in the memory cache (`pipeline.configuration.imageCache`). If it's not, Nuke calls `pipeline.loadImage(with: request)` method. The pipeline also checks if the image is available in its memory cache, and if not, starts loading it.
 

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -260,3 +260,46 @@ public struct ImageTaskMetrics: CustomDebugStringConvertible {
         }
     }
 }
+
+// MARK: - ImageView Extensions
+
+#if !os(watchOS)
+@available(*, deprecated, message: "Please use `imageView.nk.setImage(with:)` extensions instead.")
+@discardableResult
+public func loadImage(with url: URL,
+                      options: ImageLoadingOptions = ImageLoadingOptions.shared,
+                      into view: ImageDisplayingView,
+                      progress: ((_ response: ImageResponse?, _ completed: Int64, _ total: Int64) -> Void)? = nil,
+                      completion: ((_ response: ImageResponse?, _ error: ImagePipeline.Error?) -> Void)? = nil) -> ImageTask? {
+    return loadImage(with: ImageRequest(url: url), options: options, into: view, progress: progress, completion: completion)
+}
+
+@available(*, deprecated, message: "Please use `imageView.nk.setImage(with:)` extensions instead.")
+@discardableResult
+public func loadImage(with request: ImageRequest,
+                      options: ImageLoadingOptions = ImageLoadingOptions.shared,
+                      into view: ImageDisplayingView,
+                      progress: ((_ response: ImageResponse?, _ completed: Int64, _ total: Int64) -> Void)? = nil,
+                      completion: ((_ response: ImageResponse?, _ error: ImagePipeline.Error?) -> Void)? = nil) -> ImageTask? {
+    return view.nk.setImage(
+        with: request,
+        options: options,
+        progress: { completed, total in
+            progress?(nil, completed, total)
+        },
+        completion: { result in
+            switch result {
+            case let .success(response):
+                completion?(response, nil)
+            case let .failure(error):
+                completion?(nil, error)
+            }
+        }
+    )
+}
+
+@available(*, deprecated, message: "Please use `imageView.nk.cancelImageRequest()` extensions instead.")
+public func cancelRequest(for view: ImageDisplayingView) {
+    view.nk.cancelImageRequest()
+}
+#endif

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -261,7 +261,7 @@ public struct ImageTaskMetrics: CustomDebugStringConvertible {
     }
 }
 
-// MARK: - ImageView Extensions
+// MARK: - Image View Extensions (Deprecated)
 
 #if !os(watchOS)
 @available(*, deprecated, message: "Please use `imageView.nk.setImage(with:)` extensions instead.")

--- a/Sources/ImageView.swift
+++ b/Sources/ImageView.swift
@@ -16,35 +16,39 @@ public typealias Image = NSImage
 
 #if !os(watchOS)
 
-/// Displays images. Adopt this protocol in views to make them compatible with
-/// Nuke APIs.
+/// Displays images. Add the conformance to this protocol to your views to make
+/// them compatible with Nuke image loading extensions.
 ///
-/// The protocol is defined as `@objc` to enable users to override its methods
-/// in extensions (e.g. you can override `display(image:)` in `UIImageView` subclass).
-@objc public protocol ImageDisplaying {
-    @objc
-    func display(image: Image?)
+/// The protocol is defined as `@objc` to make it possible to override its
+/// methods in extensions (e.g. you can override `nuke_display(image:)` in/
+// `UIImageView` subclass like `Gifu.ImageView).
+///
+/// The protocol and its methods have prefixes to make sure they don't clash
+/// with other similar methods and protocol in Objective-C runtime.
+@objc public protocol Nuke_ImageDisplaying {
+    /// Display a given image.
+    @objc func nuke_display(image: Image?)
 }
 
 #if !os(macOS)
 import UIKit
 /// A `UIView` that implements `ImageDisplaying` protocol.
-public typealias ImageDisplayingView = UIView & ImageDisplaying
+public typealias ImageDisplayingView = UIView & Nuke_ImageDisplaying
 
-extension UIImageView: ImageDisplaying {
+extension UIImageView: Nuke_ImageDisplaying {
     /// Displays an image.
-    open func display(image: Image?) {
+    open func nuke_display(image: Image?) {
         self.image = image
     }
 }
 #else
 import Cocoa
 /// An `NSView` that implements `ImageDisplaying` protocol.
-public typealias ImageDisplayingView = NSView & ImageDisplaying
+public typealias ImageDisplayingView = NSView & Nuke_ImageDisplaying
 
-extension NSImageView: ImageDisplaying {
+extension NSImageView: Nuke_ImageDisplaying {
     /// Displays an image.
-    open func display(image: Image?) {
+    open func nuke_display(image: Image?) {
         self.image = image
     }
 }
@@ -310,7 +314,7 @@ private final class ImageViewController: ImageTaskDelegate {
 
         // Display a placeholder.
         if let placeholder = options.placeholder {
-            imageView.display(image: placeholder)
+            imageView.nuke_display(image: placeholder)
             #if !os(macOS)
             if let contentMode = options.contentModes?.placeholder {
                 imageView.contentMode = contentMode
@@ -318,7 +322,7 @@ private final class ImageViewController: ImageTaskDelegate {
             #endif
         } else {
             if options.isPrepareForReuseEnabled {
-                imageView.display(image: nil) // Remove previously displayed images (if any)
+                imageView.nuke_display(image: nil) // Remove previously displayed images (if any)
             }
         }
 
@@ -392,7 +396,7 @@ private final class ImageViewController: ImageTaskDelegate {
                 closure(imageView, image)
             }
         } else {
-            imageView.display(image: image)
+            imageView.nuke_display(image: image)
         }
         if let newContentMode = newContentMode {
             imageView.contentMode = newContentMode
@@ -427,7 +431,7 @@ private final class ImageViewController: ImageTaskDelegate {
             duration: params.duration,
             options: params.options.union(.transitionCrossDissolve),
             animations: {
-                imageView.display(image: image)
+                imageView.nuke_display(image: image)
             },
             completion: nil
         )
@@ -501,7 +505,7 @@ private final class ImageViewController: ImageTaskDelegate {
                 closure(imageView, image)
             }
         } else {
-            imageView.display(image: image)
+            imageView.nuke_display(image: image)
         }
     }
 
@@ -512,7 +516,7 @@ private final class ImageViewController: ImageTaskDelegate {
         animation.toValue = 1
         imageView?.layer?.add(animation, forKey: "imageTransition")
 
-        imageView?.display(image: image)
+        imageView?.nuke_display(image: image)
     }
 
     #endif

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -14,8 +14,6 @@ import AppKit.NSImage
 public typealias Image = NSImage
 #endif
 
-#if !os(watchOS)
-
 /// Displays images. Add the conformance to this protocol to your views to make
 /// them compatible with Nuke image loading extensions.
 ///
@@ -30,7 +28,7 @@ public typealias Image = NSImage
     @objc func nuke_display(image: Image?)
 }
 
-#if !os(macOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 /// A `UIView` that implements `ImageDisplaying` protocol.
 public typealias ImageDisplayingView = UIView & Nuke_ImageDisplaying
@@ -47,7 +45,7 @@ extension Nuke_ImageDisplaying where Self: UIView {
         return ImageViewExtensions(self)
     }
 }
-#else
+#elseif os(macOS)
 import Cocoa
 /// An `NSView` that implements `ImageDisplaying` protocol.
 public typealias ImageDisplayingView = NSView & Nuke_ImageDisplaying
@@ -60,6 +58,24 @@ extension NSImageView: Nuke_ImageDisplaying {
 }
 
 extension Nuke_ImageDisplaying where Self: NSView {
+    public var nk: ImageViewExtensions {
+        return ImageViewExtensions(self)
+    }
+}
+#elseif os(watchOS)
+import WatchKit
+
+/// An `NSView` that implements `ImageDisplaying` protocol.
+public typealias ImageDisplayingView = WKInterfaceObject & Nuke_ImageDisplaying
+
+extension WKInterfaceImage: Nuke_ImageDisplaying {
+    /// Displays an image.
+    open func nuke_display(image: Image?) {
+        self.setImage(image)
+    }
+}
+
+extension Nuke_ImageDisplaying where Self: WKInterfaceObject {
     public var nk: ImageViewExtensions {
         return ImageViewExtensions(self)
     }
@@ -150,12 +166,14 @@ public struct ImageLoadingOptions {
     /// Placeholder to be displayed when the image is loading. `nil` by default.
     public var placeholder: Image?
 
+    /// Image to be displayed when the request fails. `nil` by default.
+    public var failureImage: Image?
+
+    #if os(iOS) || os(tvOS) || os(macOS)
+
     /// The image transition animation performed when displaying a loaded image.
     /// Only runs when the image was not found in memory cache. `.nil` by default.
     public var transition: Transition?
-
-    /// Image to be displayed when the request fails. `nil` by default.
-    public var failureImage: Image?
 
     /// The image transition animation performed when displaying a failure image.
     /// `.nil` by default.
@@ -165,6 +183,8 @@ public struct ImageLoadingOptions {
     /// when loaded from cache
     public var alwaysTransition = false
 
+    #endif
+
     /// If true, every time you request a new image for a view, the view will be
     /// automatically prepared for reuse: image will be set to `nil`, and animations
     /// will be removed. `true` by default.
@@ -173,7 +193,8 @@ public struct ImageLoadingOptions {
     /// Custom pipeline to be used. `nil` by default.
     public var pipeline: ImagePipeline?
 
-    #if !os(macOS)
+    #if os(iOS) || os(tvOS)
+
     /// Content modes to be used for each image type (placeholder, success,
     /// failure). `nil`  by default (don't change content mode).
     public var contentModes: ContentModes?
@@ -196,6 +217,10 @@ public struct ImageLoadingOptions {
         }
     }
 
+    #endif
+
+    #if os(iOS) || os(tvOS)
+
     /// - parameter placeholder: Placeholder to be displayed when the image is
     /// loading . `nil` by default.
     /// - parameter transision: The image transition animation performed when
@@ -214,38 +239,52 @@ public struct ImageLoadingOptions {
         self.failureImageTransition = failureImageTransition
         self.contentModes = contentModes
     }
-    #else
+
+    #elseif os(macOS)
+
     public init(placeholder: Image? = nil, transition: Transition? = nil, failureImage: Image? = nil, failureImageTransition: Transition? = nil) {
         self.placeholder = placeholder
         self.transition = transition
         self.failureImage = failureImage
         self.failureImageTransition = failureImageTransition
     }
+
+    #elseif os(watchOS)
+
+    public init(placeholder: Image? = nil, failureImage: Image? = nil) {
+        self.placeholder = placeholder
+        self.failureImage = failureImage
+    }
+
     #endif
+
+    #if os(iOS) || os(tvOS) || os(macOS)
 
     /// An animated image transition.
     public struct Transition {
         var style: Style
-
-        struct Parameters { // internal representation
-            let duration: TimeInterval
-            #if !os(macOS)
-            let options: UIView.AnimationOptions
-            #endif
-        }
 
         enum Style { // internal representation
             case fadeIn(parameters: Parameters)
             case custom((ImageDisplayingView, Image) -> Void)
         }
 
-        #if !os(macOS)
+        #if os(iOS) || os(tvOS)
+        struct Parameters { // internal representation
+            let duration: TimeInterval
+            let options: UIView.AnimationOptions
+        }
+
         /// Fade-in transition (cross-fade in case the image view is already
         /// displaying an image).
         public static func fadeIn(duration: TimeInterval, options: UIView.AnimationOptions = .allowUserInteraction) -> Transition {
             return Transition(style: .fadeIn(parameters:  Parameters(duration: duration, options: options)))
         }
         #else
+        struct Parameters { // internal representation
+            let duration: TimeInterval
+        }
+
         /// Fade-in transition.
         public static func fadeIn(duration: TimeInterval) -> Transition {
             return Transition(style: .fadeIn(parameters:  Parameters(duration: duration)))
@@ -257,6 +296,8 @@ public struct ImageLoadingOptions {
             return Transition(style: .custom(closure))
         }
     }
+
+    #endif
 
     public init() {}
 }
@@ -314,9 +355,9 @@ private final class ImageViewController: ImageTaskDelegate {
         }
 
         if options.isPrepareForReuseEnabled { // enabled by default
-            #if !os(macOS)
+            #if os(iOS) || os(tvOS)
             imageView.layer.removeAllAnimations()
-            #else
+            #elseif os(macOS)
             imageView.layer?.removeAllAnimations()
             #endif
         }
@@ -335,7 +376,7 @@ private final class ImageViewController: ImageTaskDelegate {
         // Display a placeholder.
         if let placeholder = options.placeholder {
             imageView.nuke_display(image: placeholder)
-            #if !os(macOS)
+            #if os(iOS) || os(tvOS)
             if let contentMode = options.contentModes?.placeholder {
                 imageView.contentMode = contentMode
             }
@@ -383,7 +424,7 @@ private final class ImageViewController: ImageTaskDelegate {
 
     // MARK: - Handling Responses
 
-    #if !os(macOS)
+    #if os(iOS) || os(tvOS)
 
     private func handle(result: Result<ImageResponse, ImagePipeline.Error>, fromMemCache: Bool, options: ImageLoadingOptions) {
         switch result {
@@ -491,7 +532,7 @@ private final class ImageViewController: ImageTaskDelegate {
         )
     }
 
-    #else
+    #elseif os(macOS)
 
     private func handle(result: Result<ImageResponse, ImagePipeline.Error>, fromMemCache: Bool, options: ImageLoadingOptions) {
         // NSImageView doesn't support content mode, unfortunately.
@@ -539,7 +580,23 @@ private final class ImageViewController: ImageTaskDelegate {
         imageView?.nuke_display(image: image)
     }
 
+    #elseif os(watchOS)
+
+    private func handle(result: Result<ImageResponse, ImagePipeline.Error>, fromMemCache: Bool, options: ImageLoadingOptions) {
+        switch result {
+        case let .success(response):
+            imageView?.nuke_display(image: response.image)
+        case .failure:
+            if let failureImage = options.failureImage {
+                imageView?.nuke_display(image: failureImage)
+            }
+        }
+        self.task = nil
+    }
+
+    private func handle(partialImage response: ImageResponse, options: ImageLoadingOptions) {
+        imageView?.nuke_display(image: response.image)
+    }
+
     #endif
 }
-
-#endif

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -41,6 +41,12 @@ extension UIImageView: Nuke_ImageDisplaying {
         self.image = image
     }
 }
+
+extension Nuke_ImageDisplaying where Self: UIView {
+    public var nk: ImageViewExtensions {
+        return ImageViewExtensions(self)
+    }
+}
 #else
 import Cocoa
 /// An `NSView` that implements `ImageDisplaying` protocol.
@@ -52,72 +58,86 @@ extension NSImageView: Nuke_ImageDisplaying {
         self.image = image
     }
 }
+
+extension Nuke_ImageDisplaying where Self: NSView {
+    public var nk: ImageViewExtensions {
+        return ImageViewExtensions(self)
+    }
+}
 #endif
 
-/// Loads an image into the view.
-///
-/// Before loading the new image prepares the view for reuse by cancelling any
-/// outstanding requests and removing previously displayed images (if any).
-///
-/// If the image is stored in memory cache, the image is displayed immediately.
-/// If not, the image is loaded using an image pipeline. Displays a `placeholder`
-/// if it was provided. When the request completes the loaded image is displayed
-/// (or `failureImage` in case of an error).
-///
-/// Nuke keeps a weak reference to the view. If the view is deallocated
-/// the associated request automatically gets cancelled.
-///
-/// - parameter options: `ImageLoadingOptions.shared` by default.
-/// - parameter progress: A closure to be called periodically on the main thread
-/// when the progress is updated. `nil` by default.
-/// - parameter completion: A closure to be called on the main thread when the
-/// request is finished. Gets called synchronously if the response was found in
-/// memory cache. `nil` by default.
-/// - returns: An image task of `nil` if the image was found in memory cache.
-@discardableResult
-public func loadImage(with url: URL,
-                      options: ImageLoadingOptions = ImageLoadingOptions.shared,
-                      into view: ImageDisplayingView,
-                      progress: ImageTask.ProgressHandler? = nil,
-                      completion: ImageTask.Completion? = nil) -> ImageTask? {
-    return loadImage(with: ImageRequest(url: url), options: options, into: view, progress: progress, completion: completion)
-}
+// MARK: - ImageViewExtensions
 
-/// Loads an image into the view.
-///
-/// Before loading the new image prepares the view for reuse by cancelling any
-/// outstanding requests and removing previously displayed images (if any).
-///
-/// If the image is stored in memory cache, the image is displayed immediately.
-/// If not, the image is loaded using an image pipeline. Displays a `placeholder`
-/// if it was provided. When the request completes the loaded image is displayed
-/// (or `failureImage` in case of an error).
-///
-/// Nuke keeps a weak reference to the view. If the view is deallocated
-/// the associated request automatically gets cancelled.
-///
-/// - parameter options: `ImageLoadingOptions.shared` by default.
-/// - parameter progress: A closure to be called periodically on the main thread
-/// when the progress is updated. `nil` by default.
-/// - parameter completion: A closure to be called on the main thread when the
-/// request is finished. Gets called synchronously if the response was found in
-/// memory cache. `nil` by default.
-/// - returns: An image task of `nil` if the image was found in memory cache.
-@discardableResult
-public func loadImage(with request: ImageRequest,
-                      options: ImageLoadingOptions = ImageLoadingOptions.shared,
-                      into view: ImageDisplayingView,
-                      progress: ImageTask.ProgressHandler? = nil,
-                      completion: ImageTask.Completion? = nil) -> ImageTask? {
-    assert(Thread.isMainThread)
-    let controller = ImageViewController.controller(for: view)
-    return controller.loadImage(with: request, options: options, progress: progress, completion: completion)
-}
+public struct ImageViewExtensions {
+    let view: ImageDisplayingView
 
-/// Cancels an outstanding request associated with the view.
-public func cancelRequest(for view: ImageDisplayingView) {
-    assert(Thread.isMainThread)
-    ImageViewController.controller(for: view).cancelOutstandingTask()
+    public init(_ view: ImageDisplayingView) {
+        self.view = view
+    }
+
+    /// Loads an image with the given URL and displays it in the view.
+    ///
+    /// Before loading the new image prepares the view for reuse by cancelling any
+    /// outstanding requests and removing previously displayed images (if any).
+    ///
+    /// If the image is stored in memory cache, the image is displayed immediately.
+    /// If not, the image is loaded using an image pipeline. Displays a `placeholder`
+    /// if it was provided. When the request completes the loaded image is displayed
+    /// (or `failureImage` in case of an error).
+    ///
+    /// Nuke keeps a weak reference to the view. If the view is deallocated
+    /// the associated request automatically gets cancelled.
+    ///
+    /// - parameter options: `ImageLoadingOptions.shared` by default.
+    /// - parameter progress: A closure to be called periodically on the main thread
+    /// when the progress is updated. `nil` by default.
+    /// - parameter completion: A closure to be called on the main thread when the
+    /// request is finished. Gets called synchronously if the response was found in
+    /// memory cache. `nil` by default.
+    /// - returns: An image task of `nil` if the image was found in memory cache.
+    @discardableResult
+    public func setImage(with url: URL,
+                         options: ImageLoadingOptions = ImageLoadingOptions.shared,
+                         progress: ImageTask.ProgressHandler? = nil,
+                         completion: ImageTask.Completion? = nil) -> ImageTask? {
+        return setImage(with: ImageRequest(url: url), options: options, progress: progress, completion: completion)
+    }
+
+    /// Loads an image with the given request and displays it in the view.
+    ///
+    /// Before loading the new image, prepares the view for reuse by cancelling any
+    /// outstanding requests and removing previously displayed images (if any).
+    ///
+    /// If the image is stored in memory cache, the image is displayed immediately.
+    /// If not, the image is loaded using an image pipeline. Displays a `placeholder`
+    /// if it was provided. When the request completes the loaded image is displayed
+    /// (or `failureImage` in case of an error).
+    ///
+    /// Nuke keeps a weak reference to the view. If the view is deallocated
+    /// the associated request automatically gets cancelled.
+    ///
+    /// - parameter options: `ImageLoadingOptions.shared` by default.
+    /// - parameter progress: A closure to be called periodically on the main thread
+    /// when the progress is updated. `nil` by default.
+    /// - parameter completion: A closure to be called on the main thread when the
+    /// request is finished. Gets called synchronously if the response was found in
+    /// memory cache. `nil` by default.
+    /// - returns: An image task of `nil` if the image was found in memory cache.
+    @discardableResult
+    public func setImage(with request: ImageRequest,
+                         options: ImageLoadingOptions = ImageLoadingOptions.shared,
+                         progress: ImageTask.ProgressHandler? = nil,
+                         completion: ImageTask.Completion? = nil) -> ImageTask? {
+        assert(Thread.isMainThread)
+        let controller = ImageViewController.controller(for: view)
+        return controller.loadImage(with: request, options: options, progress: progress, completion: completion)
+    }
+
+    /// Cancels an outstanding request associated with the view.
+    public func cancelImageRequest() {
+        assert(Thread.isMainThread)
+        ImageViewController.controller(for: view).cancelOutstandingTask()
+    }
 }
 
 // MARK: - ImageLoadingOptions

--- a/Tests/DeprecatedTests.swift
+++ b/Tests/DeprecatedTests.swift
@@ -1,0 +1,715 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+
+@available(*, deprecated)
+class DeprecatedImageViewTests: XCTestCase {
+    var imageView: _ImageView!
+    var mockPipeline: MockImagePipeline!
+    var mockCache: MockImageCache!
+
+    override func setUp() {
+        super.setUp()
+
+        mockCache = MockImageCache()
+        mockPipeline = MockImagePipeline {
+            $0.imageCache = mockCache
+        }
+
+        // Nuke.loadImage(...) methods use shared pipeline by default.
+        ImagePipeline.pushShared(mockPipeline)
+
+        imageView = _ImageView()
+    }
+
+    override func tearDown() {
+        ImagePipeline.popShared()
+    }
+
+    // MARK: - Loading
+
+    func testImageLoaded() {
+        // When requesting an image with request
+        expectToLoadImage(with: Test.request, into: imageView)
+        wait()
+
+        // Expect the image to be downloaded and displayed
+        XCTAssertNotNil(imageView.image)
+    }
+
+    func testImageLoadedWithURL() {
+        // When requesting an image with URL
+        let expectation = self.expectation(description: "Image loaded")
+        Nuke.loadImage(with: Test.url, into: imageView) { response, _ in
+            expectation.fulfill()
+        }
+        wait()
+
+        // Expect the image to be downloaded and displayed
+        XCTAssertNotNil(imageView.image)
+    }
+
+    // MARK: - Managing Tasks
+
+    func testTaskReturned() {
+        // When requesting an image
+        let task = Nuke.loadImage(with: Test.request, into: imageView)
+
+        // Expect Nuke to return a task
+        XCTAssertNotNil(task)
+
+        // Expect the task's request to be equivalent to the one provided
+        XCTAssertEqual(task?.request.urlRequest, Test.request.urlRequest)
+    }
+
+    func testTaskIsNilWhenImageInMemoryCache() {
+        // When the requested image is stored in memory cache
+        let request = Test.request
+        mockCache[request] = Image()
+
+        // When requesting an image
+        let task = Nuke.loadImage(with: request, into: imageView)
+
+        // Expect Nuke to not return any tasks
+        XCTAssertNil(task)
+    }
+
+    // MARK: - Prepare For Reuse
+
+    func testViewPreparedForReuse() {
+        // Given an image view displaying an image
+        imageView.image = Test.image
+
+        // When requesting the new image
+        Nuke.loadImage(with: Test.request, into: imageView)
+
+        // Then
+        XCTAssertNil(imageView.image)
+    }
+
+    func testViewPreparedForReuseDisabled() {
+        // Given an image view displaying an image
+        let image = Test.image
+        imageView.image = image
+
+        // When requesting the new image with prepare for reuse disabled
+        var options = ImageLoadingOptions()
+        options.isPrepareForReuseEnabled = false
+        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+
+        // Expect the original image to still be displayed
+        XCTAssertEqual(imageView.image, image)
+    }
+
+    // MARK: - Memory Cache
+
+    func testMemoryCacheUsed() {
+        // Given the requested image stored in memory cache
+        let image = Test.image
+        mockCache[Test.request] = image
+
+        // When requesting the new image
+        Nuke.loadImage(with: Test.request, into: imageView)
+
+        // Expect image to be displayed immediatelly
+        XCTAssertEqual(imageView.image, image)
+    }
+
+    func testMemoryCacheDisabled() {
+        // Given the requested image stored in memory cache
+        mockCache[Test.request] = Test.image
+
+        // When requesting the image with memory cache read disabled
+        var request = Test.request
+        request.memoryCacheOptions.isReadAllowed = false
+        Nuke.loadImage(with: request, into: imageView)
+
+        // Expect image to not be displayed, loaded asyncrounously instead
+        XCTAssertNil(imageView.image)
+    }
+
+    // MARK: - Completion and Progress Closures
+
+    func testCompletionCalled() {
+        var didCallCompletion = false
+        let expectation = self.expectation(description: "Image loaded")
+        Nuke.loadImage(
+            with: Test.request,
+            into: imageView,
+            completion: { response, _ in
+                // Expect completion to be called  on the main thread
+                XCTAssertTrue(Thread.isMainThread)
+                XCTAssertNotNil(response)
+                didCallCompletion = true
+                expectation.fulfill()
+        }
+        )
+
+        // Expect completion to be called asynchronously
+        XCTAssertFalse(didCallCompletion)
+        wait()
+    }
+
+    func testCompletionCalledImageFromCache() {
+        // Given the requested image stored in memory cache
+        mockCache[Test.request] = Test.image
+
+        var didCallCompletion = false
+        Nuke.loadImage(
+            with: Test.request,
+            into: imageView,
+            completion: { response, _ in
+                // Expect completion to be called syncrhonously on the main thread
+                XCTAssertTrue(Thread.isMainThread)
+                XCTAssertNotNil(response)
+                didCallCompletion = true
+        }
+        )
+        XCTAssertTrue(didCallCompletion)
+    }
+
+    func testProgressHandlerCalled() {
+        let expectedProgress = expectProgress([(10, 20), (20, 20)])
+
+        // When loading an image into a view
+        Nuke.loadImage(
+            with: Test.request,
+            into: imageView,
+            progress: { _, completed, total in
+                // Expect progress to be reported, on the main thread
+                XCTAssertTrue(Thread.isMainThread)
+                expectedProgress.received((completed, total))
+        }
+        )
+
+        wait()
+    }
+
+    // MARK: - Cancellation
+
+    func testRequestCancelled() {
+        mockPipeline.queue.isSuspended = true
+
+        // Given an image view with an associated image task
+        expectNotification(MockImagePipeline.DidStartTask, object: mockPipeline)
+        Nuke.loadImage(with: Test.url, into: imageView)
+        wait()
+
+        // Expect the task to get cancelled
+        expectNotification(MockImagePipeline.DidCancelTask, object: mockPipeline)
+
+        // When asking Nuke to cancel the request for the view
+        Nuke.cancelRequest(for: imageView)
+        wait()
+    }
+
+    func testRequestCancelledWhenNewRequestStarted() {
+        mockPipeline.queue.isSuspended = true
+
+        // Given an image view with an associated image task
+        expectNotification(MockImagePipeline.DidStartTask, object: mockPipeline)
+        Nuke.loadImage(with: Test.url, into: imageView)
+        wait()
+
+        // When starting loading a new image
+        // Expect previous task to get cancelled
+        expectNotification(MockImagePipeline.DidCancelTask, object: mockPipeline)
+        Nuke.loadImage(with: Test.url, into: imageView)
+        wait()
+    }
+
+    func testRequestCancelledWhenTargetGetsDeallocated() {
+        mockPipeline.queue.isSuspended = true
+
+        // Wrap everything in autorelease pool to make sure that imageView
+        // gets deallocated immediately.
+        autoreleasepool {
+            // Given an image view with an associated image task
+            var imageView: _ImageView! = _ImageView()
+            expectNotification(MockImagePipeline.DidStartTask, object: mockPipeline)
+            Nuke.loadImage(with: Test.url, into: imageView)
+            wait()
+
+            // Expect the task to be cancelled automatically
+            expectNotification(MockImagePipeline.DidCancelTask, object: mockPipeline)
+
+            // When the view is deallocated
+            imageView = nil
+        }
+        wait()
+    }
+
+    func testCancellingTheTaskAndWaitingForCompletion() {
+        mockPipeline.queue.isSuspended = true
+
+        // Given pipeline with cancellation disabled (important!)
+        mockPipeline.isCancellationEnabled = false
+
+        // Given an image view which is in the process of loading the image
+        Nuke.loadImage(with: Test.request, into: imageView) { _, _ in
+            // Expect completion to never get called, we're already displaying
+            // the image B by that point.
+            XCTFail("Enexpected completion")
+        }
+
+        // When cancelling the request
+        Nuke.cancelRequest(for: imageView)
+
+        // When the pipeline finishes loading the image B.
+        expectNotification(MockImagePipeline.DidFinishTask)
+        mockPipeline.queue.isSuspended = false
+        wait()
+
+        // Expect an image view to still be displaying the image B.
+        XCTAssertNil(imageView.image)
+    }
+
+    func testCancellingTheTaskByRequestingNewImageStoredInCache() {
+        mockPipeline.queue.isSuspended = true
+
+        let requestA = ImageRequest(url: URL(string: "test://imageA")!)
+        let requestB = ImageRequest(url: URL(string: "test://imageB")!)
+
+        // Given pipeline with cancellation disabled (important!)
+        mockPipeline.isCancellationEnabled = false
+
+        // Given an image A not stored in cache and image B - stored.
+        let imageB = Image()
+        mockCache[requestB] = imageB
+
+        // Given an image view which is in the process of loading the image A.
+        Nuke.loadImage(with: requestA, into: imageView) { _, _ in
+            // Expect completion to never get called, we're already displaying
+            // the image B by that point.
+            XCTFail("Enexpected completion for requestA")
+        }
+
+        // When starting a starting a new request for the image B.
+        Nuke.loadImage(with: requestB, into: imageView)
+
+        // Expect an image B to be displayed immediatelly.
+        XCTAssertEqual(imageB, imageView.image)
+
+        // When the pipeline finishes loading the image B.
+        expectNotification(MockImagePipeline.DidFinishTask)
+        mockPipeline.queue.isSuspended = false
+        wait()
+
+        // Expect an image view to still be displaying the image B.
+        XCTAssertEqual(imageB, imageView.image)
+    }
+}
+
+@available(*, deprecated)
+class DeprecatedImageViewLoadingOptionsTests: XCTestCase {
+    var mockCache: MockImageCache!
+    var dataLoader: MockDataLoader!
+    var imageView: _ImageView!
+
+    override func setUp() {
+        super.setUp()
+
+        mockCache = MockImageCache()
+        dataLoader = MockDataLoader()
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = mockCache
+        }
+        // Nuke.loadImage(...) methods use shared pipeline by default.
+        ImagePipeline.pushShared(pipeline)
+
+        imageView = _ImageView()
+    }
+
+    override func tearDown() {
+        ImagePipeline.popShared()
+    }
+
+    // MARK: - Transition
+
+    func testCustomTransitionPerformed() {
+        // Given
+        var options = ImageLoadingOptions()
+
+        let expectTransition = self.expectation(description: "")
+        options.transition = .custom({ (view, image) in
+            // Then
+            XCTAssertEqual(view, self.imageView)
+            XCTAssertNil(self.imageView.image) // Image isn't displayed automatically.
+            XCTAssertEqual(view, self.imageView)
+            self.imageView.image = image
+            expectTransition.fulfill()
+        })
+
+        // When
+        expectToLoadImage(with: Test.request, options: options, into: imageView)
+        wait()
+    }
+
+    // Tests https://github.com/kean/Nuke/issues/206
+    func testImageIsDisplayedFadeInTransition() {
+        // Given options with .fadeIn transition
+        let options = ImageLoadingOptions(transition: .fadeIn(duration: 10))
+
+        // When loading an image into an image view
+        expectToLoadImage(with: Test.request, options: options, into: imageView)
+        wait()
+
+        // Then image is actually displayed
+        XCTAssertNotNil(imageView.image)
+    }
+
+    // MARK: - Placeholder
+
+    func testPlaceholderDisplayed() {
+        // Given
+        var options = ImageLoadingOptions()
+        let placeholder = Image()
+        options.placeholder = placeholder
+
+        // When
+        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+
+        // Then
+        XCTAssertEqual(imageView.image, placeholder)
+    }
+
+    // MARK: - Failure Image
+
+    func testFailureImageDisplayed() {
+        // Given
+        dataLoader.results[Test.url] = .failure(
+            NSError(domain: "ErrorDomain", code: 42, userInfo: nil)
+        )
+
+        var options = ImageLoadingOptions()
+        let failureImage = Image()
+        options.failureImage = failureImage
+
+        // When
+        expectToFinishLoadingImage(with: Test.request, options: options, into: imageView)
+        wait()
+
+        // Then
+        XCTAssertEqual(imageView.image, failureImage)
+    }
+
+    func testFailureImageTransitionRun() {
+        // Given
+        dataLoader.results[Test.url] = .failure(
+            NSError(domain: "t", code: 42, userInfo: nil)
+        )
+
+        var options = ImageLoadingOptions()
+        let failureImage = Image()
+        options.failureImage = failureImage
+
+        // Given
+        let expectTransition = self.expectation(description: "")
+        options.failureImageTransition = .custom({ (view, image) in
+            // Then
+            XCTAssertEqual(view, self.imageView)
+            XCTAssertEqual(image, failureImage)
+            self.imageView.image = image
+            expectTransition.fulfill()
+        })
+
+        // When
+        expectToFinishLoadingImage(with: Test.request, options: options, into: imageView)
+        wait()
+
+        // Then
+        XCTAssertEqual(imageView.image, failureImage)
+    }
+
+    #if !os(macOS)
+
+    // MARK: - Content Modes
+
+    func testPlaceholderAndSuccessContentModesApplied() {
+        // Given
+        var options = ImageLoadingOptions()
+        options.contentModes = .init(
+            success: .scaleAspectFill, // default is .scaleToFill
+            failure: .center,
+            placeholder: .center
+        )
+        options.placeholder = Image()
+
+        // When
+        expectToFinishLoadingImage(with: Test.request, options: options, into: imageView)
+
+        // Then
+        XCTAssertEqual(imageView.contentMode, .center)
+        wait()
+        XCTAssertEqual(imageView.contentMode, .scaleAspectFill)
+    }
+
+    func testSuccessContentModeAppliedWhenFromMemoryCache() {
+        // Given
+        var options = ImageLoadingOptions()
+        options.contentModes = ImageLoadingOptions.ContentModes(
+            success: .scaleAspectFill,
+            failure: .center,
+            placeholder: .center
+        )
+
+        mockCache[Test.request] = Test.image
+
+        // Whem
+        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+
+        // Then
+        XCTAssertEqual(imageView.contentMode, .scaleAspectFill)
+    }
+
+    func testFailureContentModeApplied() {
+        // Given
+        var options = ImageLoadingOptions()
+        options.contentModes = ImageLoadingOptions.ContentModes(
+            success: .scaleAspectFill,
+            failure: .center,
+            placeholder: .center
+        )
+        options.failureImage = Image()
+
+        dataLoader.results[Test.url] = .failure(
+            NSError(domain: "t", code: 42, userInfo: nil)
+        )
+
+        // When
+        expectToFinishLoadingImage(with: Test.request, options: options, into: imageView)
+        wait()
+
+        // Then
+        XCTAssertEqual(imageView.contentMode, .center)
+    }
+
+    #endif
+
+    // MARK: - Pipeline
+
+    func testCustomPipelineUsed() {
+        // Given
+        let dataLoader = MockDataLoader()
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+
+        var options = ImageLoadingOptions()
+        options.pipeline = pipeline
+
+        // When
+        expectToFinishLoadingImage(with: Test.request, options: options, into: imageView)
+
+        // Then
+        wait { _ in
+            _ = pipeline
+            XCTAssertEqual(dataLoader.createdTaskCount, 1)
+            XCTAssertEqual(self.dataLoader.createdTaskCount, 0)
+        }
+    }
+
+    // MARK: - Shared Options
+
+    func testSharedOptionsUsed() {
+        // Given
+        var options = ImageLoadingOptions.shared
+        let placeholder = Image()
+        options.placeholder = placeholder
+
+        ImageLoadingOptions.pushShared(options)
+
+        // When
+        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+
+        // Then
+        XCTAssertEqual(imageView.image, placeholder)
+
+        ImageLoadingOptions.popShared()
+
+    }
+}
+
+@available(*, deprecated)
+class DeprecatedImageRequestTests: XCTestCase {
+    // MARK: - CoW
+
+    func testStructSemanticsArePreserved() {
+        // Given
+        let url1 =  URL(string: "http://test.com/1.png")!
+        let url2 = URL(string: "http://test.com/2.png")!
+        var request = ImageRequest(url: url1)
+
+        // When
+        var copy = request
+        copy.urlRequest = URLRequest(url: url2)
+
+        // Then
+        XCTAssertEqual(url2, copy.urlRequest.url)
+        XCTAssertEqual(url1, request.urlRequest.url)
+    }
+
+    func testCopyOnWrite() {
+        // Given
+        var request = ImageRequest(url: URL(string: "http://test.com/1.png")!)
+        request.memoryCacheOptions.isReadAllowed = false
+        request.loadKey = "1"
+        request.cacheKey = "2"
+        request.userInfo = "3"
+        request.processor = MockImageProcessor(id: "4")
+        request.priority = .high
+
+        // When
+        var copy = request
+        // Requst makes a copy at this point under the hood.
+        copy.urlRequest = URLRequest(url: URL(string: "http://test.com/2.png")!)
+
+        // Then
+        XCTAssertEqual(copy.memoryCacheOptions.isReadAllowed, false)
+        XCTAssertEqual(copy.loadKey, "1")
+        XCTAssertEqual(copy.cacheKey, "2")
+        XCTAssertEqual(copy.userInfo as? String, "3")
+        XCTAssertEqual((copy.processor as? MockImageProcessor)?.identifier, MockImageProcessor(id: "4").identifier)
+        XCTAssertEqual(copy.priority, .high)
+    }
+
+    // MARK: - Misc
+
+    // Just to make sure that comparison works as expected.
+    func testPriorityComparison() {
+        typealias Priority = ImageRequest.Priority
+        XCTAssertTrue(Priority.veryLow < Priority.veryHigh)
+        XCTAssertTrue(Priority.low < Priority.normal)
+        XCTAssertTrue(Priority.normal == Priority.normal)
+    }
+}
+
+@available(*, deprecated)
+class DeprecatedImageRequestCacheKeyTests: XCTestCase {
+    func testDefaults() {
+        let request = Test.request
+        AssertHashableEqual(CacheKey(request: request), CacheKey(request: request)) // equal to itself
+    }
+
+    func testRequestsWithTheSameURLsAreEquivalent() {
+        let request1 = ImageRequest(url: Test.url)
+        let request2 = ImageRequest(url: Test.url)
+        AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
+    func testRequestsWithDefaultURLRequestAndURLAreEquivalent() {
+        let request1 = ImageRequest(url: Test.url)
+        let request2 = ImageRequest(urlRequest: URLRequest(url: Test.url))
+        AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
+    func testRequestsWithDifferentURLsAreNotEquivalent() {
+        let request1 = ImageRequest(url: URL(string: "http://test.com/1.png")!)
+        let request2 = ImageRequest(url: URL(string: "http://test.com/2.png")!)
+        XCTAssertNotEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
+    func testURLRequestParametersAreIgnored() {
+        let request1 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .reloadRevalidatingCacheData, timeoutInterval: 50))
+        let request2 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 0))
+        AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
+    func testSettingDefaultProcessorManually() {
+        let request1 = ImageRequest(url: Test.url)
+        var request2 = ImageRequest(url: Test.url)
+        request2.processor = request1.processor
+        AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
+    // MARK: Custom Cache Key
+
+    func testRequestsWithSameCustomKeysAreEquivalent() {
+        var request1 = ImageRequest(url: Test.url)
+        request1.cacheKey = "1"
+        var request2 = ImageRequest(url: Test.url)
+        request2.cacheKey = "1"
+        AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
+    func testRequestsWithSameCustomKeysButDifferentURLsAreEquivalent() {
+        var request1 = ImageRequest(url: URL(string: "https://example.com/photo1.jpg")!)
+        request1.cacheKey = "1"
+        var request2 = ImageRequest(url: URL(string: "https://example.com/photo2.jpg")!)
+        request2.cacheKey = "1"
+        AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
+    func testRequestsWithDifferentCustomKeysAreNotEquivalent() {
+        var request1 = ImageRequest(url: Test.url)
+        request1.cacheKey = "1"
+        var request2 = ImageRequest(url: Test.url)
+        request2.cacheKey = "2"
+        XCTAssertNotEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+}
+
+@available(*, deprecated)
+class DeprecatedImageRequestLoadKeyTests: XCTestCase {
+    func testDefaults() {
+        let request = ImageRequest(url: Test.url)
+        AssertHashableEqual(LoadKey(request: request), LoadKey(request: request))
+    }
+
+    func testRequestsWithTheSameURLsAreEquivalent() {
+        let request1 = ImageRequest(url: Test.url)
+        let request2 = ImageRequest(url: Test.url)
+        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+    }
+
+    func testRequestsWithDifferentURLsAreNotEquivalent() {
+        let request1 = ImageRequest(url: URL(string: "http://test.com/1.png")!)
+        let request2 = ImageRequest(url: URL(string: "http://test.com/2.png")!)
+        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+    }
+
+    func testRequestWithDifferentURLRequestParametersAreNotEquivalent() {
+        let request1 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .reloadRevalidatingCacheData, timeoutInterval: 50))
+        let request2 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 0))
+        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+    }
+
+    // MARK: - Custom Load Key
+
+    func testRequestsWithSameCustomKeysAreEquivalent() {
+        var request1 = ImageRequest(url: Test.url)
+        request1.loadKey = "1"
+        var request2 = ImageRequest(url: Test.url)
+        request2.loadKey = "1"
+        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+    }
+
+    func testRequestsWithSameCustomKeysButDifferentURLsAreEquivalent() {
+        var request1 = ImageRequest(url: URL(string: "https://example.com/photo1.jpg")!)
+        request1.loadKey = "1"
+        var request2 = ImageRequest(url: URL(string: "https://example.com/photo2.jpg")!)
+        request2.loadKey = "1"
+        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+    }
+
+    func testRequestsWithDifferentCustomKeysAreNotEquivalent() {
+        var request1 = ImageRequest(url: Test.url)
+        request1.loadKey = "1"
+        var request2 = ImageRequest(url: Test.url)
+        request2.loadKey = "2"
+        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+    }
+}
+
+private typealias CacheKey = ImageRequest.CacheKey
+private typealias LoadKey = ImageRequest.LoadKey
+
+private func AssertHashableEqual<T: Hashable>(_ lhs: T, _ rhs: T, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(lhs.hashValue, rhs.hashValue, file: file, line: line)
+    XCTAssertEqual(lhs, rhs, file: file, line: line)
+}

--- a/Tests/ImageViewIntegrationTests.swift
+++ b/Tests/ImageViewIntegrationTests.swift
@@ -48,7 +48,7 @@ class ImageViewIntegrationTests: XCTestCase {
     func testImageLoadedWithURL() {
         // When
         let expectation = self.expectation(description: "Image loaded")
-        Nuke.loadImage(with: url, into: imageView) { _ in
+        imageView.nk.setImage(with: url) { _ in
             expectation.fulfill()
         }
         wait()

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -42,7 +42,7 @@ class ImageViewTests: XCTestCase {
     func testImageLoadedWithURL() {
         // When requesting an image with URL
         let expectation = self.expectation(description: "Image loaded")
-        Nuke.loadImage(with: Test.url, into: imageView) { _ in
+        imageView.nk.setImage(with: Test.url) { _ in
             expectation.fulfill()
         }
         wait()
@@ -55,7 +55,7 @@ class ImageViewTests: XCTestCase {
 
     func testTaskReturned() {
         // When requesting an image
-        let task = Nuke.loadImage(with: Test.request, into: imageView)
+        let task = imageView.nk.setImage(with: Test.request)
 
         // Expect Nuke to return a task
         XCTAssertNotNil(task)
@@ -70,7 +70,7 @@ class ImageViewTests: XCTestCase {
         mockCache[request] = Image()
 
         // When requesting an image
-        let task = Nuke.loadImage(with: request, into: imageView)
+        let task = imageView.nk.setImage(with: request)
 
         // Expect Nuke to not return any tasks
         XCTAssertNil(task)
@@ -83,7 +83,7 @@ class ImageViewTests: XCTestCase {
         imageView.image = Test.image
 
         // When requesting the new image
-        Nuke.loadImage(with: Test.request, into: imageView)
+        imageView.nk.setImage(with: Test.request)
 
         // Then
         XCTAssertNil(imageView.image)
@@ -97,7 +97,7 @@ class ImageViewTests: XCTestCase {
         // When requesting the new image with prepare for reuse disabled
         var options = ImageLoadingOptions()
         options.isPrepareForReuseEnabled = false
-        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+        imageView.nk.setImage(with: Test.request, options: options)
 
         // Expect the original image to still be displayed
         XCTAssertEqual(imageView.image, image)
@@ -111,7 +111,7 @@ class ImageViewTests: XCTestCase {
         mockCache[Test.request] = image
 
         // When requesting the new image
-        Nuke.loadImage(with: Test.request, into: imageView)
+        imageView.nk.setImage(with: Test.request)
 
         // Expect image to be displayed immediatelly
         XCTAssertEqual(imageView.image, image)
@@ -124,7 +124,7 @@ class ImageViewTests: XCTestCase {
         // When requesting the image with memory cache read disabled
         var request = Test.request
         request.options.memoryCacheOptions.isReadAllowed = false
-        Nuke.loadImage(with: request, into: imageView)
+        imageView.nk.setImage(with: request)
 
         // Expect image to not be displayed, loaded asyncrounously instead
         XCTAssertNil(imageView.image)
@@ -135,9 +135,8 @@ class ImageViewTests: XCTestCase {
     func testCompletionCalled() {
         var didCallCompletion = false
         let expectation = self.expectation(description: "Image loaded")
-        Nuke.loadImage(
+        imageView.nk.setImage(
             with: Test.request,
-            into: imageView,
             completion: { result in
                 // Expect completion to be called  on the main thread
                 XCTAssertTrue(Thread.isMainThread)
@@ -157,9 +156,8 @@ class ImageViewTests: XCTestCase {
         mockCache[Test.request] = Test.image
 
         var didCallCompletion = false
-        Nuke.loadImage(
+        imageView.nk.setImage(
             with: Test.request,
-            into: imageView,
             completion: { result in
                 // Expect completion to be called syncrhonously on the main thread
                 XCTAssertTrue(Thread.isMainThread)
@@ -174,9 +172,8 @@ class ImageViewTests: XCTestCase {
         let expectedProgress = expectProgress([(10, 20), (20, 20)])
 
         // When loading an image into a view
-        Nuke.loadImage(
+        imageView.nk.setImage(
             with: Test.request,
-            into: imageView,
             progress: { completed, total in
                 // Expect progress to be reported, on the main thread
                 XCTAssertTrue(Thread.isMainThread)
@@ -194,14 +191,14 @@ class ImageViewTests: XCTestCase {
 
         // Given an image view with an associated image task
         expectNotification(MockImagePipeline.DidStartTask, object: mockPipeline)
-        Nuke.loadImage(with: Test.url, into: imageView)
+        imageView.nk.setImage(with: Test.url)
         wait()
 
         // Expect the task to get cancelled
         expectNotification(MockImagePipeline.DidCancelTask, object: mockPipeline)
 
         // When asking Nuke to cancel the request for the view
-        Nuke.cancelRequest(for: imageView)
+        imageView.nk.cancelImageRequest()
         wait()
     }
 
@@ -210,13 +207,13 @@ class ImageViewTests: XCTestCase {
 
         // Given an image view with an associated image task
         expectNotification(MockImagePipeline.DidStartTask, object: mockPipeline)
-        Nuke.loadImage(with: Test.url, into: imageView)
+        imageView.nk.setImage(with: Test.url)
         wait()
 
         // When starting loading a new image
         // Expect previous task to get cancelled
         expectNotification(MockImagePipeline.DidCancelTask, object: mockPipeline)
-        Nuke.loadImage(with: Test.url, into: imageView)
+        imageView.nk.setImage(with: Test.url)
         wait()
     }
 
@@ -229,7 +226,7 @@ class ImageViewTests: XCTestCase {
             // Given an image view with an associated image task
             var imageView: _ImageView! = _ImageView()
             expectNotification(MockImagePipeline.DidStartTask, object: mockPipeline)
-            Nuke.loadImage(with: Test.url, into: imageView)
+            imageView.nk.setImage(with: Test.url)
             wait()
 
             // Expect the task to be cancelled automatically
@@ -248,14 +245,14 @@ class ImageViewTests: XCTestCase {
         mockPipeline.isCancellationEnabled = false
 
         // Given an image view which is in the process of loading the image
-        Nuke.loadImage(with: Test.request, into: imageView) { _ in
+        imageView.nk.setImage(with: Test.request) { _ in
             // Expect completion to never get called, we're already displaying
             // the image B by that point.
             XCTFail("Enexpected completion")
         }
 
         // When cancelling the request
-        Nuke.cancelRequest(for: imageView)
+        imageView.nk.cancelImageRequest()
 
         // When the pipeline finishes loading the image B.
         expectNotification(MockImagePipeline.DidFinishTask)
@@ -280,14 +277,14 @@ class ImageViewTests: XCTestCase {
         mockCache[requestB] = imageB
 
         // Given an image view which is in the process of loading the image A.
-        Nuke.loadImage(with: requestA, into: imageView) { _ in
+        imageView.nk.setImage(with: requestA) { _ in
             // Expect completion to never get called, we're already displaying
             // the image B by that point.
             XCTFail("Enexpected completion for requestA")
         }
 
         // When starting a starting a new request for the image B.
-        Nuke.loadImage(with: requestB, into: imageView)
+        imageView.nk.setImage(with: requestB)
 
         // Expect an image B to be displayed immediatelly.
         XCTAssertEqual(imageB, imageView.image)
@@ -369,7 +366,7 @@ class ImageViewLoadingOptionsTests: XCTestCase {
         options.placeholder = placeholder
 
         // When
-        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+        imageView.nk.setImage(with: Test.request, options: options)
 
         // Then
         XCTAssertEqual(imageView.image, placeholder)
@@ -458,7 +455,7 @@ class ImageViewLoadingOptionsTests: XCTestCase {
         mockCache[Test.request] = Test.image
 
         // Whem
-        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+        imageView.nk.setImage(with: Test.request, options: options)
 
         // Then
         XCTAssertEqual(imageView.contentMode, .scaleAspectFill)
@@ -523,7 +520,7 @@ class ImageViewLoadingOptionsTests: XCTestCase {
         ImageLoadingOptions.pushShared(options)
 
         // When
-        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+        imageView.nk.setImage(with: Test.request, options: options)
 
         // Then
         XCTAssertEqual(imageView.image, placeholder)

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -27,7 +27,7 @@ class ImageViewPerformanceTests: XCTestCase {
 
         measure {
             for url in urls {
-                Nuke.loadImage(with: url, into: view)
+                view.nk.setImage(with: url)
             }
         }
     }
@@ -40,7 +40,7 @@ class ImageViewPerformanceTests: XCTestCase {
         measure {
             for url in urls {
                 let request = ImageRequest(url: url, processors: [ImageProcessor.Resize(size: CGSize(width: 1, height: 1))])
-                Nuke.loadImage(with: request, into: view)
+                view.nk.setImage(with: request)
             }
         }
     }
@@ -53,7 +53,7 @@ class ImageViewPerformanceTests: XCTestCase {
         measure {
             for url in urls {
                 let request = ImageRequest(url: url, processors: [ImageProcessor.Resize(size: CGSize(width: 1, height: 1))])
-                Nuke.loadImage(with: request, into: view)
+                view.nk.setImage(with: request)
             }
         }
     }
@@ -64,12 +64,10 @@ class ImagePipelinePerfomanceTests: XCTestCase {
     /// data, decode, and decomperss 50+ images. It's very useful to get a
     /// broad picture about how loader options affect perofmance.
     func testLoaderOverallPerformance() {
-        let dataLoader = MockDataLoader()
-
-        let loader = ImagePipeline {
+        let pipeline = ImagePipeline {
             $0.imageCache = nil
 
-            $0.dataLoader = dataLoader
+            $0.dataLoader = MockDataLoader()
 
             $0.isDecompressionEnabled = false
 
@@ -86,7 +84,7 @@ class ImagePipelinePerfomanceTests: XCTestCase {
                 var request = ImageRequest(url: url)
                 request.processors = [] // Remove processing time from equation
 
-                loader.loadImage(with: url) { _ in
+                pipeline.loadImage(with: url) { _ in
                     finished += 1
                     if finished == urls.count {
                         expectation.fulfill()

--- a/Tests/XCTestCase+Nuke.swift
+++ b/Tests/XCTestCase+Nuke.swift
@@ -60,10 +60,9 @@ struct TestExpectationImagePipeline {
 extension XCTestCase {
     func expectToFinishLoadingImage(with request: ImageRequest, options: ImageLoadingOptions = ImageLoadingOptions.shared, into imageView: ImageDisplayingView, completion: ImageTask.Completion? = nil) {
         let expectation = self.expectation(description: "Image loaded for \(request)")
-        Nuke.loadImage(
+        imageView.nk.setImage(
             with: request,
             options: options,
-            into: imageView,
             completion: { result in
                 XCTAssertTrue(Thread.isMainThread)
                 completion?(result)


### PR DESCRIPTION
- Future-proof Objective-C `ImageDisplaying` protocol by adding `nuke_` prefixes to avoid clashes in Objective-C runtime
- Add `imageView.nk.setImage(with:)` family of methods as a replacement for `Nuke.loadImage(with:into:)`. The latter wasn't grammatically correct, that's the first. `setImage(with:)` methods are also more conventional.
- Add `WKInterfaceImage` support
- Add `DeprecatedTests` to make sure that all deprecated methods work exactly as they were in the previous versions