### PR TITLE
DataCache Improvements

### DIFF
--- a/Sources/DataCache.swift
+++ b/Sources/DataCache.swift
@@ -157,7 +157,7 @@ public final class DataCache: DataCaching {
 
         lock.unlock()
 
-        guard let url = self.url(for: key) else {
+        guard let url = url(forKey: key) else {
             return nil
         }
         return try? Data(contentsOf: url)
@@ -179,7 +179,7 @@ public final class DataCache: DataCaching {
 
     /// Performs the IO for the given change.
     private func perform(_ change: Staging.Change) {
-        guard let url = self.url(for: change.key) else {
+        guard let url = url(forKey: change.key) else {
             return
         }
         switch change.type {
@@ -267,7 +267,8 @@ public final class DataCache: DataCaching {
         return filenameGenerator(key)
     }
 
-    /* testable */ func url(for key: Key) -> URL? {
+    /// Returns `url` for the given cache key.
+    public func url(forKey key: Key) -> URL? {
         guard let filename = self.filename(for: key) else {
             return nil
         }
@@ -276,7 +277,7 @@ public final class DataCache: DataCaching {
 
     // MARK: Flush Changes
 
-    /// Synchronously waits on the caller's thread until all outstanding disk IO
+    /// Synchronously waits on the caller's thread until all outstanding disk I/O
     /// operations are finished.
     public func flush() {
         queue.sync {}

--- a/Sources/DataCache.swift
+++ b/Sources/DataCache.swift
@@ -80,18 +80,17 @@ public final class DataCache: DataCaching {
     /// The delay after which the initial sweep is performed. 10 by default.
     /// The initial sweep is performed after a delay to avoid competing with
     /// other subsystems for the resources.
-    private var initialSweepDelay: TimeInterval = 15
+    private var initialSweepDelay: TimeInterval = 10
 
     // Staging
 
     private let lock = NSLock()
     private var staging = Staging()
+    private var isFlushNeeded = false
+    private var isFlushScheduled = false
+    private var flushInterval: DispatchTimeInterval = .seconds(2)
 
     /// A queue which is used for disk I/O.
-    ///
-    /// If you perform a request using `ImagePipeline` which completes successfully,
-    /// you can dispatch - preferrable asynchronous - operation to the data cache's
-    /// queue to read the cached data and have a guarantee that it is going to be there.
     public let queue = DispatchQueue(label: "com.github.kean.Nuke.DataCache.WriteQueue", target: .global(qos: .utility))
 
     /// A function which generates a filename for the given key. A good candidate
@@ -108,8 +107,7 @@ public final class DataCache: DataCaching {
     /// with the given `name` in a `.cachesDirectory` in `.userDomainMask`.
     /// - parameter filenameGenerator: Generates a filename for the given URL.
     /// The default implementation generates a filename using SHA1 hash function.
-    public convenience init(name: String,
-                            filenameGenerator: @escaping (String) -> String? = DataCache.filename(for:)) throws {
+    public convenience init(name: String, filenameGenerator: @escaping (String) -> String? = DataCache.filename(for:)) throws {
         guard let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
         }
@@ -134,7 +132,7 @@ public final class DataCache: DataCaching {
     private func didInit() throws {
         try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true, attributes: nil)
         queue.asyncAfter(deadline: .now() + initialSweepDelay) { [weak self] in
-            self?._performAndScheduleSweep()
+            self?.performAndScheduleSweep()
         }
     }
 
@@ -144,20 +142,18 @@ public final class DataCache: DataCaching {
     /// syncrhonously if there is no cached data for the given key.
     public func cachedData(for key: Key) -> Data? {
         lock.lock()
-
         if let change = staging.change(for: key) {
             lock.unlock()
-            switch change {
+            switch change { // Change wasn't flushed to disk yet
             case let .add(data):
                 return data
             case .remove:
                 return nil
             }
         }
-
         lock.unlock()
 
-        guard let url = url(forKey: key) else {
+        guard let url = url(for: key) else {
             return nil
         }
         return try? Data(contentsOf: url)
@@ -166,63 +162,26 @@ public final class DataCache: DataCaching {
     /// Stores data for the given key. The method returns instantly and the data
     /// is written asynchronously.
     public func storeData(_ data: Data, for key: Key) {
-        lock.sync {
-            let change = staging.add(data: data, for: key)
-            queue.async {
-                self.perform(change)
-                self.lock.sync {
-                    self.staging.flushed(change)
-                }
-            }
-        }
-    }
-
-    /// Performs the IO for the given change.
-    private func perform(_ change: Staging.Change) {
-        guard let url = url(forKey: change.key) else {
-            return
-        }
-        switch change.type {
-        case let .add(data):
-            do {
-                try data.write(to: url)
-            } catch let error as NSError {
-                guard error.code == CocoaError.fileNoSuchFile.rawValue && error.domain == CocoaError.errorDomain else { return }
-                try? FileManager.default.createDirectory(at: self.path, withIntermediateDirectories: true, attributes: nil)
-                try? data.write(to: url) // re-create a directory and try again
-            }
-        case .remove:
-            try? FileManager.default.removeItem(at: url)
-        }
+        stage { staging.add(data: data, for: key) }
     }
 
     /// Removes data for the given key. The method returns instantly, the data
     /// is removed asynchronously.
     public func removeData(for key: Key) {
-        lock.sync {
-            let change = staging.removeData(for: key)
-            queue.async {
-                self.perform(change)
-                self.lock.sync {
-                    self.staging.flushed(change)
-                }
-            }
-        }
+        stage { staging.removeData(for: key) }
     }
 
     /// Removes all items. The method returns instantly, the data is removed
     /// asynchronously.
     public func removeAll() {
-        lock.sync {
-            let change = staging.removeAll()
-            queue.async {
-                try? FileManager.default.removeItem(at: self.path)
-                try? FileManager.default.createDirectory(at: self.path, withIntermediateDirectories: true, attributes: nil)
-                self.lock.sync {
-                    self.staging.flushed(change)
-                }
-            }
-        }
+        stage { staging.removeAll() }
+    }
+
+    private func stage(_ change: () -> Void) {
+        lock.lock()
+        change()
+        setNeedsFlushChanges()
+        lock.unlock()
     }
 
     /// Accesses the data associated with the given key for reading and writing.
@@ -268,7 +227,7 @@ public final class DataCache: DataCaching {
     }
 
     /// Returns `url` for the given cache key.
-    public func url(forKey key: Key) -> URL? {
+    public func url(for key: Key) -> URL? {
         guard let filename = self.filename(for: key) else {
             return nil
         }
@@ -280,27 +239,99 @@ public final class DataCache: DataCaching {
     /// Synchronously waits on the caller's thread until all outstanding disk I/O
     /// operations are finished.
     public func flush() {
-        queue.sync {}
+        queue.sync(execute: flushChangesIfNeeded)
+    }
+
+    private func setNeedsFlushChanges() {
+        guard !isFlushNeeded else { return }
+        isFlushNeeded = true
+        scheduleNextFlush()
+    }
+
+    private func scheduleNextFlush() {
+        guard !isFlushScheduled else { return }
+        isFlushScheduled = true
+        queue.asyncAfter(deadline: .now() + flushInterval, execute: flushChangesIfNeeded)
+    }
+
+    private func flushChangesIfNeeded() {
+        // Create a snapshot of the recently made changes
+        let staging: Staging
+        lock.lock()
+        guard isFlushNeeded else {
+            return lock.unlock()
+        }
+        staging = self.staging
+        isFlushNeeded = false
+        lock.unlock()
+
+        // Apply the snapshot to disk
+        performChanges(for: staging)
+
+        // Update the staging area and schedule the next flush if needed
+        lock.lock()
+        self.staging.flushed(staging)
+        isFlushScheduled = false
+        if isFlushNeeded {
+            scheduleNextFlush()
+        }
+        lock.unlock()
+    }
+
+    // MARK: - I/O
+
+    private func performChanges(for staging: Staging) {
+        autoreleasepool {
+            if let change = staging.changeRemoveAll {
+                perform(change)
+            }
+            for change in staging.changes.values {
+                perform(change)
+            }
+        }
+    }
+
+    private func perform(_ change: Staging.ChangeRemoveAll) {
+        try? FileManager.default.removeItem(at: self.path)
+        try? FileManager.default.createDirectory(at: self.path, withIntermediateDirectories: true, attributes: nil)
+    }
+
+    /// Performs the IO for the given change.
+    private func perform(_ change: Staging.Change) {
+        guard let url = url(for: change.key) else {
+            return
+        }
+        switch change.type {
+        case let .add(data):
+            do {
+                try data.write(to: url)
+            } catch let error as NSError {
+                guard error.code == CocoaError.fileNoSuchFile.rawValue && error.domain == CocoaError.errorDomain else { return }
+                try? FileManager.default.createDirectory(at: self.path, withIntermediateDirectories: true, attributes: nil)
+                try? data.write(to: url) // re-create a directory and try again
+            }
+        case .remove:
+            try? FileManager.default.removeItem(at: url)
+        }
     }
 
     // MARK: Sweep
 
-    private func _performAndScheduleSweep() {
-        _sweep()
+    private func performAndScheduleSweep() {
+        performSweep()
         queue.asyncAfter(deadline: .now() + sweepInterval) { [weak self] in
-            self?._performAndScheduleSweep()
+            self?.performAndScheduleSweep()
         }
     }
 
-    /// Schedules a cache sweep to be performed immediately.
+    /// Synchronously performs a cache sweep and removes the least recently items
+    /// which no longer fit in cache.
     public func sweep() {
-        queue.async {
-            self._sweep()
-        }
+        queue.sync(execute: performSweep)
     }
 
     /// Discards the least recently used items first.
-    private func _sweep() {
+    private func performSweep() {
         var items = contents(keys: [.contentAccessDateKey, .totalFileAllocatedSizeKey])
         guard !items.isEmpty else {
             return
@@ -379,86 +410,88 @@ public final class DataCache: DataCaching {
             $0 + ($1.meta.totalFileAllocatedSize ?? 0)
         }
     }
+}
 
-    // MARK: - Staging
+// MARK: - Staging
 
-    /// DataCache allows for parallel reads and writes. This is made possible by
-    /// DataCacheStaging.
-    ///
-    /// For example, when the data is added in cache, it is first added to staging
-    /// and is removed from staging only after data is written to disk. Removal works
-    /// the same way.
-    private final class Staging {
-        private var changes = [String: Change]()
-        private var changeRemoveAll: ChangeRemoveAll?
+/// DataCache allows for parallel reads and writes. This is made possible by
+/// DataCacheStaging.
+///
+/// For example, when the data is added in cache, it is first added to staging
+/// and is removed from staging only after data is written to disk. Removal works
+/// the same way.
+private struct Staging {
+    private(set) var changes = [String: Change]()
+    private(set) var changeRemoveAll: ChangeRemoveAll?
 
-        struct ChangeRemoveAll {
-            let id: Int
+    struct ChangeRemoveAll {
+        let id: Int
+    }
+
+    struct Change {
+        let key: String
+        let id: Int
+        let type: ChangeType
+    }
+
+    enum ChangeType {
+        case add(Data)
+        case remove
+    }
+
+    private var nextChangeId = 0
+
+    // MARK: Changes
+
+    func change(for key: String) -> ChangeType? {
+        if let change = changes[key] {
+            return change.type
         }
-
-        struct Change {
-            let key: String
-            let id: Int
-            let type: ChangeType
+        if changeRemoveAll != nil {
+            return .remove
         }
+        return nil
+    }
 
-        enum ChangeType {
-            case add(Data)
-            case remove
+    // MARK: Register Changes
+
+    mutating func add(data: Data, for key: String) {
+        nextChangeId += 1
+        changes[key] = Change(key: key, id: nextChangeId, type: .add(data))
+    }
+
+    mutating func removeData(for key: String) {
+        nextChangeId += 1
+        changes[key] = Change(key: key, id: nextChangeId, type: .remove)
+    }
+
+    mutating func removeAll() {
+        nextChangeId += 1
+        changeRemoveAll = ChangeRemoveAll(id: nextChangeId)
+        changes.removeAll()
+    }
+
+    // MARK: Flush Changes
+
+    mutating func flushed(_ staging: Staging) {
+        for change in staging.changes.values {
+            flushed(change)
         }
-
-        private var nextChangeId = 0
-
-        // MARK: Changes
-
-        func change(for key: String) -> ChangeType? {
-            if let change = changes[key] {
-                return change.type
-            }
-            if changeRemoveAll != nil {
-                return .remove
-            }
-            return nil
+        if let change = staging.changeRemoveAll {
+            flushed(change)
         }
+    }
 
-        // MARK: Register Changes
-
-        func add(data: Data, for key: String) -> Change {
-            return makeChange(.add(data), for: key)
+    private mutating func flushed(_ change: Change) {
+        if let index = changes.index(forKey: change.key),
+            changes[index].value.id == change.id {
+            changes.remove(at: index)
         }
+    }
 
-        func removeData(for key: String) -> Change {
-            return makeChange(.remove, for: key)
-        }
-
-        private func makeChange(_ type: ChangeType, for key: String) -> Change {
-            nextChangeId += 1
-            let change = Change(key: key, id: nextChangeId, type: type)
-            changes[key] = change
-            return change
-        }
-
-        func removeAll() -> ChangeRemoveAll {
-            nextChangeId += 1
-            let change = ChangeRemoveAll(id: nextChangeId)
-            changeRemoveAll = change
-            changes.removeAll()
-            return change
-        }
-
-        // MARK: Flush Changes
-
-        func flushed(_ change: Change) {
-            if let index = changes.index(forKey: change.key),
-                changes[index].value.id == change.id {
-                changes.remove(at: index)
-            }
-        }
-
-        func flushed(_ change: ChangeRemoveAll) {
-            if changeRemoveAll?.id == change.id {
-                changeRemoveAll = nil
-            }
+    private mutating func flushed(_ change: ChangeRemoveAll) {
+        if changeRemoveAll?.id == change.id {
+            changeRemoveAll = nil
         }
     }
 }

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -245,8 +245,11 @@ public /* final */ class ImagePipeline {
             subscription.setPriority(priority)
         }
     }
+}
 
-    // MARK: - Cache
+// MARK: - Image Cache
+
+public extension ImagePipeline {
 
     /// Returns a cached response from the memory cache. Returns `nil` if the request disables
     /// memory cache reads.
@@ -260,6 +263,21 @@ public /* final */ class ImagePipeline {
     private func storeResponse(_ response: ImageResponse, for request: ImageRequest, isCompleted: Bool) {
         guard isCompleted, request.options.memoryCacheOptions.isWriteAllowed else { return }
         configuration.imageCache?.storeResponse(response, for: request)
+    }
+}
+
+// MARK: - Data Cache
+
+public extension ImagePipeline {
+    /// Returns a key used for disk cache (see `DataCaching`).
+    ///
+    /// - parameter isProcessedData: If `true`, returns a key for processed image
+    /// data (see `isDataCachingForProcessedImagesEnabled` for more info). Otherwise
+    /// returns a key for original image data. `false` by default.
+    func cacheKey(for request: ImageRequest, isProcessedData: Bool = false) -> String {
+        return isProcessedData ?
+            request.makeCacheKeyForProcessedImageData() :
+            request.makeCacheKeyForOriginalImageData()
     }
 }
 

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -253,7 +253,7 @@ public extension ImagePipeline {
 
     /// Returns a cached response from the memory cache. Returns `nil` if the request disables
     /// memory cache reads.
-    public func cachedResponse(for request: ImageRequest) -> ImageResponse? {
+    func cachedResponse(for request: ImageRequest) -> ImageResponse? {
         guard request.options.memoryCacheOptions.isReadAllowed else { return nil }
 
         let request = inheritOptions(request)

--- a/Tests/DataCacheTests.swift
+++ b/Tests/DataCacheTests.swift
@@ -390,7 +390,7 @@ class DataCacheTests: XCTestCase {
         cache.flush()
 
         do {
-            guard let url = cache.url(for: "1") else {
+            guard let url = cache.url(forKey: "1") else {
                 return XCTFail("Failed to create URL")
             }
             let data = try Data(contentsOf: url)

--- a/Tests/DataCacheTests.swift
+++ b/Tests/DataCacheTests.swift
@@ -407,8 +407,8 @@ extension DataCache {
     }
 
     func withSuspendedIO(_ closure: () -> Void) {
-        wqueue.suspend()
+        queue.suspend()
         closure()
-        wqueue.resume()
+        queue.resume()
     }
 }

--- a/Tests/DataCacheTests.swift
+++ b/Tests/DataCacheTests.swift
@@ -390,7 +390,7 @@ class DataCacheTests: XCTestCase {
         cache.flush()
 
         do {
-            guard let url = cache.url(forKey: "1") else {
+            guard let url = cache.url(for: "1") else {
                 return XCTFail("Failed to create URL")
             }
             let data = try Data(contentsOf: url)

--- a/Tests/DataCacheTests.swift
+++ b/Tests/DataCacheTests.swift
@@ -333,15 +333,39 @@ class DataCacheTests: XCTestCase {
 
     func testFlush() {
         // Given
-        cache.withSuspendedIO {
-            cache["key"] = blob
-        }
+        cache.flushInterval = .seconds(20)
+        cache["key"] = blob
 
         // When
         cache.flush()
 
         // Then
-        XCTAssertEqual(cache.contents.count, 1)
+        XCTAssertEqual(cache.contents, [cache.url(for: "key")])
+    }
+
+    func testFlushForKey() {
+        // Given
+        cache.flushInterval = .seconds(20)
+        cache["key"] = blob
+
+        // When
+        cache.flush(for: "key")
+
+        // Then
+        XCTAssertEqual(cache.contents, [cache.url(for: "key")])
+    }
+
+    func testFlushForKey2() {
+        // Given
+        cache.flushInterval = .seconds(20)
+        cache["key1"] = blob
+        cache["key2"] = blob
+
+        // When
+        cache.flush(for: "key1")
+
+        // Then only flushes content for the specific key
+        XCTAssertEqual(cache.contents, [cache.url(for: "key1")])
     }
 
     // MARK: Inspection


### PR DESCRIPTION
This PR realizes the original vision for `DataCache`.

- Reimplement staging/flushing mechanism which now performs flushes on certain intervals instead of on every write. This gives more control to the component and makes empty flushes instantaneous. It is also theoretically faster, but it's not something that I measured or wanted to optimize.
- Add public property `let queue: DispatchQueue`
- Add public method `func url(for key: Key) -> URL?`
- `flush` not performs synchronously
- Add `flush(for:)` methods which allows to flush changes on disk only for the given key

This PR also adds a new API to `ImagePipeline`:

- `func cacheKey(for request: ImageRequest, isProcessedData: Bool = false) -> String`