### PR TITLE
Remove no longer needed synchronization point in ImageDecoder

### DIFF
--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -94,29 +94,13 @@ public final class ImageDecoder: ImageDecoding {
     }
 }
 
-// Image initializers are documented as fully-thread safe:
-//
-// > The immutable nature of image objects also means that they are safe
-//   to create and use from any thread.
-//
-// However, there are some versions of iOS which violated this. The
-// `UIImage` is supposably fully thread safe again starting with iOS 10.
-//
-// The `queue.sync` call below prevents the majority of the potential
-// crashes that could happen on the previous versions of iOS.
-//
-// See also https://github.com/AFNetworking/AFNetworking/issues/2572
-private let _queue = DispatchQueue(label: "com.github.kean.Nuke.DataDecoder")
-
 extension ImageDecoder {
     static func decode(_ data: Data) -> Image? {
-        return _queue.sync {
-            #if os(macOS)
-            return NSImage(data: data)
-            #else
-            return UIImage(data: data, scale: Screen.scale)
-            #endif
-        }
+        #if os(macOS)
+        return NSImage(data: data)
+        #else
+        return UIImage(data: data, scale: Screen.scale)
+        #endif
     }
 }
 


### PR DESCRIPTION
There was a defect in iOS 9 which made `UIImage` initializer not thread safe and which was fixed in iOS 10. The workaround is no longer needed.

It is now also possible to decode images in parallel.

More information available here https://github.com/AFNetworking/AFNetworking/issues/2572.