### PR TITLE
ImagePipeline Cleanup

### DIFF
--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -239,10 +239,28 @@ public /* final */ class ImagePipeline {
         }
     }
 
-    // MARK: - Starting Image Tasks
+    // MARK: - Cache
 
-    private func startImageTask(_ task: ImageTask, observer: @escaping (ImageTask, Task<ImageResponse, Error>.Event) -> Void) {
-        self.tasks[task] = getDecompressedImage(for: task.request)
+    /// Returns a cached response from the memory cache. Returns `nil` if the request disables
+    /// memory cache reads.
+    public func cachedResponse(for request: ImageRequest) -> ImageResponse? {
+        guard request.options.memoryCacheOptions.isReadAllowed else { return nil }
+
+        let request = inheritOptions(request)
+        return configuration.imageCache?.cachedResponse(for: request)
+    }
+
+    private func storeResponse(_ response: ImageResponse, for request: ImageRequest, isCompleted: Bool) {
+        guard isCompleted, request.options.memoryCacheOptions.isWriteAllowed else { return }
+        configuration.imageCache?.storeResponse(response, for: request)
+    }
+}
+
+// MARK: - Starting Image Tasks (Private)
+
+private extension ImagePipeline {
+    func startImageTask(_ task: ImageTask, observer: @escaping (ImageTask, Task<ImageResponse, Error>.Event) -> Void) {
+        tasks[task] = getDecompressedImage(for: task.request)
             .subscribe(priority: task._priority) { [weak self, weak task] event in
                 guard let self = self, let task = task else { return }
 
@@ -260,10 +278,10 @@ public /* final */ class ImagePipeline {
         }
     }
 
-    private func startDataTask(_ task: ImageTask,
-                               progress progressHandler: ((_ completed: Int64, _ total: Int64) -> Void)?,
-                               completion: @escaping (Result<(data: Data, response: URLResponse?), ImagePipeline.Error>) -> Void) {
-        self.tasks[task] = getOriginalImageData(for: task.request)
+    func startDataTask(_ task: ImageTask,
+                       progress progressHandler: ((_ completed: Int64, _ total: Int64) -> Void)?,
+                       completion: @escaping (Result<(data: Data, response: URLResponse?), ImagePipeline.Error>) -> Void) {
+        tasks[task] = getOriginalImageData(for: task.request)
             .subscribe(priority: task._priority) { [weak self, weak task] event in
                 guard let self = self, let task = task else { return }
 
@@ -288,19 +306,21 @@ public /* final */ class ImagePipeline {
                 }
         }
     }
+}
 
-    // MARK: - Get Decompressed Image
+// MARK: - Get Decompressed Image (Private)
 
-    private typealias DecompressedImageFetchTask = Task<ImageResponse, Error>
+private extension ImagePipeline {
+    typealias DecompressedImageTask = Task<ImageResponse, Error>
 
-    private func getDecompressedImage(for request: ImageRequest) -> DecompressedImageFetchTask.Publisher {
+    func getDecompressedImage(for request: ImageRequest) -> DecompressedImageTask.Publisher {
         let key = request.makeLoadKeyForProcessedImage()
         return decompressedImageFetchTasks.publisher(withKey: key, starter: { task in
             self.loadDecompressedImage(for: request, task: task)
         })
     }
 
-    private func loadDecompressedImage(for request: ImageRequest, task: DecompressedImageFetchTask) {
+    func loadDecompressedImage(for request: ImageRequest, task: DecompressedImageTask) {
         if let response = cachedResponse(for: request) {
             return task.send(value: response, isCompleted: true)
         }
@@ -310,23 +330,23 @@ public /* final */ class ImagePipeline {
         }
     }
 
-    private func decompressProcessedImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, task: DecompressedImageFetchTask) {
-        #if os(macOS)
+    #if os(macOS)
+    func decompressProcessedImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, task: DecompressedImageTask) {
         storeResponse(response, for: request, isCompleted: isCompleted)
         task.send(value: response, isCompleted: isCompleted) // There is no decompression on macOS
-        #else
-        guard configuration.isDecompressionEnabled &&
-            ImageDecompression.isDecompressionNeeded(for: response.image) ?? false &&
-            !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
-                storeResponse(response, for: request, isCompleted: isCompleted)
-                task.send(value: response, isCompleted: isCompleted)
-                return
+    }
+    #else
+    func decompressProcessedImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, task: DecompressedImageTask) {
+        guard isDecompressionNeeded(for: response) else {
+            storeResponse(response, for: request, isCompleted: isCompleted)
+            task.send(value: response, isCompleted: isCompleted)
+            return
         }
 
         if isCompleted {
             task.operation?.cancel() // Cancel any potential pending progressive decompression tasks
         } else if task.operation != nil {
-            return  // Back pressure - already decompressiong another progressive image
+            return  // Back-pressure: we are receiving data too fast
         }
 
         guard !task.isDisposed else { return }
@@ -348,28 +368,22 @@ public /* final */ class ImagePipeline {
         }
         task.operation = operation
         configuration.imageDecompressingQueue.addOperation(operation)
-        #endif
     }
 
-    /// Returns a cached response from the memory cache. Returns `nil` if the request disables
-    /// memory cache reads.
-    public func cachedResponse(for request: ImageRequest) -> ImageResponse? {
-        guard request.options.memoryCacheOptions.isReadAllowed else { return nil }
-
-        let request = inheritOptions(request)
-        return configuration.imageCache?.cachedResponse(for: request)
+    func isDecompressionNeeded(for response: ImageResponse) -> Bool {
+        return configuration.isDecompressionEnabled &&
+            ImageDecompression.isDecompressionNeeded(for: response.image) ?? false &&
+            !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil)
     }
+    #endif
+}
 
-    private func storeResponse(_ response: ImageResponse, for request: ImageRequest, isCompleted: Bool) {
-        guard isCompleted, request.options.memoryCacheOptions.isWriteAllowed else { return }
-        configuration.imageCache?.storeResponse(response, for: request)
-    }
+// MARK: - Get Processed Image (Private)
 
-    // MARK: - Get Processed Image
+private extension ImagePipeline {
+    typealias ProcessedImageTask = Task<ImageResponse, Error>
 
-    private typealias ProcessedImageFetchTask = Task<ImageResponse, Error>
-
-    private func getProcessedImage(for request: ImageRequest) -> ProcessedImageFetchTask.Publisher {
+    func getProcessedImage(for request: ImageRequest) -> ProcessedImageTask.Publisher {
         guard !request.processors.isEmpty else {
             return getOriginalImage(for: request) // No processing needed
         }
@@ -380,7 +394,7 @@ public /* final */ class ImagePipeline {
         })
     }
 
-    private func loadProcessedImage(for request: ImageRequest, task: ProcessedImageFetchTask) {
+    func loadProcessedImage(for request: ImageRequest, task: ProcessedImageTask) {
         if let response = cachedResponse(for: request) {
             return task.send(value: response, isCompleted: true)
         }
@@ -411,7 +425,7 @@ public /* final */ class ImagePipeline {
         configuration.dataCachingQueue.addOperation(operation)
     }
 
-    private func decodeProcessedImageData(_ data: Data, for request: ImageRequest, task: ProcessedImageFetchTask) {
+    func decodeProcessedImageData(_ data: Data, for request: ImageRequest, task: ProcessedImageTask) {
         guard !task.isDisposed else { return }
 
         let decoderContext = ImageDecodingContext(request: request, data: data, urlResponse: nil)
@@ -437,7 +451,7 @@ public /* final */ class ImagePipeline {
         configuration.imageDecodingQueue.addOperation(operation)
     }
 
-    private func loadOriginaImage(for request: ImageRequest, task: ProcessedImageFetchTask) {
+    func loadOriginaImage(for request: ImageRequest, task: ProcessedImageTask) {
         assert(!request.processors.isEmpty)
         guard !task.isDisposed, !request.processors.isEmpty else { return }
 
@@ -459,7 +473,7 @@ public /* final */ class ImagePipeline {
         }
     }
 
-    private func processImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, processor: ImageProcessing, task: ProcessedImageFetchTask) {
+    func processImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, processor: ImageProcessing, task: ProcessedImageTask) {
         guard !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
             task.send(value: response, isCompleted: isCompleted)
             return
@@ -499,7 +513,7 @@ public /* final */ class ImagePipeline {
         configuration.imageProcessingQueue.addOperation(operation)
     }
 
-    private func storeProcessedImageInDataCache(_ response: ImageResponse, request: ImageRequest) {
+    func storeProcessedImageInDataCache(_ response: ImageResponse, request: ImageRequest) {
         guard let dataCache = configuration.dataCache, configuration.isDataCachingForProcessedImagesEnabled else {
             return
         }
@@ -516,12 +530,14 @@ public /* final */ class ImagePipeline {
             dataCache.storeData(data, for: key) // This is instant
         }
     }
+}
 
-    // MARK: - Get Original Image
+// MARK: - Get Original Image (Private)
 
-    private typealias OriginalImageFetchTask = Task<ImageResponse, Error>
+private extension ImagePipeline {
+    typealias OriginalImageTask = Task<ImageResponse, Error>
 
-    private final class OriginalImageFetchContext {
+    final class OriginalImageTaskContext {
         let request: ImageRequest
         var decoder: ImageDecoding?
 
@@ -530,10 +546,10 @@ public /* final */ class ImagePipeline {
         }
     }
 
-    private func getOriginalImage(for request: ImageRequest) -> OriginalImageFetchTask.Publisher {
+    func getOriginalImage(for request: ImageRequest) -> OriginalImageTask.Publisher {
         let key = request.makeLoadKeyForOriginalImage()
         return originalImageFetchTasks.publisher(withKey: key, starter: { task in
-            let context = OriginalImageFetchContext(request: request)
+            let context = OriginalImageTaskContext(request: request)
             task.dependency = self.getOriginalImageData(for: request)
                 .subscribe(task) { [weak self] value, isCompleted, task in
                     self?.decodeData(value.0, urlResponse: value.1, isCompleted: isCompleted, task: task, context: context)
@@ -541,7 +557,7 @@ public /* final */ class ImagePipeline {
         })
     }
 
-    private func decodeData(_ data: Data, urlResponse: URLResponse?, isCompleted: Bool, task: OriginalImageFetchTask, context: OriginalImageFetchContext) {
+    func decodeData(_ data: Data, urlResponse: URLResponse?, isCompleted: Bool, task: OriginalImageTask, context: OriginalImageTaskContext) {
         if isCompleted {
             task.operation?.cancel() // Cancel any potential pending progressive decoding tasks
         } else if !configuration.isProgressiveDecodingEnabled || task.operation != nil {
@@ -581,7 +597,7 @@ public /* final */ class ImagePipeline {
     }
 
     // Lazily creates decoding for task
-    private func decoder(for context: OriginalImageFetchContext, data: Data, urlResponse: URLResponse?) -> ImageDecoding {
+    func decoder(for context: OriginalImageTaskContext, data: Data, urlResponse: URLResponse?) -> ImageDecoding {
         // Return the existing processor in case it has already been created.
         if let decoder = context.decoder {
             return decoder
@@ -591,12 +607,14 @@ public /* final */ class ImagePipeline {
         context.decoder = decoder
         return decoder
     }
+}
 
-    // MARK: - Get Original Image Data
+// MARK: - Get Original Image Data (Private)
 
-    private typealias OriginalImageDataFetchTask = Task<(Data, URLResponse?), Error>
+private extension ImagePipeline {
+    typealias OriginalImageDataTask = Task<(Data, URLResponse?), Error>
 
-    private final class OriginalImageDataFetchContext {
+    final class OriginalImageDataTaskContext {
         let request: ImageRequest
         var urlResponse: URLResponse?
         var resumableData: ResumableData?
@@ -608,10 +626,10 @@ public /* final */ class ImagePipeline {
         }
     }
 
-    private func getOriginalImageData(for request: ImageRequest) -> OriginalImageDataFetchTask.Publisher {
+    func getOriginalImageData(for request: ImageRequest) -> OriginalImageDataTask.Publisher {
         let key = request.makeLoadKeyForOriginalImage()
         return originalImageDataFetchTasks.publisher(withKey: key, starter: { task in
-            let context = OriginalImageDataFetchContext(request: request)
+            let context = OriginalImageDataTaskContext(request: request)
             if self.configuration.isRateLimiterEnabled {
                 // Rate limiter is synchronized on pipeline's queue. Delayed work is
                 // executed asynchronously also on this same queue.
@@ -628,7 +646,7 @@ public /* final */ class ImagePipeline {
         })
     }
 
-    private func loadImageDataFromCache(for task: OriginalImageDataFetchTask, context: OriginalImageDataFetchContext) {
+    func loadImageDataFromCache(for task: OriginalImageDataTask, context: OriginalImageDataTaskContext) {
         guard let cache = configuration.dataCache, configuration.isDataCachingForOriginalImageDataEnabled else {
             loadImageData(for: task, context: context) // Skip disk cache lookup, load data
             return
@@ -655,7 +673,7 @@ public /* final */ class ImagePipeline {
         configuration.dataCachingQueue.addOperation(operation)
     }
 
-    private func loadImageData(for task: OriginalImageDataFetchTask, context: OriginalImageDataFetchContext) {
+    func loadImageData(for task: OriginalImageDataTask, context: OriginalImageDataTaskContext) {
         // Wrap data request in an operation to limit maximum number of
         // concurrent data tasks.
         let operation = Operation(starter: { [weak self, weak task] finish in
@@ -671,9 +689,9 @@ public /* final */ class ImagePipeline {
     }
 
     // This methods gets called inside data loading operation (Operation).
-    private func loadImageData(for task: OriginalImageDataFetchTask, context: OriginalImageDataFetchContext, finish: @escaping () -> Void) {
+    func loadImageData(for task: OriginalImageDataTask, context: OriginalImageDataTaskContext, finish: @escaping () -> Void) {
         guard !task.isDisposed else {
-            return finish() // Task was cancelled by the time it got the chance to start
+            return finish() // Task was cancelled by the time it got a chance to start
         }
 
         var urlRequest = context.request.urlRequest
@@ -727,20 +745,18 @@ public /* final */ class ImagePipeline {
         }
     }
 
-    private func imageDataLoadingTask(_ task: OriginalImageDataFetchTask, context: OriginalImageDataFetchContext, didReceiveData chunk: Data, response: URLResponse, signpost: Signpost) {
+    func imageDataLoadingTask(_ task: OriginalImageDataTask, context: OriginalImageDataTaskContext, didReceiveData chunk: Data, response: URLResponse, signpost: Signpost) {
         // Check if this is the first response.
         if context.urlResponse == nil {
             // See if the server confirmed that the resumable data can be used
-            if let resumableData = context.resumableData {
-                if ResumableData.isResumedResponse(response) {
-                    context.data = resumableData.data
-                    context.resumedDataCount = Int64(resumableData.data.count)
-                    if #available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-                        os_signpost(.event, log: self.log, name: "Load Image Data", signpostID: signpost.signpostID, "Resumed with data %{xcode:size-in-bytes}d", context.resumedDataCount)
-                    }
+            if let resumableData = context.resumableData, ResumableData.isResumedResponse(response) {
+                context.data = resumableData.data
+                context.resumedDataCount = Int64(resumableData.data.count)
+                if #available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+                    os_signpost(.event, log: self.log, name: "Load Image Data", signpostID: signpost.signpostID, "Resumed with data %{xcode:size-in-bytes}d", context.resumedDataCount)
                 }
-                context.resumableData = nil // Get rid of resumable data
             }
+            context.resumableData = nil // Get rid of resumable data
         }
 
         // Append data and save response
@@ -758,7 +774,7 @@ public /* final */ class ImagePipeline {
         task.send(value: (context.data, response))
     }
 
-    private func imageDataLoadingTask(_ task: OriginalImageDataFetchTask, context: OriginalImageDataFetchContext, didFinishLoadingDataWithError error: Swift.Error?) {
+    func imageDataLoadingTask(_ task: OriginalImageDataTask, context: OriginalImageDataTaskContext, didFinishLoadingDataWithError error: Swift.Error?) {
         if let error = error {
             tryToSaveResumableData(for: context)
             task.send(error: .dataLoadingFailed(error))
@@ -780,7 +796,7 @@ public /* final */ class ImagePipeline {
         task.send(value: (context.data, context.urlResponse), isCompleted: true)
     }
 
-    private func tryToSaveResumableData(for context: OriginalImageDataFetchContext) {
+    func tryToSaveResumableData(for context: OriginalImageDataTaskContext) {
         // Try to save resumable data in case the task was cancelled
         // (`URLError.cancelled`) or failed to complete with other error.
         if configuration.isResumableDataEnabled,
@@ -789,11 +805,27 @@ public /* final */ class ImagePipeline {
             ResumableData.storeResumableData(resumableData, for: context.request.urlRequest)
         }
     }
+}
 
-    // MARK: - Errors
+// MARK: - Misc (Private)
 
+private extension ImagePipeline {
+    /// Inherits some of the pipeline configuration options like processors.
+    func inheritOptions(_ request: ImageRequest) -> ImageRequest {
+        // Do not manipulate is the request has some processors already.
+        guard request.processors.isEmpty, !configuration.processors.isEmpty else { return request }
+
+        var request = request
+        request.processors = configuration.processors
+        return request
+    }
+}
+
+// MARK: - Errors
+
+public extension ImagePipeline {
     /// Represents all possible image pipeline errors.
-    public enum Error: Swift.Error, CustomDebugStringConvertible {
+    enum Error: Swift.Error, CustomDebugStringConvertible {
         /// Data loader failed to load image data with a wrapped error.
         case dataLoadingFailed(Swift.Error)
         /// Decoder failed to produce a final image.
@@ -808,17 +840,5 @@ public /* final */ class ImagePipeline {
             case .processingFailed: return "Failed to process the image"
             }
         }
-    }
-
-    // MARK: - Misc
-
-    /// Inherits some of the pipeline configuration options like processors.
-    private func inheritOptions(_ request: ImageRequest) -> ImageRequest {
-        // Do not manipulate is the request has some processors already.
-        guard request.processors.isEmpty, !configuration.processors.isEmpty else { return request }
-
-        var request = request
-        request.processors = configuration.processors
-        return request
     }
 }

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -349,15 +349,13 @@ private final class ImageViewController {
                 imageView.contentMode = contentMode
             }
             #endif
-        } else {
-            if options.isPrepareForReuseEnabled {
-                imageView.nuke_display(image: nil) // Remove previously displayed images (if any)
-            }
+        } else if options.isPrepareForReuseEnabled {
+            imageView.nuke_display(image: nil) // Remove previously displayed images (if any)
         }
 
         // Uses a special internal API (`isMainThreadConfined`) for performance
         // reasons, it attributes for about than 20% performance improvement.
-        self.task = pipeline.loadImage(with: request, isMainThreadConfined: true, queue: .main) { [weak self] task, event in
+        task = pipeline.loadImage(with: request, isMainThreadConfined: true, queue: .main) { [weak self] task, event in
             switch event {
             case .progress:
                 progressHandler?(nil, task.completedUnitCount, task.totalUnitCount)
@@ -374,7 +372,7 @@ private final class ImageViewController {
                 completion?(.failure(error))
             }
         }
-        return self.task
+        return task
     }
 
     func cancelOutstandingTask() {

--- a/Sources/Internal.swift
+++ b/Sources/Internal.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+import os
 
 // MARK: - Lock
 
@@ -402,9 +403,62 @@ extension String {
     }
 }
 
-// MARK: - Signpost
+// MARK: - Log
 
-import os
+class Log {
+    private let log: OSLog
+    private let name: StaticString
+    private let signpostsEnabled: Bool
+
+    init(_ log: OSLog, _ name: StaticString, _ signpostsEnabled: Bool = ImagePipeline.Configuration.isSignpostLoggingEnabled) {
+        self.log = log
+        self.name = name
+        self.signpostsEnabled = signpostsEnabled
+    }
+
+    // MARK: Signposts
+
+    func signpost(_ type: SignpostType, _ message: @autoclosure () -> String) {
+        guard signpostsEnabled else { return }
+        signpost(type, "%{public}s", message())
+    }
+
+    func signpost(_ type: SignpostType) {
+        guard signpostsEnabled else { return }
+        if #available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+            os_signpost(type.os, log: log, name: name, signpostID: signpostID)
+        }
+    }
+
+    // Unfortunately, there is no way to wrap os_signpost which takes variadic
+    // arguments, because Swift implicitly wraps `arguments CVarArg...` from `log`
+    // into an array and passes the array to `os_signpost` which is not what
+    // we expect. So in this scenario we have to limit the number of arguments
+    // to one, there is no way to pass more. For more info see https://stackoverflow.com/questions/50937765/why-does-wrapping-os-log-cause-doubles-to-not-be-logged-correctly
+    func signpost(_ type: SignpostType, _ format: StaticString, _ argument: CVarArg) {
+        guard signpostsEnabled else { return }
+        if #available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+            os_signpost(type.os, log: log, name: name, signpostID: signpostID, format, argument)
+        }
+    }
+
+    @available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+    var signpostID: OSSignpostID {
+        return OSSignpostID(log: log, object: self)
+    }
+}
+
+private let byteFormatter = ByteCountFormatter()
+
+extension Log {
+    static func bytes(_ count: Int) -> String {
+        return bytes(Int64(count))
+    }
+
+    static func bytes(_ count: Int64) -> String {
+        return byteFormatter.string(fromByteCount: count)
+    }
+}
 
 enum SignpostType {
     case begin, event, end
@@ -417,26 +471,4 @@ enum SignpostType {
         case .end: return .end
         }
     }
-}
-
-final class Signpost {
-    private let log: OSLog
-
-    @available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
-    var signpostID: OSSignpostID {
-        return OSSignpostID(log: log, object: self)
-    }
-
-    init(log: OSLog) {
-        self.log = log
-    }
-
-    func log(_ type: SignpostType, name: StaticString) {
-        if #available(OSX 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            os_signpost(type.os, log: log, name: name, signpostID: signpostID)
-        }
-    }
-
-    // Unfortunately, it's not technically possible to wrap the version which
-    // accepts `CVarArg...` because there is no way to pass them to `os_singpost`
 }


### PR DESCRIPTION
Make `ImagePipeline` more readable by splitting it into separate extensions and also extracting all logging code into a separate component.