### PR TITLE
Add DataLoader and ImagePipeline events

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0C3261F71FEBC232009276AC /* MockImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE745741D4767B900123F65 /* MockImageDecoder.swift */; };
 		0C42D4C722A286260094CB5A /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42D4C422A283140094CB5A /* Deprecated.swift */; };
 		0C42D4C922A2BB850094CB5A /* DeprecatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42D4C822A2BB850094CB5A /* DeprecatedTests.swift */; };
+		0C45706B2377874500AB20DD /* ImagePipelineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C45706A2377874500AB20DD /* ImagePipelineEventsTests.swift */; };
 		0C49232920BACA81001DFCC8 /* XCTestCase+Nuke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C49232820BACA81001DFCC8 /* XCTestCase+Nuke.swift */; };
 		0C4AF1EB1FE85539002F86CB /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */; };
 		0C4F8FE822E4B7390070ECFD /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5D81871D46A385000ECCB6 /* ThreadSafetyTests.swift */; };
@@ -149,6 +150,7 @@
 		0C2A8CFA20970D8D0013FD65 /* ImagePipelineProgressiveDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineProgressiveDecodingTests.swift; sourceTree = "<group>"; };
 		0C42D4C422A283140094CB5A /* Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecated.swift; sourceTree = "<group>"; };
 		0C42D4C822A2BB850094CB5A /* DeprecatedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedTests.swift; sourceTree = "<group>"; };
+		0C45706A2377874500AB20DD /* ImagePipelineEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineEventsTests.swift; sourceTree = "<group>"; };
 		0C49232820BACA81001DFCC8 /* XCTestCase+Nuke.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Nuke.swift"; sourceTree = "<group>"; };
 		0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTest.swift; sourceTree = "<group>"; };
 		0C4B6A341E36630E00E86B21 /* Nuke 5 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 5 Migration Guide.md"; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				0C2A8CFA20970D8D0013FD65 /* ImagePipelineProgressiveDecodingTests.swift */,
 				0C6D0A8B20E57C810037B68F /* ImagePipelineDataCachingTests.swift */,
 				2DFD93AF233A6AB300D84DB9 /* ImagePipelineProcessorTests.swift */,
+				0C45706A2377874500AB20DD /* ImagePipelineEventsTests.swift */,
 				0C7C06871BCA888800089D7F /* ImageCacheTests.swift */,
 				0C7C06881BCA888800089D7F /* ImageProcessingTests.swift */,
 				0C70D9772089017500A49DAC /* ImageDecoderTests.swift */,
@@ -748,6 +751,7 @@
 				0C7C06981BCA888800089D7F /* Helpers.swift in Sources */,
 				0C4AF1EB1FE85539002F86CB /* LinkedListTest.swift in Sources */,
 				0CB2EFD62110F52C00F7C63F /* RateLimiterTests.swift in Sources */,
+				0C45706B2377874500AB20DD /* ImagePipelineEventsTests.swift in Sources */,
 				0C7C06971BCA888800089D7F /* MockDataLoader.swift in Sources */,
 				0C42D4C922A2BB850094CB5A /* DeprecatedTests.swift in Sources */,
 				0C1ECA501D52811D009063A9 /* ImageViewTests.swift in Sources */,

--- a/Sources/DataLoader.swift
+++ b/Sources/DataLoader.swift
@@ -21,10 +21,12 @@ public protocol DataLoading {
 extension URLSessionTask: Cancellable {}
 
 /// Provides basic networking using `URLSession`.
-public final class DataLoader: DataLoading {
+public final class DataLoader: DataLoading, _DataLoaderObserving {
     public let session: URLSession
     private let impl: _DataLoader
-    public var didReceiveData: ((_ data: Data?, _ error: Swift.Error?) -> Void)?
+
+    public var observer: DataLoaderObserving?
+
     /// Initializes `DataLoader` with the given configuration.
     /// - parameter configuration: `URLSessionConfiguration.default` with
     /// `URLCache` with 0 MB memory capacity and 150 MB disk capacity.
@@ -34,10 +36,7 @@ public final class DataLoader: DataLoading {
         self.session = URLSession(configuration: configuration, delegate: impl, delegateQueue: impl.queue)
         self.impl.session = self.session
         self.impl.validate = validate
-        self.impl.didReceiveData = {[weak self] data, error in
-            guard let _strongSelf = self else { return }
-            _strongSelf.didReceiveData?(data, error)
-        }
+        self.impl.observer = self
     }
 
     /// Returns a default configuration which has a `sharedUrlCache` set
@@ -57,9 +56,9 @@ public final class DataLoader: DataLoading {
         return (200..<300).contains(response.statusCode) ? nil : Error.statusCodeUnacceptable(response.statusCode)
     }
 
-#if !os(macOS) && !targetEnvironment(macCatalyst)
+    #if !os(macOS) && !targetEnvironment(macCatalyst)
     private static let cachePath = "com.github.kean.Nuke.Cache"
-#else
+    #else
     private static let cachePath: String = {
         let cachePaths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)
         if let cachePath = cachePaths.first, let identifier = Bundle.main.bundleIdentifier {
@@ -68,7 +67,7 @@ public final class DataLoader: DataLoading {
 
         return ""
     }()
-#endif
+    #endif
 
     /// Shared url cached used by a default `DataLoader`. The cache is
     /// initialized with 0 MB memory capacity and 150 MB disk capacity.
@@ -99,6 +98,12 @@ public final class DataLoader: DataLoading {
             }
         }
     }
+
+    // MARK: _DataLoaderObserving
+
+    func urlSession(_ urlSession: URLSession, dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent) {
+        observer?.dataLoader(self, urlSession: urlSession, dataTask: dataTask, didReceiveEvent: event)
+    }
 }
 
 // Actual data loader implementation. Hide NSObject inheritance, hide
@@ -109,7 +114,8 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
     var validate: (URLResponse) -> Swift.Error? = DataLoader.validate
     let queue = OperationQueue()
     private var handlers = [URLSessionTask: _Handler]()
-    var didReceiveData: ((_ data: Data?, _ error: Error?) -> Void)?
+    weak var observer: _DataLoaderObserving?
+
     override init() {
         self.queue.maxConcurrentOperationCount = 1
     }
@@ -124,6 +130,7 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
             self.handlers[task] = handler
         }
         task.resume()
+        send(task, .resumed)
         return task
     }
 
@@ -133,6 +140,8 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
                     dataTask: URLSessionDataTask,
                     didReceive response: URLResponse,
                     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        send(dataTask, .receivedResponse(response: response))
+
         guard let handler = handlers[dataTask] else {
             completionHandler(.cancel)
             return
@@ -146,10 +155,14 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        assert(task is URLSessionDataTask)
+        if let dataTask = task as? URLSessionDataTask {
+            send(dataTask, .completed(error: error))
+        }
+
         guard let handler = handlers[task] else {
             return
         }
-        didReceiveData?(nil, error)
         handlers[task] = nil
         handler.completion(error)
     }
@@ -157,12 +170,19 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
     // MARK: URLSessionDataDelegate
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        send(dataTask, .receivedData(data: data))
+
         guard let handler = handlers[dataTask], let response = dataTask.response else {
             return
         }
-        didReceiveData?(data, nil)
         // Don't store data anywhere, just send it to the pipeline.
         handler.didReceiveData(data, response)
+    }
+
+    // MARK: Internal
+
+    private func send(_ dataTask: URLSessionDataTask, _ event: DataTaskEvent) {
+        observer?.urlSession(session, dataTask: dataTask, didReceiveEvent: event)
     }
 
     private final class _Handler {
@@ -174,4 +194,23 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
             self.completion = completion
         }
     }
+}
+
+// MARK: - DataLoaderObserving
+
+public enum DataTaskEvent {
+    case resumed
+    case receivedResponse(response: URLResponse)
+    case receivedData(data: Data)
+    case completed(error: Error?)
+}
+
+/// Allows you to tap into internal events of the data loader. Events are
+/// delivered on the internal serial operation queue.
+public protocol DataLoaderObserving {
+    func dataLoader(_ loader: DataLoader, urlSession: URLSession, dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent)
+}
+
+protocol _DataLoaderObserving: class {
+    func urlSession(_ urlSession: URLSession, dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent)
 }

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -21,6 +21,8 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
     /// unique within this pipeline.
     public let taskId: Int
 
+    let isDataTask: Bool
+
     weak var pipeline: ImagePipeline?
 
     /// The original request with which the task was created.
@@ -63,11 +65,12 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
     /// A progress handler to be called periodically during the lifetime of a task.
     public typealias ProgressHandler = (_ intermediateResponse: ImageResponse?, _ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void
 
-    init(taskId: Int, request: ImageRequest, isMainThreadConfined: Bool = false, queue: DispatchQueue?) {
+    init(taskId: Int, request: ImageRequest, isMainThreadConfined: Bool = false, isDataTask: Bool, queue: DispatchQueue?) {
         self.taskId = taskId
         self.request = request
         self._priority = request.priority
         self.priority = request.priority
+        self.isDataTask = isDataTask
         self.queue = queue
         lock = isMainThreadConfined ? nil : NSLock()
     }

--- a/Tests/ImagePipelineEventsTests.swift
+++ b/Tests/ImagePipelineEventsTests.swift
@@ -1,0 +1,113 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+
+class ImagePipelineObservingTests: XCTestCase {
+    var dataLoader: MockDataLoader!
+    var pipeline: ImagePipeline!
+    private var observer: MockImagePipelineObserver!
+
+    override func setUp() {
+        super.setUp()
+
+        dataLoader = MockDataLoader()
+        pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+        observer = MockImagePipelineObserver()
+        pipeline.observer = observer
+    }
+
+    // MARK: - Completion
+
+    func testStartAndCompletedEvents() throws {
+        var result: Result<ImageResponse, ImagePipeline.Error>?
+        expect(pipeline).toLoadImage(with: Test.request) { result = $0 }
+        wait()
+
+        // Then
+        XCTAssertEqual(observer.events, [
+            ImageTaskEvent.started,
+            .progressUpdated(completedUnitCount: 22789, totalUnitCount: -1),
+            .completed(result: try XCTUnwrap(result))
+        ])
+    }
+
+    func testProgressUpdateEvents() throws {
+        let request = ImageRequest(url: Test.url)
+        dataLoader.results[Test.url] = .success(
+            (Data(count: 20), URLResponse(url: Test.url, mimeType: "jpeg", expectedContentLength: 20, textEncodingName: nil))
+        )
+
+        var result: Result<ImageResponse, ImagePipeline.Error>?
+        expect(pipeline).toFailRequest(request) { result = $0 }
+        wait()
+
+        // Then
+        XCTAssertEqual(observer.events, [
+            ImageTaskEvent.started,
+            .progressUpdated(completedUnitCount: 10, totalUnitCount: 20),
+            .progressUpdated(completedUnitCount: 20, totalUnitCount: 20),
+            .completed(result: try XCTUnwrap(result))
+        ])
+    }
+
+    func testUpdatePriorityEvents() {
+        // Given
+        let queue = pipeline.configuration.dataLoadingQueue
+        queue.isSuspended = true
+
+        let request = Test.request
+        XCTAssertEqual(request.priority, .normal)
+
+        let operationQueueObserver = self.expect(queue).toEnqueueOperationsWithCount(1)
+
+        let task = pipeline.loadImage(with: request)
+        wait() // Wait till the operation is created.
+
+        guard let operation = operationQueueObserver.operations.first else {
+            return XCTFail("Failed to find operation")
+        }
+        expect(operation).toUpdatePriority()
+        task.priority = .high
+        wait()
+
+        // Then
+        XCTAssertEqual(observer.events, [
+            ImageTaskEvent.started,
+            .priorityUpdated(priority: .high)
+        ])
+    }
+
+    func testCancelationEvents() {
+        dataLoader.queue.isSuspended = true
+
+        expectNotification(MockDataLoader.DidStartTask, object: dataLoader)
+        let task = pipeline.loadImage(with: Test.request) { _ in
+            XCTFail()
+        }
+        wait() // Wait till operation is created
+
+        expectNotification(MockDataLoader.DidCancelTask, object: dataLoader)
+        task.cancel()
+        wait()
+
+        // Then
+        XCTAssertEqual(observer.events, [
+            ImageTaskEvent.started,
+            .cancelled
+        ])
+    }
+}
+
+private final class MockImagePipelineObserver: ImagePipelineObserving {
+    var events = [ImageTaskEvent]()
+
+    func pipeline(_ pipeline: ImagePipeline, imageTask: ImageTask, didReceiveEvent event: ImageTaskEvent) {
+        events.append(event)
+    }
+}

--- a/Tests/ImagePipelineProcessorTests.swift
+++ b/Tests/ImagePipelineProcessorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import Nuke
 
 #if !os(macOS)
-    import UIKit
+import UIKit
 #endif
 
 class ImagePipelineProcessorTests: XCTestCase {

--- a/Tests/MockImagePipeline.swift
+++ b/Tests/MockImagePipeline.swift
@@ -10,7 +10,7 @@ private class MockImageTask: ImageTask {
     var __isCancelled = false
 
     init(request: ImageRequest) {
-        super.init(taskId: 0, request: request, queue: nil)
+        super.init(taskId: 0, request: request, isDataTask: false, queue: nil)
     }
 
     override func cancel() {

--- a/Tests/MockImageProcessor.swift
+++ b/Tests/MockImageProcessor.swift
@@ -31,7 +31,7 @@ class MockImageProcessor: ImageProcessing {
     func process(image: PlatformImage, context: ImageProcessingContext?) -> PlatformImage? {
         var processorIDs: [String] = image.nk_test_processorIDs
         #if os(macOS)
-        let processedImage = image.copy() as! Image
+        let processedImage = image.copy() as! PlatformImage
         #else
         guard let copy = image.cgImage?.copy() else {
             return image

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -17,6 +17,26 @@ extension ImagePipeline.Error: Equatable {
     }
 }
 
+extension ImageTaskEvent: Equatable {
+    public static func == (lhs: ImageTaskEvent, rhs: ImageTaskEvent) -> Bool {
+        switch (lhs, rhs) {
+        case (.started, .started): return true
+        case (.cancelled, .cancelled): return true
+        case let (.priorityUpdated(lhs), .priorityUpdated(rhs)): return lhs == rhs
+        case let (.intermediateResponseReceived(lhs), .intermediateResponseReceived(rhs)): return lhs == rhs
+        case let (.progressUpdated(lhs), .progressUpdated(rhs)): return lhs == rhs
+        case let (.completed(lhs), .completed(rhs)): return lhs == rhs
+        default: return false
+        }
+    }
+}
+
+extension ImageResponse: Equatable {
+    public static func == (lhs: ImageResponse, rhs: ImageResponse) -> Bool {
+        return lhs === rhs
+    }
+}
+
 extension ImagePipeline {
     func reconfigured(_ configure: (inout ImagePipeline.Configuration) -> Void) -> ImagePipeline {
         var configuration = self.configuration

--- a/Tests/XCTestCase+Nuke.swift
+++ b/Tests/XCTestCase+Nuke.swift
@@ -16,9 +16,10 @@ struct TestExpectationImagePipeline {
     let test: XCTestCase
     let pipeline: ImagePipeline
 
-    func toLoadImage(with request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) {
+    @discardableResult
+    func toLoadImage(with request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) -> ImageTask {
         let expectation = test.expectation(description: "Image loaded for \(request)")
-        pipeline.loadImage(with: request, progress: progress) { result in
+        return pipeline.loadImage(with: request, progress: progress) { result in
             completion?(result)
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertTrue(result.isSuccess)
@@ -26,9 +27,10 @@ struct TestExpectationImagePipeline {
         }
     }
 
-    func toFailRequest(_ request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) {
+    @discardableResult
+    func toFailRequest(_ request: ImageRequest, progress: ImageTask.ProgressHandler? = nil, completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) -> ImageTask {
         let expectation = test.expectation(description: "Image request failed \(request)")
-        pipeline.loadImage(with: request, progress: progress) { result in
+        return pipeline.loadImage(with: request, progress: progress) { result in
             completion?(result)
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertTrue(result.isFailure)

--- a/Tests/XCTestCaseExtensions.swift
+++ b/Tests/XCTestCaseExtensions.swift
@@ -258,3 +258,10 @@ extension Array {
         return self[index]
     }
 }
+
+func XCTUnwrap<T>(_ value: T?) throws -> T {
+    guard let value = value else {
+        throw NSError(domain: "XCTest", code: -32, userInfo: [NSLocalizedDescriptionKey: "Failed to unwrap value"])
+    }
+    return value
+}


### PR DESCRIPTION
## Use cases

- Logging

```
LocalDataTask <B6C07A0C-7E8E-4E3D-9727-56887E5232B2>.<27> resumed
LocalDataTask <B6C07A0C-7E8E-4E3D-9727-56887E5232B2>.<27> receivedResponse(response: <NSHTTPURLResponse: 0x600001f9dd60> { URL: https://cloud.githubusercontent.com/assets/1567433/9781961/f3d865de-57a1-11e5-87fd-bb8f28515a16.jpg } { Status Code: 200, Headers {
LocalDataTask <B6C07A0C-7E8E-4E3D-9727-56887E5232B2>.<27> receivedData(data: 32038 bytes)
LocalDataTask <B6C07A0C-7E8E-4E3D-9727-56887E5232B2>.<27> completed(error: nil)
```

- Monitoring download speed https://github.com/kean/Nuke/issues/313
