### PR TITLE
Border width Scale of RoundedCorners image processor 

### DIFF
--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -599,7 +599,7 @@ struct ImageProcessingExtensions {
             context.setStrokeColor(border.color.cgColor)
 
             let path = UIBezierPath(roundedRect: rect, cornerRadius: radius)
-            path.lineWidth = border.width
+            path.lineWidth = border.width * (Screen.scale + image.scale)
 
             path.stroke()
         }


### PR DESCRIPTION
ImageProcessing.Border has width parameter. However, now border width is not drawn as expected, because, border width does not take `Screen.scale & image.scale` into account.

This PR corrects the width caluculation of the stroke border in the RoundedCorners processor.