### PR TITLE
RoundedCorners and Circle image processor Border width

### DIFF
--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -157,14 +157,22 @@ extension ImageProcessor {
 
     /// Rounds the corners of an image into a circle.
     public struct Circle: ImageProcessing, Hashable, CustomStringConvertible {
-        public init() {}
+        private let border: Border?
+
+        public init(border: Border? = nil) {
+            self.border = border
+        }
 
         public func process(image: UIImage, context: ImageProcessingContext?) -> UIImage? {
-            return image.processed.byDrawingInCircle()
+            return image.processed.byDrawingInCircle(border: border)
         }
 
         public var identifier: String {
-            return "com.github.kean/nuke/circle"
+            if let border = self.border {
+                return "com.github.kean/nuke/circle?border=\(border)"
+            } else {
+                return "com.github.kean/nuke/circle"
+            }
         }
 
         public var hashableIdentifier: AnyHashable {
@@ -536,12 +544,12 @@ struct ImageProcessingExtensions {
 
     #if os(iOS) || os(tvOS) || os(watchOS)
 
-    func byDrawingInCircle() -> UIImage? {
+    func byDrawingInCircle(border: ImageProcessor.Border?) -> UIImage? {
         guard let squared = byCroppingToSquare(), let cgImage = squared.cgImage else {
             return nil
         }
         let radius = CGFloat(cgImage.width) / 2.0 // Can use any dimenstion since image is a square
-        return squared.processed.byAddingRoundedCorners(radius: radius)
+        return squared.processed.byAddingRoundedCorners(radius: radius, border: border)
     }
 
     /// Draws an image in square by preserving an aspect ratio and filling the


### PR DESCRIPTION
The `RoundedCorners` image processor has an existing `Border` parameter. However It was not respecting the `border.width` when drawing the stroke. The stoke was always drawn with a width of 1.
This PR corrects the width of the stroke border in the `RoundedCorners` processor. 

This PR also adds an optional `border` parameter to the `Circle` processor. The new parameter defaults to `nil` in order to prevent a breaking API change.