### PR TITLE
Add URLSessionTaskMetrics collection support

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -32,7 +32,7 @@ public extension ImageCaching {
         }
         set {
             if let newValue = newValue {
-                storeResponse(ImageResponse(image: newValue, urlResponse: nil, scanNumber: nil), for: request)
+                storeResponse(ImageResponse(image: newValue, urlResponse: nil, sessionTaskMetrics: nil, scanNumber: nil), for: request)
             } else {
                 removeResponse(for: request)
             }

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -117,8 +117,10 @@ extension ImageDecoding {
         #endif
 
         let scanNumber: Int? = (self as? ImageDecoder)?.numberOfScans
-
-        return ImageResponse(image: image, urlResponse: fetchResult.urlResponse, scanNumber: scanNumber)
+        return ImageResponse(image: image,
+                             urlResponse: fetchResult.urlResponse,
+                             sessionTaskMetrics: fetchResult.sessionTaskMetrics,
+                             scanNumber: scanNumber)
     }
 }
 

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -105,9 +105,9 @@ extension ImageDecoder {
 }
 
 extension ImageDecoding {
-    func decode(_ data: Data, urlResponse: URLResponse?, isFinal: Bool) -> ImageResponse? {
+    func decode(_ fetchResult: DataFetchResult, isFinal: Bool) -> ImageResponse? {
         func decode() -> Image? {
-            return self.decode(data: data, isFinal: isFinal)
+            return self.decode(data: fetchResult.data, isFinal: isFinal)
         }
         guard let image = autoreleasepool(invoking: decode) else {
             return nil
@@ -117,7 +117,8 @@ extension ImageDecoding {
         #endif
 
         let scanNumber: Int? = (self as? ImageDecoder)?.numberOfScans
-        return ImageResponse(image: image, urlResponse: urlResponse, scanNumber: scanNumber)
+
+        return ImageResponse(image: image, urlResponse: fetchResult.urlResponse, scanNumber: scanNumber)
     }
 }
 

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -146,18 +146,24 @@ enum DataFetchResult {
             return response.urlResponse
         }
     }
+
+    var sessionTaskMetrics: URLSessionTaskMetrics? {
+        guard case .result(let response) = self else { return nil }
+        return response.sessionTaskMetrics
+    }
 }
 
 // MARK: - DataResponse
 
-/// Represents data response.
 public final class DataResponse {
     public let data: Data
     public let urlResponse: URLResponse?
+    public let sessionTaskMetrics: URLSessionTaskMetrics?
 
-    public init(data: Data, urlResponse: URLResponse? = nil) {
+    public init(data: Data, urlResponse: URLResponse? = nil, sessionTaskMetrics: URLSessionTaskMetrics? = nil) {
         self.data = data
         self.urlResponse = urlResponse
+        self.sessionTaskMetrics = sessionTaskMetrics
     }
 }
 
@@ -167,13 +173,15 @@ public final class DataResponse {
 public final class ImageResponse {
     public let image: Image
     public let urlResponse: URLResponse?
+    public let sessionTaskMetrics: URLSessionTaskMetrics?
     // the response is only nil when new disk cache is enabled (it only stores
     // data for now, but this might change in the future).
     public let scanNumber: Int?
 
-    public init(image: Image, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
+    public init(image: Image, urlResponse: URLResponse? = nil, sessionTaskMetrics: URLSessionTaskMetrics? = nil, scanNumber: Int? = nil) {
         self.image = image
         self.urlResponse = urlResponse
+        self.sessionTaskMetrics = sessionTaskMetrics
         self.scanNumber = scanNumber
     }
 
@@ -182,7 +190,7 @@ public final class ImageResponse {
             guard let output = transformation(image) else {
                 return nil
             }
-            return ImageResponse(image: output, urlResponse: urlResponse, scanNumber: scanNumber)
+            return ImageResponse(image: output, urlResponse: urlResponse, sessionTaskMetrics: sessionTaskMetrics, scanNumber: scanNumber)
         }
     }
 }

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -123,6 +123,44 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
     }
 }
 
+// MARK: - DataFetchResult
+
+enum DataFetchResult {
+    case chunk(Data, URLResponse?)
+    case result(DataResponse)
+
+    var data: Data {
+        switch self {
+        case .chunk(let data, _):
+            return data
+        case .result(let response):
+            return response.data
+        }
+    }
+
+    var urlResponse: URLResponse? {
+        switch self {
+        case .chunk(_, let response):
+            return response
+        case .result(let response):
+            return response.urlResponse
+        }
+    }
+}
+
+// MARK: - DataResponse
+
+/// Represents data response.
+public final class DataResponse {
+    public let data: Data
+    public let urlResponse: URLResponse?
+
+    public init(data: Data, urlResponse: URLResponse? = nil) {
+        self.data = data
+        self.urlResponse = urlResponse
+    }
+}
+
 // MARK: - ImageResponse
 
 /// Represents an image response.

--- a/Tests/ImagePipelineResumableDataTests.swift
+++ b/Tests/ImagePipelineResumableDataTests.swift
@@ -48,7 +48,10 @@ private class _MockResumableDataLoader: DataLoading {
     let data: Data = Test.data(name: "fixture", extension: "jpeg")
     let eTag: String = "img_01"
 
-    func loadData(with request: URLRequest, didReceiveData: @escaping (Data, URLResponse) -> Void, completion: @escaping (Error?) -> Void) -> Cancellable {
+    func loadData(with request: URLRequest,
+                  didReceiveData: @escaping (Data, URLResponse) -> Void,
+                  didCollectTaskMetrics: @escaping (URLSessionTaskMetrics) -> Void,
+                  completion: @escaping (Error?) -> Void) -> Cancellable {
         let headers = request.allHTTPHeaderFields
 
         func sendChunks(_ chunks: [Data], of data: Data, statusCode: Int) {

--- a/Tests/MockDataLoader.swift
+++ b/Tests/MockDataLoader.swift
@@ -22,7 +22,10 @@ class MockDataLoader: DataLoading {
     var results = [URL: _Result<(Data, URLResponse), NSError>]()
     let queue = OperationQueue()
 
-    func loadData(with request: URLRequest, didReceiveData: @escaping (Data, URLResponse) -> Void, completion: @escaping (Error?) -> Void) -> Cancellable {
+    func loadData(with request: URLRequest,
+                  didReceiveData: @escaping (Data, URLResponse) -> Void,
+                  didCollectTaskMetrics: @escaping (URLSessionTaskMetrics) -> Void,
+                  completion: @escaping (Error?) -> Void) -> Cancellable {
         let task = MockDataTask()
 
         NotificationCenter.default.post(name: MockDataLoader.DidStartTask, object: self)

--- a/Tests/MockProgressiveDataLoader.swift
+++ b/Tests/MockProgressiveDataLoader.swift
@@ -26,7 +26,10 @@ final class MockProgressiveDataLoader: DataLoading {
         self.chunks = Array(_createChunks(for: data, size: data.count / 3))
     }
 
-    func loadData(with request: URLRequest, didReceiveData: @escaping (Data, URLResponse) -> Void, completion: @escaping (Error?) -> Void) -> Cancellable {
+    func loadData(with request: URLRequest,
+                  didReceiveData: @escaping (Data, URLResponse) -> Void,
+                  didCollectTaskMetrics: @escaping (URLSessionTaskMetrics) -> Void,
+                  completion: @escaping (Error?) -> Void) -> Cancellable {
         self.didReceiveData = didReceiveData
         self.completion = completion
         self.resume()


### PR DESCRIPTION
## Why?

Nuke doesn't have support for URLSessionTaskMetrics collection.

## How?

Added a parameter `sessionTaskMetrics` to `ImageResponse`. Also refactored a bit to make it possible:
Removed tuples from data loading types. Added concrete types:
- DataResponse to represent result of fetching image data
- DataFetchResult enum to represent either chunk response, or complete result of data loading.
