### PR TITLE
Add ImageIO Encoder and HEIF Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ let request = ImageRequest(url: url, processors: [
 
 To avoid storing unwanted images, compose the processors, `ImageProcessor.Composition` is an easy way to do it.
 
+> To save disk space see `ImageEncoders.ImageIO` and a new experimental `ImageEncoder._isHEIFPreferred` option for HEIF support.
+
 <br/>
 
 # Advanced Features


### PR DESCRIPTION
- Add a new `ImageEncoders` "namespace"
- Add `ImageEncoders.ImageIO`- an [Image I/O](https://developer.apple.com/documentation/imageio) based encoder with support for HEIF
- Add an experimental `ImageEncoder._isHEIFPreferred` option to `ImageEncoder` which automatically switches to HEIF when it is available. HEIF can save up to 50% space on disk compared to JPEG
- The default adaptive encoder now uses `ImageEncoders.ImageIO` under the hood