### PR TITLE
Deprecate Image

### DIFF
--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -269,3 +269,8 @@ extension ImageTask {
         self.priority = priority
     }
 }
+
+// MARK: - Image (Deprecated)
+
+@available(*, deprecated, message: "Deprecated to avoid name clashes with SwiftUI. Please use `PlatformImage` instead.")
+public typealias Image = PlatformImage

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -26,7 +26,7 @@ public protocol ImageCaching: AnyObject {
 /// Convenience subscript.
 public extension ImageCaching {
     /// Accesses the image associated with the given request.
-    subscript(request: ImageRequest) -> Image? {
+    subscript(request: ImageRequest) -> PlatformImage? {
         get {
             return cachedResponse(for: request)?.image
         }
@@ -134,7 +134,7 @@ public final class ImageCache: ImageCaching {
     }
 
     /// Returns cost for the given image by approximating its bitmap size in bytes in memory.
-    func cost(for image: Image) -> Int {
+    func cost(for image: PlatformImage) -> Int {
         let dataCost: Int
         if ImagePipeline.Configuration.isAnimatedImageDataEnabled {
             dataCost = image.animatedImageData?.count ?? 0

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -21,11 +21,11 @@ public protocol ImageDecoding {
     /// progressive decoding enabled, the `decode(data:isFinal:)` method gets
     /// called each time the data buffer has new data available. The decoder may
     /// decide whether or not to produce a new image based on the previous scans.
-    func decode(data: Data, isFinal: Bool) -> Image?
+    func decode(data: Data, isFinal: Bool) -> PlatformImage?
 }
 
 extension ImageDecoding {
-    public func decode(data: Data) -> Image? {
+    public func decode(data: Data) -> PlatformImage? {
         return self.decode(data: data, isFinal: true)
     }
 }
@@ -43,7 +43,7 @@ public final class ImageDecoder: ImageDecoding {
 
     public init() { }
 
-    public func decode(data: Data, isFinal: Bool) -> Image? {
+    public func decode(data: Data, isFinal: Bool) -> PlatformImage? {
         let format = ImageFormat.format(for: data)
 
         guard !isFinal else { // Just decode the data.
@@ -95,7 +95,7 @@ public final class ImageDecoder: ImageDecoding {
 }
 
 extension ImageDecoder {
-    static func decode(_ data: Data) -> Image? {
+    static func decode(_ data: Data) -> PlatformImage? {
         #if os(macOS)
         return NSImage(data: data)
         #else
@@ -106,7 +106,7 @@ extension ImageDecoder {
 
 extension ImageDecoding {
     func decode(_ data: Data, urlResponse: URLResponse?, isFinal: Bool) -> ImageResponse? {
-        func decode() -> Image? {
+        func decode() -> PlatformImage? {
             return self.decode(data: data, isFinal: isFinal)
         }
         guard let image = autoreleasepool(invoking: decode) else {
@@ -234,7 +234,7 @@ enum ImageFormat: Equatable {
 
 private var _animatedImageDataAK = "Nuke.AnimatedImageData.AssociatedKey"
 
-extension Image {
+extension PlatformImage {
     // Animated image data. Only not `nil` when image data actually contains
     // an animated image.
     public var animatedImageData: Data? {

--- a/Sources/ImageEncoding.swift
+++ b/Sources/ImageEncoding.swift
@@ -15,7 +15,7 @@ import WatchKit
 // MARK: - ImageEncoding
 
 public protocol ImageEncoding {
-    func encode(image: Image) -> Data?
+    func encode(image: PlatformImage) -> Data?
 }
 
 // MARK: - ImageEncoder
@@ -27,7 +27,7 @@ public struct ImageEncoder: ImageEncoding {
         self.compressionQuality =  compressionQuality
     }
 
-    public func encode(image: Image) -> Data? {
+    public func encode(image: PlatformImage) -> Data? {
         guard let cgImage = image.cgImage else {
             return nil
         }
@@ -42,23 +42,23 @@ public struct ImageEncoder: ImageEncoding {
 /// Image encoding context used when selecting which encoder to use.
 public struct ImageEncodingContext {
     public let request: ImageRequest
-    public let image: Image
+    public let image: PlatformImage
     public let urlResponse: URLResponse?
 }
 
 #if !os(macOS)
 extension ImageEncoder {
-    static func pngData(from image: Image) -> Data? {
+    static func pngData(from image: UIImage) -> Data? {
         return image.pngData()
     }
 
-    static func jpegData(from image: Image, compressionQuality: CGFloat) -> Data? {
+    static func jpegData(from image: UIImage, compressionQuality: CGFloat) -> Data? {
         return image.jpegData(compressionQuality: compressionQuality)
     }
 }
 #else
 extension ImageEncoder {
-    static func pngData(from image: Image) -> Data? {
+    static func pngData(from image: NSImage) -> Data? {
         guard let cgImage = image.cgImage else {
             return nil
         }
@@ -66,7 +66,7 @@ extension ImageEncoder {
         return rep.representation(using: .png, properties: [:])
     }
 
-    static func jpegData(from image: Image, compressionQuality: CGFloat) -> Data? {
+    static func jpegData(from image: NSImage, compressionQuality: CGFloat) -> Data? {
         guard let cgImage = image.cgImage else {
             return nil
         }

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -4,6 +4,12 @@
 
 import Foundation
 
+#if !os(macOS)
+import UIKit.UIImage
+#else
+import AppKit.NSImage
+#endif
+
 // MARK: - ImageTask
 
 /// A task performed by the `ImagePipeline`. The pipeline maintains a strong
@@ -127,19 +133,19 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
 
 /// Represents an image response.
 public final class ImageResponse {
-    public let image: Image
+    public let image: PlatformImage
     public let urlResponse: URLResponse?
     // the response is only nil when new disk cache is enabled (it only stores
     // data for now, but this might change in the future).
     public let scanNumber: Int?
 
-    public init(image: Image, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
+    public init(image: PlatformImage, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
         self.image = image
         self.urlResponse = urlResponse
         self.scanNumber = scanNumber
     }
 
-    func map(_ transformation: (Image) -> Image?) -> ImageResponse? {
+    func map(_ transformation: (PlatformImage) -> PlatformImage?) -> ImageResponse? {
         return autoreleasepool {
             guard let output = transformation(image) else {
                 return nil


### PR DESCRIPTION
Deprecate Image to avoid name clashes with SwiftUI, add PlatformImage as a replacement