### PR TITLE
Improve cache and load keys support

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -104,17 +104,17 @@ public final class ImageCache: ImageCaching {
 
     /// Returns the `ImageResponse` stored in the cache with the given request.
     public func cachedResponse(for request: ImageRequest) -> ImageResponse? {
-        return impl.value(forKey: ImageRequest.CacheKey(request: request))
+        return impl.value(forKey: request.makeCacheKeyForProcessedImage())
     }
 
     /// Stores the given `ImageResponse` in the cache using the given request.
     public func storeResponse(_ response: ImageResponse, for request: ImageRequest) {
-        impl.set(response, forKey: ImageRequest.CacheKey(request: request), cost: self.cost(for: response.image))
+        impl.set(response, forKey: request.makeCacheKeyForProcessedImage(), cost: self.cost(for: response.image))
     }
 
     /// Removes response stored with the given request.
     public func removeResponse(for request: ImageRequest) {
-        impl.removeValue(forKey: ImageRequest.CacheKey(request: request))
+        impl.removeValue(forKey: request.makeCacheKeyForProcessedImage())
     }
 
     /// Removes all cached images.

--- a/Sources/ImagePreheater.swift
+++ b/Sources/ImagePreheater.swift
@@ -16,7 +16,7 @@ public final class ImagePreheater {
     private let pipeline: ImagePipeline
     private let queue = DispatchQueue(label: "com.github.kean.Nuke.Preheater")
     private let preheatQueue = OperationQueue()
-    private var tasks = [ImageRequest.ImageLoadKey: Task]()
+    private var tasks = [AnyHashable: Task]()
     private let destination: Destination
 
     /// Prefetching destination.
@@ -63,7 +63,7 @@ public final class ImagePreheater {
     }
 
     private func _startPreheating(with request: ImageRequest) {
-        let key = ImageRequest.ImageLoadKey(request: request)
+        let key = request.makeLoadKeyForProcessedImage()
 
         // Check if we we've already started preheating.
         guard tasks[key] == nil else {
@@ -141,7 +141,7 @@ public final class ImagePreheater {
     }
 
     private func _stopPreheating(with request: ImageRequest) {
-        if let task = tasks[ImageRequest.ImageLoadKey(request: request)] {
+        if let task = tasks[request.makeLoadKeyForProcessedImage()] {
             tasks[task.key] = nil
             task.cancel()
         }
@@ -164,13 +164,13 @@ public final class ImagePreheater {
     }
 
     private final class Task {
-        let key: ImageRequest.ImageLoadKey
+        let key: AnyHashable
         let request: ImageRequest
         var isCancelled = false
         var onCancelled: (() -> Void)?
         weak var operation: Operation?
 
-        init(request: ImageRequest, key: ImageRequest.ImageLoadKey) {
+        init(request: ImageRequest, key: AnyHashable) {
             self.request = request
             self.key = key
         }

--- a/Tests/DeprecatedTests.swift
+++ b/Tests/DeprecatedTests.swift
@@ -658,25 +658,25 @@ class DeprecatedImageRequestCacheKeyTests: XCTestCase {
 class DeprecatedImageRequestLoadKeyTests: XCTestCase {
     func testDefaults() {
         let request = ImageRequest(url: Test.url)
-        AssertHashableEqual(LoadKey(request: request), LoadKey(request: request))
+        AssertHashableEqual(request.makeLoadKeyForOriginalImage(), request.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithTheSameURLsAreEquivalent() {
         let request1 = ImageRequest(url: Test.url)
         let request2 = ImageRequest(url: Test.url)
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithDifferentURLsAreNotEquivalent() {
         let request1 = ImageRequest(url: URL(string: "http://test.com/1.png")!)
         let request2 = ImageRequest(url: URL(string: "http://test.com/2.png")!)
-        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+        XCTAssertNotEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestWithDifferentURLRequestParametersAreNotEquivalent() {
         let request1 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .reloadRevalidatingCacheData, timeoutInterval: 50))
         let request2 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 0))
-        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+        XCTAssertNotEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     // MARK: - Custom Load Key
@@ -686,7 +686,7 @@ class DeprecatedImageRequestLoadKeyTests: XCTestCase {
         request1.loadKey = "1"
         var request2 = ImageRequest(url: Test.url)
         request2.loadKey = "1"
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithSameCustomKeysButDifferentURLsAreEquivalent() {
@@ -694,7 +694,7 @@ class DeprecatedImageRequestLoadKeyTests: XCTestCase {
         request1.loadKey = "1"
         var request2 = ImageRequest(url: URL(string: "https://example.com/photo2.jpg")!)
         request2.loadKey = "1"
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithDifferentCustomKeysAreNotEquivalent() {
@@ -702,12 +702,11 @@ class DeprecatedImageRequestLoadKeyTests: XCTestCase {
         request1.loadKey = "1"
         var request2 = ImageRequest(url: Test.url)
         request2.loadKey = "2"
-        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+        XCTAssertNotEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 }
 
 private typealias CacheKey = ImageRequest.CacheKey
-private typealias LoadKey = ImageRequest.LoadKey
 
 private func AssertHashableEqual<T: Hashable>(_ lhs: T, _ rhs: T, file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(lhs.hashValue, rhs.hashValue, file: file, line: line)

--- a/Tests/ImageRequestTests.swift
+++ b/Tests/ImageRequestTests.swift
@@ -106,6 +106,12 @@ class ImageRequestCacheKeyTests: XCTestCase {
         AssertHashableEqual(CacheKey(request: request1), CacheKey(request: request2))
     }
 
+    func testRequestWithDefaultAndCustomKeysAreNotEquivalent() {
+        let request1 = ImageRequest(url: Test.url)
+        let request2 = ImageRequest(url: Test.url, options: .init(cacheKey: "2"))
+        XCTAssertNotEqual(CacheKey(request: request1), CacheKey(request: request2))
+    }
+
     // MARK: Custom Cache Key
 
     func testRequestsWithSameCustomKeysAreEquivalent() {
@@ -136,37 +142,37 @@ class ImageRequestCacheKeyTests: XCTestCase {
 class ImageRequestLoadKeyTests: XCTestCase {
     func testDefaults() {
         let request = ImageRequest(url: Test.url)
-        AssertHashableEqual(LoadKey(request: request), LoadKey(request: request))
+        AssertHashableEqual(request.makeLoadKeyForOriginalImage(), request.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithTheSameURLsAreEquivalent() {
         let request1 = ImageRequest(url: Test.url)
         let request2 = ImageRequest(url: Test.url)
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithDifferentURLsAreNotEquivalent() {
         let request1 = ImageRequest(url: URL(string: "http://test.com/1.png")!)
         let request2 = ImageRequest(url: URL(string: "http://test.com/2.png")!)
-        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+        XCTAssertNotEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithTheSameProcessorsAreEquivalent() {
         let request1 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
         let request2 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithDifferentProcessorsAreEquivalent() {
         let request1 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
         let request2 = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "2")])
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestWithDifferentURLRequestParametersAreNotEquivalent() {
         let request1 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .reloadRevalidatingCacheData, timeoutInterval: 50))
         let request2 = ImageRequest(urlRequest: URLRequest(url: Test.url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 0))
-        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+        XCTAssertNotEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testMockImageProcessorCorrectlyImplementsIdentifiers() {
@@ -184,7 +190,7 @@ class ImageRequestLoadKeyTests: XCTestCase {
         request1.options.loadKey = "1"
         var request2 = ImageRequest(url: Test.url)
         request2.options.loadKey = "1"
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithSameCustomKeysButDifferentURLsAreEquivalent() {
@@ -192,7 +198,7 @@ class ImageRequestLoadKeyTests: XCTestCase {
         request1.options.loadKey = "1"
         var request2 = ImageRequest(url: URL(string: "https://example.com/photo2.jpg")!)
         request2.options.loadKey = "1"
-        AssertHashableEqual(LoadKey(request: request1), LoadKey(request: request2))
+        AssertHashableEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 
     func testRequestsWithDifferentCustomKeysAreNotEquivalent() {
@@ -200,12 +206,11 @@ class ImageRequestLoadKeyTests: XCTestCase {
         request1.options.loadKey = "1"
         var request2 = ImageRequest(url: Test.url)
         request2.options.loadKey = "2"
-        XCTAssertNotEqual(LoadKey(request: request1), LoadKey(request: request2))
+        XCTAssertNotEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
     }
 }
 
 private typealias CacheKey = ImageRequest.CacheKey
-private typealias LoadKey = ImageRequest.LoadKey
 
 private func AssertHashableEqual<T: Hashable>(_ lhs: T, _ rhs: T, file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(lhs.hashValue, rhs.hashValue, file: file, line: line)

--- a/Tests/ImageRequestTests.swift
+++ b/Tests/ImageRequestTests.swift
@@ -30,6 +30,7 @@ class ImageRequestTests: XCTestCase {
         request.options.loadKey = "1"
         request.options.cacheKey = "2"
         request.options.userInfo = "3"
+        request.options.filteredURL = "4"
         request.processors = [MockImageProcessor(id: "4")]
         request.priority = .high
 
@@ -43,6 +44,7 @@ class ImageRequestTests: XCTestCase {
         XCTAssertEqual(copy.options.loadKey, "1")
         XCTAssertEqual(copy.options.cacheKey, "2")
         XCTAssertEqual(copy.options.userInfo as? String, "3")
+        XCTAssertEqual(copy.options.filteredURL, "4")
         XCTAssertEqual((copy.processors.first as? MockImageProcessor)?.identifier, "4")
         XCTAssertEqual(copy.priority, .high)
     }
@@ -207,6 +209,56 @@ class ImageRequestLoadKeyTests: XCTestCase {
         var request2 = ImageRequest(url: Test.url)
         request2.options.loadKey = "2"
         XCTAssertNotEqual(request1.makeLoadKeyForOriginalImage(), request2.makeLoadKeyForOriginalImage())
+    }
+}
+
+class ImageRequestFilteredURLTests: XCTestCase {
+    func testThatCacheKeyUsesAbsoluteURLByDefault() {
+        let lhs = ImageRequest(url: Test.url)
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"))
+        XCTAssertNotEqual(lhs.makeCacheKeyForProcessedImage(), rhs.makeCacheKeyForProcessedImage())
+    }
+
+    func testThatCacheKeyUsesFilteredURLWhenSet() {
+        let lhs = ImageRequest(url: Test.url, options: .init(filteredURL: Test.url.absoluteString))
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"), options: .init(filteredURL: Test.url.absoluteString))
+        AssertHashableEqual(lhs.makeCacheKeyForProcessedImage(), rhs.makeCacheKeyForProcessedImage())
+    }
+
+    func testThatCacheKeyForProcessedImageDataUsesAbsoluteURLByDefault() {
+        let lhs = ImageRequest(url: Test.url)
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"))
+        XCTAssertNotEqual(lhs.makeCacheKeyForProcessedImageData(), rhs.makeCacheKeyForProcessedImageData())
+    }
+
+    func testThatCacheKeyForProcessedImageDataUsesFilteredURLWhenSet() {
+        let lhs = ImageRequest(url: Test.url, options: .init(filteredURL: Test.url.absoluteString))
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"), options: .init(filteredURL: Test.url.absoluteString))
+        AssertHashableEqual(lhs.makeCacheKeyForProcessedImageData(), rhs.makeCacheKeyForProcessedImageData())
+    }
+
+    func testThatCacheKeyForOriginalImageDataUsesAbsoluteURLByDefault() {
+        let lhs = ImageRequest(url: Test.url)
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"))
+        XCTAssertNotEqual(lhs.makeCacheKeyForOriginalImageData(), rhs.makeCacheKeyForOriginalImageData())
+    }
+
+    func testThatCacheKeyForOriginalImageDataUsesFilteredURLWhenSet() {
+        let lhs = ImageRequest(url: Test.url, options: .init(filteredURL: Test.url.absoluteString))
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"), options: .init(filteredURL: Test.url.absoluteString))
+        AssertHashableEqual(lhs.makeCacheKeyForOriginalImageData(), rhs.makeCacheKeyForOriginalImageData())
+    }
+
+    func testThatLoadKeyForProcessedImageDoesntUseFilteredURL() {
+        let lhs = ImageRequest(url: Test.url, options: .init(filteredURL: Test.url.absoluteString))
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"), options: .init(filteredURL: Test.url.absoluteString))
+        XCTAssertNotEqual(lhs.makeLoadKeyForProcessedImage(), rhs.makeLoadKeyForProcessedImage())
+    }
+
+    func testThatLoadKeyForOriginalImageDoesntUseFilteredURL() {
+        let lhs = ImageRequest(url: Test.url, options: .init(filteredURL: Test.url.absoluteString))
+        let rhs = ImageRequest(url: Test.url.appendingPathComponent("?token=1"), options: .init(filteredURL: Test.url.absoluteString))
+        XCTAssertNotEqual(lhs.makeLoadKeyForOriginalImage(), rhs.makeLoadKeyForOriginalImage())
     }
 }
 


### PR DESCRIPTION
- Add `filteredURL` option to `ImageRequestOptions`

In some cases your image URLs might contains transient query parameters like access tokens which must be ignored when generating cache keys. If that's the case, set this property to a URL without the unwanted fields:

```swift
let request = ImageRequest(
    url: URL(string: "http://example.com/image.jpeg?token=1")! ,
    options: .init(filteredURL: "http://example.com/image.jpeg")
)
```

This option affects both memory and disk caches.

-  Refactor the way cache and load keys are created and used
