### PR TITLE
Add two options to configure callback queues

### DIFF
--- a/Sources/ImagePipelineConfiguration.swift
+++ b/Sources/ImagePipelineConfiguration.swift
@@ -61,6 +61,10 @@ extension ImagePipeline {
 
         // MARK: - Options
 
+        /// A queue on which all callbacks, like `progress` and `completion`
+        /// callbacks are called. `.main` by default.
+        public var callbackQueue = DispatchQueue.main
+
         #if !os(macOS)
         /// Decompresses the loaded images. `true` by default.
         ///

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -49,17 +49,20 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
     private(set) var _isCancelled = false
     private let lock: NSLock?
 
+    let queue: DispatchQueue?
+
     /// A completion handler to be called when task finishes or fails.
     public typealias Completion = (_ result: Result<ImageResponse, ImagePipeline.Error>) -> Void
 
     /// A progress handler to be called periodically during the lifetime of a task.
     public typealias ProgressHandler = (_ intermediateResponse: ImageResponse?, _ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void
 
-    init(taskId: Int, request: ImageRequest, isMainThreadConfined: Bool = false) {
+    init(taskId: Int, request: ImageRequest, isMainThreadConfined: Bool = false, queue: DispatchQueue?) {
         self.taskId = taskId
         self.request = request
         self._priority = request.priority
         self.priority = request.priority
+        self.queue = queue
         lock = isMainThreadConfined ? nil : NSLock()
     }
 

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -357,7 +357,7 @@ private final class ImageViewController {
 
         // Uses a special internal API (`isMainThreadConfined`) for performance
         // reasons, it attributes for about than 20% performance improvement.
-        self.task = pipeline.loadImage(with: request, isMainThreadConfined: true) { [weak self] task, event in
+        self.task = pipeline.loadImage(with: request, isMainThreadConfined: true, queue: .main) { [weak self] task, event in
             switch event {
             case .progress:
                 progressHandler?(nil, task.completedUnitCount, task.totalUnitCount)

--- a/Tests/ImagePipelineConfigurationTests.swift
+++ b/Tests/ImagePipelineConfigurationTests.swift
@@ -21,4 +21,56 @@ class ImagePipelineConfigurationTests: XCTestCase {
         expect(pipeline).toLoadImage(with: Test.request)
         wait()
     }
+
+    // MARK: Changing Callback Queue
+
+    func testChangingCallbackQueueLoadImage() {
+        // Given
+        let queue = DispatchQueue(label: "testChangingCallbackQueue")
+        let queueKey = DispatchSpecificKey<Void>()
+        queue.setSpecific(key: queueKey, value: ())
+
+        let dataLoader = MockDataLoader()
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+
+            $0.callbackQueue = queue
+        }
+
+        // When/Then
+        let expectation = self.expectation(description: "Image Loaded")
+        pipeline.loadImage(with: Test.url, progress: { _, _, _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+        }, completion: { _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+            expectation.fulfill()
+        })
+        wait()
+    }
+
+    func testChangingCallbackQueueLoadData() {
+        // Given
+        let queue = DispatchQueue(label: "testChangingCallbackQueue")
+        let queueKey = DispatchSpecificKey<Void>()
+        queue.setSpecific(key: queueKey, value: ())
+
+        let dataLoader = MockDataLoader()
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+
+            $0.callbackQueue = queue
+        }
+
+        // When/Then
+        let expectation = self.expectation(description: "Image data Loaded")
+        pipeline.loadData(with: Test.request, progress: { _, _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+        }, completion: { _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+            expectation.fulfill()
+        })
+        wait()
+    }
 }   

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -81,6 +81,42 @@ class ImagePipelineTests: XCTestCase {
         wait()
     }
 
+    // MARK: - Callback Queues
+
+    func testChangingCallbackQueueLoadImage() {
+        // Given
+        let queue = DispatchQueue(label: "testChangingCallbackQueue")
+        let queueKey = DispatchSpecificKey<Void>()
+        queue.setSpecific(key: queueKey, value: ())
+
+        // When/Then
+        let expectation = self.expectation(description: "Image Loaded")
+        pipeline.loadImage(with: Test.url, queue: queue, progress: { _, _, _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+        }, completion: { _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+            expectation.fulfill()
+        })
+        wait()
+    }
+
+    func testChangingCallbackQueueLoadData() {
+        // Given
+        let queue = DispatchQueue(label: "testChangingCallbackQueue")
+        let queueKey = DispatchSpecificKey<Void>()
+        queue.setSpecific(key: queueKey, value: ())
+
+        // When/Then
+        let expectation = self.expectation(description: "Image data Loaded")
+        pipeline.loadData(with: Test.request,queue: queue, progress: { _, _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+        }, completion: { _ in
+            XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
+            expectation.fulfill()
+        })
+        wait()
+    }
+
     // MARK: - Animated Images
 
     func testAnimatedImagesArentProcessed() {

--- a/Tests/MockImagePipeline.swift
+++ b/Tests/MockImagePipeline.swift
@@ -10,7 +10,7 @@ private class MockImageTask: ImageTask {
     var __isCancelled = false
 
     init(request: ImageRequest) {
-        super.init(taskId: 0, request: request)
+        super.init(taskId: 0, request: request, queue: nil)
     }
 
     override func cancel() {
@@ -33,7 +33,7 @@ class MockImagePipeline: ImagePipeline {
         return queue
     }()
 
-    override func loadImage(with request: ImageRequest, isMainThreadConfined: Bool, observer: @escaping (ImageTask, Task<ImageResponse, ImagePipeline.Error>.Event) -> Void) -> ImageTask {
+    override func loadImage(with request: ImageRequest, isMainThreadConfined: Bool, queue: DispatchQueue?, observer: @escaping (ImageTask, Task<ImageResponse, ImagePipeline.Error>.Event) -> Void) -> ImageTask {
         let task = MockImageTask(request: request)
 
         createdTaskCount += 1


### PR DESCRIPTION
- Add an option to configure callback queue on the pipeline level via `ImagePipeline.Configuration`
- Add an option to configure callback queue on individual request level