### PR TITLE
Target system queues

### DIFF
--- a/Sources/DataCache.swift
+++ b/Sources/DataCache.swift
@@ -86,7 +86,7 @@ public final class DataCache: DataCaching {
     private let lock = NSLock()
     private var staging = Staging()
 
-    /* testable */ let wqueue = DispatchQueue(label: "com.github.kean.Nuke.DataCache.WriteQueue")
+    /* testable */ let wqueue = DispatchQueue(label: "com.github.kean.Nuke.DataCache.WriteQueue", target: .global(qos: .utility))
 
     /// A function which generates a filename for the given key. A good candidate
     /// for a filename generator is a _cryptographic_ hash function like SHA1.

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -21,7 +21,7 @@ public /* final */ class ImagePipeline {
     public let configuration: Configuration
 
     // This is a queue on which we access the sessions.
-    private let queue = DispatchQueue(label: "com.github.kean.Nuke.ImagePipeline")
+    private let queue = DispatchQueue(label: "com.github.kean.Nuke.ImagePipeline", target: .global(qos: .userInteractive))
 
     private var tasks = [ImageTask: TaskSubscription]()
 

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -21,7 +21,7 @@ public /* final */ class ImagePipeline {
     public let configuration: Configuration
 
     // This is a queue on which we access the sessions.
-    private let queue = DispatchQueue(label: "com.github.kean.Nuke.ImagePipeline", target: .global(qos: .userInteractive))
+    private let queue = DispatchQueue(label: "com.github.kean.Nuke.ImagePipeline", target: .global(qos: .userInitiated))
 
     private var tasks = [ImageTask: TaskSubscription]()
 

--- a/Sources/ImagePreheater.swift
+++ b/Sources/ImagePreheater.swift
@@ -14,7 +14,7 @@ import Foundation
 /// All `Preheater` methods are thread-safe.
 public final class ImagePreheater {
     private let pipeline: ImagePipeline
-    private let queue = DispatchQueue(label: "com.github.kean.Nuke.Preheater")
+    private let queue = DispatchQueue(label: "com.github.kean.Nuke.Preheater", target: .global(qos: .userInteractive))
     private let preheatQueue = OperationQueue()
     private var tasks = [AnyHashable: Task]()
     private let destination: Destination

--- a/Sources/ImagePreheater.swift
+++ b/Sources/ImagePreheater.swift
@@ -14,7 +14,7 @@ import Foundation
 /// All `Preheater` methods are thread-safe.
 public final class ImagePreheater {
     private let pipeline: ImagePipeline
-    private let queue = DispatchQueue(label: "com.github.kean.Nuke.Preheater", target: .global(qos: .userInteractive))
+    private let queue = DispatchQueue(label: "com.github.kean.Nuke.Preheater", target: .global(qos: .userInitiated))
     private let preheatQueue = OperationQueue()
     private var tasks = [AnyHashable: Task]()
     private let destination: Destination


### PR DESCRIPTION
These changes configure access queues to target system queues. I have written about this [recently](https://troubled.pro/2019/07/mutex.html), it is to control thread creation. 

The quality of service configuration I’m suggesting performs particularly well in my setup. I have also tried setting QoS for Nuke’s operation queues, but didn’t accomplish any palpable performance gains. 