### PR TITLE
Add new _ImageDecoding infrastructure

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		0C7C06991BCA888800089D7F /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068E1BCA888800089D7F /* XCTestCaseExtensions.swift */; };
 		0C8684FF20BDD578009FF7CC /* ImagePipelineProgressiveDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2A8CFA20970D8D0013FD65 /* ImagePipelineProgressiveDecodingTests.swift */; };
 		0C86AB6A228B3B5100A81BA1 /* ImageTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C86AB69228B3B5100A81BA1 /* ImageTask.swift */; };
+		0C880532242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C880531242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift */; };
 		0C8D7BD31D9DBF1600D12EB7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD21D9DBF1600D12EB7 /* AppDelegate.swift */; };
 		0C8D7BD51D9DBF1600D12EB7 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD41D9DBF1600D12EB7 /* ViewController.swift */; };
 		0C8D7BD81D9DBF1600D12EB7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD61D9DBF1600D12EB7 /* Main.storyboard */; };
@@ -176,6 +177,7 @@
 		0C7C068D1BCA888800089D7F /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		0C7C068E1BCA888800089D7F /* XCTestCaseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtensions.swift; sourceTree = "<group>"; };
 		0C86AB69228B3B5100A81BA1 /* ImageTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTask.swift; sourceTree = "<group>"; };
+		0C880531242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDecodingTests.swift; sourceTree = "<group>"; };
 		0C8D74201D9D6EEB0036349E /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		0C8D7BD01D9DBF1600D12EB7 /* Nuke Tests Host.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Nuke Tests Host.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C8D7BD21D9DBF1600D12EB7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				0C6D0A8B20E57C810037B68F /* ImagePipelineDataCachingTests.swift */,
 				2DFD93AF233A6AB300D84DB9 /* ImagePipelineProcessorTests.swift */,
 				0C45706A2377874500AB20DD /* ImagePipelineEventsTests.swift */,
+				0C880531242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift */,
 				0C7C06871BCA888800089D7F /* ImageCacheTests.swift */,
 				0C7C06881BCA888800089D7F /* ImageProcessingTests.swift */,
 				0C70D9772089017500A49DAC /* ImageDecoderTests.swift */,
@@ -736,6 +739,7 @@
 				0C69FA4E1D4E222D00DA9982 /* ImagePreheaterTests.swift in Sources */,
 				0CCBB530217D0B6A0026F552 /* ImageViewIntegrationTests.swift in Sources */,
 				0CB26807208F25C2004C83F4 /* DataCacheTests.swift in Sources */,
+				0C880532242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift in Sources */,
 				0C7C06991BCA888800089D7F /* XCTestCaseExtensions.swift in Sources */,
 				0CE5F6832156386B0046609F /* ResumableDataTests.swift in Sources */,
 				0CAAB0101E45D6DA00924450 /* NukeExtensions.swift in Sources */,

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -126,6 +126,18 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
 
 // MARK: - ImageResponse
 
+public struct ImageContainer {
+    public let image: PlatformImage
+    public let data: Data?
+    public let userInfo: [AnyHashable: Any]
+
+    public init(image: PlatformImage, data: Data?, userInfo: [AnyHashable: Any]) {
+        self.image = image
+        self.data = data
+        self.userInfo = userInfo
+    }
+}
+
 /// Represents an image response.
 public final class ImageResponse {
     public let image: PlatformImage

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -131,7 +131,7 @@ public struct ImageContainer {
     public let data: Data?
     public let userInfo: [AnyHashable: Any]
 
-    public init(image: PlatformImage, data: Data?, userInfo: [AnyHashable: Any]) {
+    public init(image: PlatformImage, data: Data? = nil, userInfo: [AnyHashable: Any] = [:]) {
         self.image = image
         self.data = data
         self.userInfo = userInfo
@@ -140,14 +140,22 @@ public struct ImageContainer {
 
 /// Represents an image response.
 public final class ImageResponse {
-    public let image: PlatformImage
+    public let container: ImageContainer
+    /// A convenience computed property which returns an image from the container.
+    public var image: PlatformImage { return container.image }
     public let urlResponse: URLResponse?
     // the response is only nil when new disk cache is enabled (it only stores
     // data for now, but this might change in the future).
     public let scanNumber: Int?
 
     public init(image: PlatformImage, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
-        self.image = image
+        self.container = ImageContainer(image: image)
+        self.urlResponse = urlResponse
+        self.scanNumber = scanNumber
+    }
+
+    public init(container: ImageContainer, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
+        self.container = container
         self.urlResponse = urlResponse
         self.scanNumber = scanNumber
     }
@@ -157,7 +165,8 @@ public final class ImageResponse {
             guard let output = transformation(image) else {
                 return nil
             }
-            return ImageResponse(image: output, urlResponse: urlResponse, scanNumber: scanNumber)
+            let container = ImageContainer(image: output, data: self.container.data, userInfo: self.container.userInfo)
+            return ImageResponse(container: container, urlResponse: urlResponse, scanNumber: scanNumber)
         }
     }
 }

--- a/Tests/ImagePipelineDecodingTests.swift
+++ b/Tests/ImagePipelineDecodingTests.swift
@@ -1,0 +1,57 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+
+class ImagePipelineDecodingTests: XCTestCase {
+    var dataLoader: MockDataLoader!
+    var pipeline: ImagePipeline!
+
+    override func setUp() {
+        super.setUp()
+
+        dataLoader = MockDataLoader()
+        pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+    }
+
+    func testExperimentalDecoder() throws {
+        // Given
+        let decoder = MockExperimentalDecoder()
+
+        let dummyImage = PlatformImage()
+        let dummyData = "123".data(using: .utf8)
+        decoder._decode = { data in
+            return ImageContainer(image: dummyImage, data: dummyData, userInfo: ["a": 1])
+        }
+
+        pipeline = pipeline.reconfigured {
+            $0.makeImageDecoder = { _ in decoder }
+        }
+
+        // When
+        var response: ImageResponse?
+        expect(pipeline).toLoadImage(with: Test.request, completion: {
+            response = $0.value
+        })
+        wait()
+
+        // Then
+        let container = try XCTUnwrap(response?.container)
+        XCTAssertNotNil(container.image)
+        XCTAssertEqual(container.data, dummyData)
+        XCTAssertEqual(container.userInfo["a"] as? Int, 1)
+    }
+}
+
+private final class MockExperimentalDecoder: _ImageDecoding {
+    var _decode: ((Data) -> ImageContainer?)!
+
+    func decode(data: Data) -> ImageContainer? {
+        return _decode(data)
+    }
+}


### PR DESCRIPTION
- Add new experimental `_ImageDecoding` protocol

```swift
public protocol _ImageDecoding: ImageDecoding {
    func decode(data: Data) -> ImageContainer?
    func decodeProgressively(data: Data) -> ImageContainer?
}
```

- Add `ImageContainer` type which contains image along with associated image data (optional, depends on decoder), and user info.
- Add SVG example in README
- Add `ImageDecoders.Empty`

> All change are fully backward comparably, nothing is deprecated

