### PR TITLE
Remove image task delegate

### DIFF
--- a/Demo/Sources/ProgressiveDecodingDemoViewController.swift
+++ b/Demo/Sources/ProgressiveDecodingDemoViewController.swift
@@ -63,7 +63,7 @@ final class ProgressiveDecodingDemoViewController: UIViewController {
         imageView.nk.setImage(
             with: ImageRequest(url: url, processors: [_ProgressiveBlurImageProcessor()]),
             options: options,
-            progress: { completed, total in
+            progress: { _, completed, total in
                 container.updateProgress(completed: completed, total: total)
         })
     }

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -23,10 +23,8 @@
 		0C1ECA451D52667B009063A9 /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C06881BCA888800089D7F /* ImageProcessingTests.swift */; };
 		0C1ECA501D52811D009063A9 /* ImageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C94466D1D47EC0E006DB314 /* ImageViewTests.swift */; };
 		0C2A8CF720970B790013FD65 /* ImagePipelineResumableDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2A8CF620970B790013FD65 /* ImagePipelineResumableDataTests.swift */; };
-		0C3261F31FEBC232009276AC /* MockImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C06891BCA888800089D7F /* MockImageCache.swift */; };
 		0C3261F41FEBC232009276AC /* MockImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068A1BCA888800089D7F /* MockImageProcessor.swift */; };
 		0C3261F51FEBC232009276AC /* MockDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068C1BCA888800089D7F /* MockDataLoader.swift */; };
-		0C3261F61FEBC232009276AC /* MockImagePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01287F1D43E85100668A1F /* MockImagePipeline.swift */; };
 		0C3261F71FEBC232009276AC /* MockImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE745741D4767B900123F65 /* MockImageDecoder.swift */; };
 		0C42D4C722A286260094CB5A /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42D4C422A283140094CB5A /* Deprecated.swift */; };
 		0C42D4C922A2BB850094CB5A /* DeprecatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42D4C822A2BB850094CB5A /* DeprecatedTests.swift */; };
@@ -641,8 +639,6 @@
 				0C3261F71FEBC232009276AC /* MockImageDecoder.swift in Sources */,
 				0C09B16F1FE9A6D800E8FE3B /* Helpers.swift in Sources */,
 				0C3261F41FEBC232009276AC /* MockImageProcessor.swift in Sources */,
-				0C3261F31FEBC232009276AC /* MockImageCache.swift in Sources */,
-				0C3261F61FEBC232009276AC /* MockImagePipeline.swift in Sources */,
 				0CAAB0131E45D6DA00924450 /* NukeExtensions.swift in Sources */,
 				0C3261F51FEBC232009276AC /* MockDataLoader.swift in Sources */,
 				0C8D7BF51D9DC07E00D12EB7 /* PerformanceTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Use `ImagePipeline` directly to load images without a view.
 ```swift
 let task = ImagePipeline.shared.loadImage(
     with: url,
-    progress: { completed, total in
+    progress: { _, completed, total in
         print("progress updated")
     },
     completion: { result in
@@ -289,7 +289,9 @@ let imageView = UIImageView()
 let task = ImagePipeline.shared.loadImage(
     with: url,
     progress: { response, _, _ in
-        imageView.image = response?.image
+        if let response = response {
+            imageView.image = response?.image
+        }
     },
     completion: { result in
         imageView.image = try? result.get().image

--- a/Sources/DataCache.swift
+++ b/Sources/DataCache.swift
@@ -263,7 +263,7 @@ public final class DataCache: DataCaching {
 
     /// Synchronously waits on the caller's thread until all outstanding disk IO
     /// operations are finished.
-    func flush() {
+    public func flush() {
         wqueue.sync {}
     }
 

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -284,8 +284,8 @@ public func loadImage(with request: ImageRequest,
     return view.nk.setImage(
         with: request,
         options: options,
-        progress: { completed, total in
-            progress?(nil, completed, total)
+        progress: { response, completed, total in
+            progress?(response, completed, total)
         },
         completion: { result in
             switch result {

--- a/Tests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineDeduplicationTests.swift
@@ -444,7 +444,7 @@ class ImagePipelineDeduplicationTests: XCTestCase {
 
             pipeline.loadImage(
                 with: request,
-                progress: { completed, total in
+                progress: { _, completed, total in
                     XCTAssertTrue(Thread.isMainThread)
                     expectedProgress.received((completed, total))
                 }

--- a/Tests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/ImagePipelineProgressiveDecodingTests.swift
@@ -8,11 +8,9 @@ import XCTest
 class ImagePipelineProgressiveDecodingTests: XCTestCase {
     private var dataLoader: MockProgressiveDataLoader!
     private var pipeline: ImagePipeline!
-    private var delegate: MockImageTaskDelegate!
 
     override func setUp() {
         dataLoader = MockProgressiveDataLoader()
-        delegate = MockImageTaskDelegate()
         ResumableData.cache.removeAll()
 
         // We make two important assumptions with this setup:
@@ -60,20 +58,17 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         // When/Then
         let finalLoaded = self.expectation(description: "Final image loaded")
 
-        delegate.progressHandler = { [unowned self] _, _ in
-            self.dataLoader.resume()
-        }
-
-        delegate.progressiveResponseHandler = { _ in
-            XCTFail("Expected partial images to never be produced")
-        }
-
-        delegate.completion = { result in
-            XCTAssertTrue(result.isSuccess, "Expected the final image to be produced")
-            finalLoaded.fulfill()
-        }
-
-        pipeline.imageTask(with: Test.request, delegate: delegate).start()
+        pipeline.loadImage(
+            with: Test.url,
+            progress: { image, _, _ in
+                XCTAssertNil(image, "Expected partial images to never be produced") // Partial images never produced.
+                self.dataLoader.resume()
+            },
+            completion: { result in
+                XCTAssertTrue(result.isSuccess, "Expected the final image to be produced")
+                finalLoaded.fulfill()
+            }
+        )
 
         wait()
 
@@ -95,20 +90,21 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         )
 
         // When/Then
-        delegate.progressiveResponseHandler = { response in
-            let image = response.image
-            XCTAssertEqual(image.cgImage?.width, 45, "Expected progressive image to be resized")
-            XCTAssertEqual(image.cgImage?.height, 30, "Expected progressive image to be resized")
-        }
-
-        delegate.completion = { result in
-            XCTAssertTrue(result.isSuccess, "Expected the final image to be produced")
-            let image = result.value?.image
-            XCTAssertEqual(image?.cgImage?.width, 45, "Expected the final image to be resized")
-            XCTAssertEqual(image?.cgImage?.height, 30, "Expected the final image to be resized")
-        }
-
-        expect(pipeline, dataLoader).toProducePartialImages(for: request, delegate: delegate)
+        expect(pipeline, dataLoader).toProducePartialImages(
+            for: request,
+            progress: { response, _, _ in
+                if let image = response?.image {
+                    XCTAssertEqual(image.cgImage?.width, 45, "Expected progressive image to be resized")
+                    XCTAssertEqual(image.cgImage?.height, 30, "Expected progressive image to be resized")
+                }
+        },
+            completion: { result in
+                XCTAssertTrue(result.isSuccess, "Expected the final image to be produced")
+                let image = result.value?.image
+                XCTAssertEqual(image?.cgImage?.width, 45, "Expected the final image to be resized")
+                XCTAssertEqual(image?.cgImage?.height, 30, "Expected the final image to be resized")
+            }
+        )
 
         wait()
     }
@@ -119,40 +115,74 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "_image_processor")])
 
         // When/Then
-        delegate.progressiveResponseHandler = { response in
-            let image = response.image
-            XCTAssertEqual(image.nk_test_processorIDs.count, 1)
-            XCTAssertEqual(image.nk_test_processorIDs.first, "_image_processor")
-        }
-        delegate.completion = { result in
-            let image = result.value?.image
-            XCTAssertEqual(image?.nk_test_processorIDs.count, 1)
-            XCTAssertEqual(image?.nk_test_processorIDs.first, "_image_processor")
-        }
-        expect(pipeline, dataLoader).toProducePartialImages(for: request, delegate: delegate)
+        expect(pipeline, dataLoader).toProducePartialImages(
+            for: request,
+            progress: { response, _, _ in
+                if let image = response?.image {
+                    XCTAssertEqual(image.nk_test_processorIDs.count, 1)
+                    XCTAssertEqual(image.nk_test_processorIDs.first, "_image_processor")
+                }
+            },
+            completion: { result in
+                let image = result.value?.image
+                XCTAssertEqual(image?.nk_test_processorIDs.count, 1)
+                XCTAssertEqual(image?.nk_test_processorIDs.first, "_image_processor")
+            }
+        )
         wait()
+    }
+
+    func testParitalImagesAreDisplayed() {
+        // Given
+        ImagePipeline.pushShared(pipeline)
+
+        let imageView = _ImageView()
+
+        let expectPartialImageProduced = self.expectation(description: "Partial Image Produced")
+        // We expect two partial images (at 5 scans, and 9 scans marks).
+        expectPartialImageProduced.expectedFulfillmentCount = 2
+
+        let expectedFinalLoaded = self.expectation(description: "Final Image Produced")
+
+        // When/Then
+        imageView.nk.setImage(
+            with: Test.request,
+            progress: { response, _, _ in
+                if let image = response?.image {
+                    XCTAssertTrue(imageView.image === image)
+                    expectPartialImageProduced.fulfill()
+                    self.dataLoader.resume()
+                }
+            },
+            completion: { result in
+                XCTAssertTrue(imageView.image === result.value?.image)
+                expectedFinalLoaded.fulfill()
+            }
+        )
+        wait()
+
+        ImagePipeline.popShared()
     }
 
     func testProgressiveDecodingDisabled() {
         // Given
-        pipeline = pipeline.reconfigured {
-            $0.isProgressiveDecodingEnabled = false
-        }
+        var configuration = pipeline.configuration
+        configuration.isProgressiveDecodingEnabled = false
+        pipeline = ImagePipeline(configuration: configuration)
 
         // When/Then
         let expectFinalImageProduced = self.expectation(description: "Final Image Is Produced")
-        delegate.progressHandler = { [unowned self] _, _ in
-            self.dataLoader.resume()
-        }
-        delegate.progressiveResponseHandler = { _ in
-            XCTFail("Expected partial images to never be produced")
-        }
-        delegate.completion = { result in
-            XCTAssertTrue(result.isSuccess)
-            expectFinalImageProduced.fulfill()
-        }
-        pipeline.imageTask(with: Test.request, delegate: delegate).start()
-
+        pipeline.loadImage(
+            with: Test.request,
+            progress: { response, _, _ in
+                XCTAssertNil(response, "Expected partial images to never be produced")
+                self.dataLoader.resume()
+            },
+            completion: { result in
+                XCTAssertTrue(result.isSuccess)
+                expectFinalImageProduced.fulfill()
+            }
+        )
         wait()
     }
 
@@ -170,20 +200,22 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
 
         let finalLoaded = self.expectation(description: "Final image produced")
 
-        delegate.progressHandler = { [unowned self] _, _ in
-            self.dataLoader.resume()
-        }
-        delegate.progressiveResponseHandler = { _ in
-            XCTFail("Expected partial images to never be produced")
-        }
-        delegate.completion = { result in
-            XCTAssertTrue(result.isSuccess)
-            finalLoaded.fulfill()
-        }
-
-
         let request = ImageRequest(url: Test.url, processors: [ImageProcessor.Anonymous(id: "1", { $0 })])
-        pipeline.imageTask(with: request, delegate: delegate).start()
+        pipeline.loadImage(
+            with: request,
+            progress: { image, _, _ in
+                if image != nil {
+                    // We don't expect partial to finish, because as soon as
+                    // we create operation to create final image, partial
+                    // operations is going to be finished before even starting
+                }
+                self.dataLoader.resume()
+            },
+            completion: { result in
+                XCTAssertTrue(result.isSuccess)
+                finalLoaded.fulfill()
+            }
+        )
 
         wait()
     }
@@ -199,27 +231,30 @@ private struct TestExpectationProgressivePipeline {
     let test: XCTestCase
     let pipeline: ImagePipeline
     let dataLoader: MockProgressiveDataLoader
-    let delegate = MockImageTaskDelegate()
 
     // We expect two partial images (at 5 scans, and 9 scans marks).
-    func toProducePartialImages(for request: ImageRequest = Test.request, withCount count: Int = 2, delegate: MockImageTaskDelegate? = nil) {
+    func toProducePartialImages(for request: ImageRequest = Test.request, withCount count: Int = 2, progress: ImageTask.ProgressHandler? = nil, completion: ImageTask.Completion? = nil) {
         let expectPartialImageProduced = test.expectation(description: "Partial Image Is Produced")
         expectPartialImageProduced.expectedFulfillmentCount = count
 
         let expectFinalImageProduced = test.expectation(description: "Final Image Is Produced")
 
-        self.delegate.next = delegate
+        pipeline.loadImage(
+            with: request,
+            progress: { image, completed, total in
+                progress?(image, completed, total)
 
-        self.delegate.progressiveResponseHandler = { response in
-            expectPartialImageProduced.fulfill()
-            self.dataLoader.resume()
-        }
-
-        self.delegate.completion = { result in
-            XCTAssertTrue(result.isSuccess)
-            expectFinalImageProduced.fulfill()
-        }
-
-        pipeline.imageTask(with: request, delegate: self.delegate).start()
+                // This works because each new chunk resulted in a new scan
+                if image != nil {
+                    expectPartialImageProduced.fulfill()
+                    self.dataLoader.resume()
+                }
+            },
+            completion: { result in
+                completion?(result)
+                XCTAssertTrue(result.isSuccess)
+                expectFinalImageProduced.fulfill()
+            }
+        )
     }
 }

--- a/Tests/ImagePipelineResumableDataTests.swift
+++ b/Tests/ImagePipelineResumableDataTests.swift
@@ -25,7 +25,7 @@ class ImagePipelineResumableDataTests: XCTestCase {
         let expectedProgressInitial = expectProgress(
             [(3799, 22789), (7598, 22789), (11397, 22789)]
         )
-        expect(pipeline).toFailRequest(Test.request, progress: { completed, total in
+        expect(pipeline).toFailRequest(Test.request, progress: { _, completed, total in
             expectedProgressInitial.received((completed, total))
         })
         wait()
@@ -35,7 +35,7 @@ class ImagePipelineResumableDataTests: XCTestCase {
         let expectedProgersRemaining = expectProgress(
             [(15196, 22789), (18995, 22789), (22789, 22789)]
         )
-        expect(pipeline).toLoadImage(with: Test.request, progress: { completed, total in
+        expect(pipeline).toLoadImage(with: Test.request, progress: { _, completed, total in
             expectedProgersRemaining.received((completed, total))
         })
         wait()

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -46,7 +46,7 @@ class ImagePipelineTests: XCTestCase {
 
         pipeline.loadImage(
             with: request,
-            progress: { completed, total in
+            progress: { _, completed, total in
                 // Then
                 XCTAssertTrue(Thread.isMainThread)
                 expectedProgress.received((completed, total))
@@ -468,99 +468,6 @@ class ImagePipelineErrorHandlingTests: XCTestCase {
 
         // When/Then
         expect(pipeline).toFailRequest(request, with: .processingFailed)
-        wait()
-    }
-}
-
-class ImagePipelineImageTaskDelegateTests: XCTestCase {
-    var dataLoader: MockDataLoader!
-    var pipeline: ImagePipeline!
-    var delegate: MockImageTaskDelegate!
-
-    override func setUp() {
-        super.setUp()
-
-        dataLoader = MockDataLoader()
-        delegate = MockImageTaskDelegate()
-        pipeline = ImagePipeline {
-            $0.dataLoader = dataLoader
-            $0.imageCache = nil
-        }
-    }
-
-    func testThatTaskIsntStartedByDefault() {
-        // Given
-        delegate.completion = { _ in
-            XCTFail("Expect completion not to be called")
-        }
-
-        // When
-        let _ = pipeline.imageTask(with: Test.request, delegate: delegate)
-
-        let expectation = self.expectation(description: "Wait a bit")
-        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(150)) {
-            expectation.fulfill()
-        }
-
-        wait()
-
-        // Then
-        XCTAssertEqual(dataLoader.createdTaskCount, 0)
-    }
-
-    func testThatTaskIsStartedWhenStartIsCalled() {
-        // Given
-        let expectation = self.expectation(description: "Expected image to be loaded")
-        delegate.completion = { result in
-            XCTAssertTrue(Thread.isMainThread)
-            XCTAssertTrue(result.isSuccess)
-            expectation.fulfill()
-        }
-
-        // When
-        let task = pipeline.imageTask(with: Test.request, delegate: delegate)
-        task.start()
-        wait()
-    }
-
-    func testThatCancelledTaskCantBeStarted() {
-        // Given cancelled task
-        delegate.completion = { _ in
-            XCTFail("Expect completion not to be called")
-        }
-        let task = pipeline.imageTask(with: Test.request, delegate: delegate)
-        task.cancel()
-
-        // When
-        task.start()
-
-        let expectation = self.expectation(description: "Wait a bit")
-        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(150)) {
-            expectation.fulfill()
-        }
-
-        wait()
-
-        // Then
-        XCTAssertEqual(dataLoader.createdTaskCount, 0)
-    }
-
-    func testThatProgressIsReported() {
-        // Given
-        dataLoader.results[Test.url] = .success(
-            (Data(count: 20), URLResponse(url: Test.url, mimeType: "jpeg", expectedContentLength: 20, textEncodingName: nil))
-        )
-
-        let expectedProgress = expectProgress([(10, 20), (20, 20)])
-
-        delegate.progressHandler = { completed, total in
-            // Then
-            XCTAssertTrue(Thread.isMainThread)
-            expectedProgress.received((completed, total))
-        }
-
-        pipeline.imageTask(with: Test.request, delegate: delegate).start()
-
         wait()
     }
 }

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -174,7 +174,7 @@ class ImageViewTests: XCTestCase {
         // When loading an image into a view
         imageView.nk.setImage(
             with: Test.request,
-            progress: { completed, total in
+            progress: { _, completed, total in
                 // Expect progress to be reported, on the main thread
                 XCTAssertTrue(Thread.isMainThread)
                 expectedProgress.received((completed, total))

--- a/Tests/MockDataLoader.swift
+++ b/Tests/MockDataLoader.swift
@@ -3,7 +3,7 @@
 // Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
-@testable import Nuke
+import Nuke
 
 private let data: Data = Test.data(name: "fixture", extension: "jpeg")
 

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -3,7 +3,7 @@
 // Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
 
 import XCTest
-@testable import Nuke
+import Nuke
 
 class ImageViewPerformanceTests: XCTestCase {
     private let dummyCacheRequest = ImageRequest(url: URL(string: "http://test.com/9999999)")!, processors: [ImageProcessor.Resize(size: CGSize(width: 2, height: 2))])


### PR DESCRIPTION
Revert the addition of `ImageTaskDelegate` because this change of the primary public API and the increased complexity were not worth the performance improvements.