### PR TITLE
Image Decoding Improvements

### DIFF
--- a/Demo/NukeDemo.xcodeproj/project.pbxproj
+++ b/Demo/NukeDemo.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kean/Nuke";
 			requirement = {
-				branch = master;
+				branch = "image-decoding-guide";
 				kind = branch;
 			};
 		};

--- a/Demo/NukeDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/NukeDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
         "package": "Nuke",
         "repositoryURL": "https://github.com/kean/Nuke",
         "state": {
-          "branch": "master",
-          "revision": "e881a95f843ab21bfeaaaf9456c104ca607c5924",
+          "branch": "image-decoding-guide",
+          "revision": "b1b26e148d993deaff5066a4d88a6f4a291b4bab",
           "version": null
         }
       },

--- a/Demo/Sources/AlamofireIntegrationDemoViewController.swift
+++ b/Demo/Sources/AlamofireIntegrationDemoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/AnimatedImageUsingVideoViewController.swift
+++ b/Demo/Sources/AnimatedImageUsingVideoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/AnimatedImageUsingVideoViewController.swift
+++ b/Demo/Sources/AnimatedImageUsingVideoViewController.swift
@@ -6,13 +6,9 @@ import UIKit
 import Nuke
 import AVKit
 
-private let textViewCellReuseID = "textViewReuseID"
-private let imageCellReuseID = "imageCellReuseID"
+// MARK: - AnimatedImageUsingVideoViewController
 
 final class AnimatedImageUsingVideoViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
-    private var imageURLs = [URL]()
-    private let storage = try! TemporaryVideoStorage()
-
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(collectionViewLayout: UICollectionViewFlowLayout())
     }
@@ -24,11 +20,8 @@ final class AnimatedImageUsingVideoViewController: UICollectionViewController, U
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        MP4Decoder.register()
-
-        imageURLs = [
-            URL(string: "https://kean.github.io/videos/cat_video.mp4")!
-        ]
+        TemporaryVideoStorage.shared.removeAll()
+        ImageDecoders.MP4.register()
 
         collectionView?.register(VideoCell.self, forCellWithReuseIdentifier: imageCellReuseID)
         if #available(iOS 13.0, *) {
@@ -54,20 +47,7 @@ final class AnimatedImageUsingVideoViewController: UICollectionViewController, U
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: imageCellReuseID, for: indexPath) as! VideoCell
-        cell.storage = storage
-
-        // Do it once somewhere where you configure the app / pipelines.
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
-
-        cell.activityIndicator.startAnimating()
-        loadImage(
-            with: imageURLs[indexPath.row],
-            into: cell,
-            completion: { [weak cell] _ in
-                cell?.activityIndicator.stopAnimating()
-            }
-        )
-
+        cell.setVideo(with: imageURLs[indexPath.row])
         return cell
     }
 
@@ -78,82 +58,76 @@ final class AnimatedImageUsingVideoViewController: UICollectionViewController, U
     }
 }
 
+private let imageCellReuseID = "imageCellReuseID"
+
+private let imageURLs = [
+    URL(string: "https://kean.github.io/videos/cat_video.mp4")!
+]
+
 // MARK: - MP4Decoder
 
-final class MP4Decoder: ImageDecoding {
-    func decode(data: Data, isFinal: Bool) -> UIImage? {
-        guard isFinal else { return nil }
-
-        let image = UIImage()
-        image.animatedImageData = data
-        image.mimeType = "video/mp4"
-        return image
-    }
-
-    private static func _match(_ data: Data, offset: Int = 0, _ numbers: [UInt8]) -> Bool {
-        guard data.count >= numbers.count + offset else { return false }
-        return !zip(numbers.indices, numbers).contains { (index, number) in
-            data[index + offset] != number
+private extension ImageDecoders {
+    final class MP4: _ImageDecoding {
+        func decode(_ data: Data) -> ImageContainer? {
+            var container = ImageContainer(image: UIImage())
+            container.data = data
+            container.userInfo["mime-type"] = "video/mp4"
+            return container
         }
-    }
 
-    private static var isRegistered: Bool = false
-
-    static func register() {
-        guard !isRegistered else { return }
-        isRegistered = true
-        ImageDecoderRegistry.shared.register {
-            // FIXME: these magic numbers are for:
-            // ftypisom - ISO Base Media file (MPEG-4) v1
-            // There are a bunch of other ways to create MP4
-            // https://www.garykessler.net/library/file_sigs.html
-            guard _match($0.data, offset: 4, [0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6F, 0x6D]) else {
-                return nil
+        private static func _match(_ data: Data, offset: Int = 0, _ numbers: [UInt8]) -> Bool {
+            guard data.count >= numbers.count + offset else { return false }
+            return !zip(numbers.indices, numbers).contains { (index, number) in
+                data[index + offset] != number
             }
-            return MP4Decoder()
         }
-    }
-}
 
-private var _imageFormatAK = "Nuke.ImageFormat.AssociatedKey"
+        private static var isRegistered: Bool = false
 
-private extension UIImage {
-    // At some point going to be available in the main repo.
-    var mimeType: String? {
-        get { return objc_getAssociatedObject(self, &_imageFormatAK) as? String }
-        set { objc_setAssociatedObject(self, &_imageFormatAK, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+        static func register() {
+            guard !isRegistered else { return }
+            isRegistered = true
+
+            ImageDecoderRegistry.shared.register {
+                // FIXME: these magic numbers are for:
+                // ftypisom - ISO Base Media file (MPEG-4) v1
+                // There are a bunch of other ways to create MP4
+                // https://www.garykessler.net/library/file_sigs.html
+                guard _match($0.data, offset: 4, [0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6F, 0x6D]) else {
+                    return nil
+                }
+                return MP4()
+            }
+        }
     }
 }
 
 // MARK: - VideoCell
 
 /// - warning: This is proof of concept, please don't use in production.
-private final class VideoCell: UICollectionViewCell, Nuke.Nuke_ImageDisplaying {
+private final class VideoCell: UICollectionViewCell {
     private var requestId: Int = 0
     private var videoURL: URL?
-    var storage: TemporaryVideoStorage!
+    private var task: ImageTask?
 
+    private let spinner: UIActivityIndicatorView
     private var player: AVPlayer?
     private var playerLayer: AVPlayerLayer?
     private var playerLooper: AnyObject?
-
-    let activityIndicator: UIActivityIndicatorView
 
     deinit {
         prepareForReuse()
     }
 
     override init(frame: CGRect) {
-        activityIndicator = UIActivityIndicatorView(style: .gray)
+        spinner = UIActivityIndicatorView(style: .gray)
 
         super.init(frame: frame)
 
-        self.backgroundColor = UIColor(white: 235.0 / 255.0, alpha: 1.0)
+        backgroundColor = UIColor(white: 235.0 / 255.0, alpha: 1.0)
 
-        contentView.addSubview(activityIndicator)
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addConstraint(NSLayoutConstraint(item: activityIndicator, attribute: .centerX, relatedBy: .equal, toItem: contentView, attribute: .centerX, multiplier: 1.0, constant: 0.0))
-        contentView.addConstraint(NSLayoutConstraint(item: activityIndicator, attribute: .centerY, relatedBy: .equal, toItem: contentView, attribute: .centerY, multiplier: 1.0, constant: 0.0))
+        contentView.addSubview(spinner)
+        spinner.centerInSuperview()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -163,25 +137,40 @@ private final class VideoCell: UICollectionViewCell, Nuke.Nuke_ImageDisplaying {
     override func prepareForReuse() {
         super.prepareForReuse()
 
-        videoURL.map(storage.removeData(for:))
+        videoURL.map(TemporaryVideoStorage.shared.removeData(for:))
         playerLayer?.removeFromSuperlayer()
         playerLayer = nil
         player = nil
     }
 
-    func nuke_display(image: UIImage?) {
-        prepareForReuse()
+    func setVideo(with url: URL) {
+        let pipeline = ImagePipeline.shared
+        let request = ImageRequest(url: url)
 
-        guard let data = image?.animatedImageData else {
+        if let response = pipeline.cachedResponse(for: request) {
+            return display(response: response)
+        }
+
+        spinner.startAnimating()
+        task = pipeline.loadImage(with: request) { [weak self] result in
+            self?.spinner.stopAnimating()
+            if case let .success(response) = result {
+                self?.display(response: response)
+            }
+        }
+    }
+
+    private func display(response: ImageResponse) {
+        guard let data = response.container.data else {
             return
         }
 
-        assert(image?.mimeType == "video/mp4")
+        assert(response.container.userInfo["mime-type"] as? String == "video/mp4")
 
         self.requestId += 1
         let requestId = self.requestId
 
-        storage.storeData(data) { [weak self] url in
+        TemporaryVideoStorage.shared.storeData(data) { [weak self] url in
             guard self?.requestId == requestId else { return }
             self?._playVideoAtURL(url)
         }
@@ -211,6 +200,9 @@ private final class TemporaryVideoStorage {
     private let path: URL
     private let _queue = DispatchQueue(label: "com.github.kean.Nuke.TemporaryVideoStorage.Queue")
 
+    // Ignoring error handling for simplicity.
+    static let shared = try! TemporaryVideoStorage()
+
     init() throws {
         guard let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
@@ -234,6 +226,14 @@ private final class TemporaryVideoStorage {
     func removeData(for url: URL) {
         _queue.async {
             try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    func removeAll() {
+        _queue.async {
+            // Clear the contents that could potentially was left from the previous session.
+            try? FileManager.default.removeItem(at: self.path)
+            try? FileManager.default.createDirectory(at: self.path, withIntermediateDirectories: true, attributes: nil)
         }
     }
 }

--- a/Demo/Sources/AnimatedImageViewController.swift
+++ b/Demo/Sources/AnimatedImageViewController.swift
@@ -1,17 +1,14 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke
 import Gifu
 
-private let textViewCellReuseID = "textViewReuseID"
-private let imageCellReuseID = "imageCellReuseID"
+// MARK: - AnimatedImageViewController
 
 final class AnimatedImageViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
-    private var imageURLs = [URL]()
-
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(collectionViewLayout: UICollectionViewFlowLayout())
     }
@@ -23,7 +20,7 @@ final class AnimatedImageViewController: UICollectionViewController, UICollectio
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        collectionView?.register(UICollectionViewCell.self, forCellWithReuseIdentifier: textViewCellReuseID)
+        collectionView?.register(HeaderCell.self, forCellWithReuseIdentifier: headerCellReuseId)
         collectionView?.register(AnimatedImageCell.self, forCellWithReuseIdentifier: imageCellReuseID)
 
         if #available(iOS 13.0, *) {
@@ -35,18 +32,6 @@ final class AnimatedImageViewController: UICollectionViewController, UICollectio
         let layout = collectionViewLayout as! UICollectionViewFlowLayout
         layout.sectionInset = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         layout.minimumInteritemSpacing = 8
-
-        let root = "https://cloud.githubusercontent.com/assets"
-        imageURLs = [
-            URL(string: "\(root)/1567433/6505557/77ff05ac-c2e7-11e4-9a09-ce5b7995cad0.gif")!,
-            URL(string: "\(root)/1567433/6505565/8aa02c90-c2e7-11e4-8127-71df010ca06d.gif")!,
-            URL(string: "\(root)/1567433/6505571/a28a6e2e-c2e7-11e4-8161-9f39cc3bb8df.gif")!,
-            URL(string: "\(root)/1567433/6505576/b785a8ac-c2e7-11e4-831a-666e2b064b95.gif")!,
-            URL(string: "\(root)/1567433/6505579/c88c77ca-c2e7-11e4-88ad-d98c7360602d.gif")!,
-            URL(string: "\(root)/1567433/6505595/def06c06-c2e7-11e4-9cdf-d37d28618af0.gif")!,
-            URL(string: "\(root)/1567433/6505634/26e5dad2-c2e8-11e4-89c3-3c3a63110ac0.gif")!,
-            URL(string: "\(root)/1567433/6505643/42eb3ee8-c2e8-11e4-8666-ac9c8e1dc9b5.gif")!
-        ]
     }
 
     // MARK: Collection View
@@ -56,48 +41,19 @@ final class AnimatedImageViewController: UICollectionViewController, UICollectio
     }
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return section == 0 ? 1 : imageURLs.count
+        switch section {
+        case 0: return 1
+        default: return imageURLs.count
+        }
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        if indexPath.section == 0 {
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: textViewCellReuseID, for: indexPath)
-            var textView: UITextView! = cell.viewWithTag(14) as? UITextView
-            if textView == nil {
-                textView = UITextView()
-                if #available(iOS 13.0, *) {
-                    textView.textColor = UIColor.label
-                } else {
-                    textView.textColor = UIColor.black
-                }
-                textView.font = UIFont.systemFont(ofSize: 16)
-                textView.isEditable = false
-                textView.textAlignment = .center
-                textView.dataDetectorTypes = .link
-
-                cell.contentView.addSubview(textView)
-                textView.frame = cell.contentView.bounds
-                textView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-
-                textView.text = "Images by Florian de Looij\n http://flrngif.tumblr.com"
-            }
-            return cell
-        } else {
+        switch indexPath.section {
+        case 0:
+            return collectionView.dequeueReusableCell(withReuseIdentifier: headerCellReuseId, for: indexPath)
+        default:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: imageCellReuseID, for: indexPath) as! AnimatedImageCell
-
-            // Do it once somewhere where you configure the app / pipelines.
-            ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
-
-            cell.activityIndicator.startAnimating()
-            loadImage(
-                with: imageURLs[indexPath.row],
-                options: ImageLoadingOptions(transition: .fadeIn(duration: 0.33)),
-                into: cell.imageView,
-                completion: { [weak cell] _ in
-                    cell?.activityIndicator.stopAnimating()
-                }
-            )
-
+            cell.setImage(with: imageURLs[indexPath.row])
             return cell
         }
     }
@@ -105,56 +61,126 @@ final class AnimatedImageViewController: UICollectionViewController, UICollectio
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let layout = collectionViewLayout as! UICollectionViewFlowLayout
         let width = view.bounds.size.width - layout.sectionInset.left - layout.sectionInset.right
-        if indexPath.section == 0 {
+        switch indexPath.section {
+        case 0:
             return CGSize(width: width, height: 50)
-        } else {
+        default:
             return CGSize(width: width, height: width)
         }
     }
 }
 
-final class AnimatedImageCell: UICollectionViewCell {
-    let imageView: GIFImageView
-    let activityIndicator: UIActivityIndicatorView
+private let headerCellReuseId = "headerCellReuseID"
+private let imageCellReuseID = "imageCellReuseID"
+
+// MARK: - Image URLs
+
+private let root = "https://cloud.githubusercontent.com/assets"
+private let imageURLs = [
+    URL(string: "\(root)/1567433/6505557/77ff05ac-c2e7-11e4-9a09-ce5b7995cad0.gif")!,
+    URL(string: "\(root)/1567433/6505565/8aa02c90-c2e7-11e4-8127-71df010ca06d.gif")!,
+    URL(string: "\(root)/1567433/6505571/a28a6e2e-c2e7-11e4-8161-9f39cc3bb8df.gif")!,
+    URL(string: "\(root)/1567433/6505576/b785a8ac-c2e7-11e4-831a-666e2b064b95.gif")!,
+    URL(string: "\(root)/1567433/6505579/c88c77ca-c2e7-11e4-88ad-d98c7360602d.gif")!,
+    URL(string: "\(root)/1567433/6505595/def06c06-c2e7-11e4-9cdf-d37d28618af0.gif")!,
+    URL(string: "\(root)/1567433/6505634/26e5dad2-c2e8-11e4-89c3-3c3a63110ac0.gif")!,
+    URL(string: "\(root)/1567433/6505643/42eb3ee8-c2e8-11e4-8666-ac9c8e1dc9b5.gif")!
+]
+
+// MARK: - AnimatedImageCell
+
+private final class AnimatedImageCell: UICollectionViewCell {
+    private let imageView: GIFImageView
+    private let spinner: UIActivityIndicatorView
+    private var task: ImageTask?
 
     override init(frame: CGRect) {
         imageView = GIFImageView()
-        activityIndicator = UIActivityIndicatorView(style: .gray)
-
-        super.init(frame: frame)
-
-        self.backgroundColor = UIColor(white: 235.0 / 255.0, alpha: 1.0)
-
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
 
+        spinner = UIActivityIndicatorView(style: .gray)
+
+        super.init(frame: frame)
+
+        backgroundColor = UIColor(white: 235.0 / 255.0, alpha: 1.0)
+
         contentView.addSubview(imageView)
-        imageView.frame = contentView.bounds
-        imageView.autoresizingMask =  [.flexibleWidth, .flexibleHeight]
+        contentView.addSubview(spinner)
 
-        contentView.addSubview(activityIndicator)
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addConstraint(NSLayoutConstraint(item: activityIndicator, attribute: .centerX, relatedBy: .equal, toItem: contentView, attribute: .centerX, multiplier: 1.0, constant: 0.0))
-        contentView.addConstraint(NSLayoutConstraint(item: activityIndicator, attribute: .centerY, relatedBy: .equal, toItem: contentView, attribute: .centerY, multiplier: 1.0, constant: 0.0))
-    }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        imageView.nuke_display(image: nil)
+        imageView.pinToSuperview()
+        spinner.centerInSuperview()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
+
+    func setImage(with url: URL) {
+        let pipeline = ImagePipeline.shared
+        let request = ImageRequest(url: url)
+
+        if let response = pipeline.cachedResponse(for: request) {
+            return display(response: response)
+        }
+
+        spinner.startAnimating()
+        task = pipeline.loadImage(with: request) { [weak self] result in
+            self?.spinner.stopAnimating()
+            if case let .success(response) = result {
+                self?.display(response: response)
+                self?.animateFadeIn()
+            }
+        }
+    }
+
+    private func display(response: ImageResponse) {
+        if let data = response.container.data {
+            imageView.animate(withGIFData: data)
+        } else {
+            imageView.image = response.image
+        }
+    }
+
+    private func animateFadeIn() {
+        imageView.alpha = 0
+        UIView.animate(withDuration: 0.33) { self.imageView.alpha = 1 }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        task?.cancel()
+        spinner.stopAnimating()
+        imageView.prepareForReuse()
+    }
 }
 
-extension GIFImageView {
-    @objc open override func nuke_display(image: UIImage?) {
-        prepareForReuse()
-        if let data = image?.animatedImageData {
-            animate(withGIFData: data)
+// MARK: - HeaderCell
+
+private final class HeaderCell: UICollectionViewCell {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        let textView = UITextView()
+        if #available(iOS 13.0, *) {
+            textView.textColor = UIColor.label
         } else {
-            self.image = image
+            textView.textColor = UIColor.black
         }
+        textView.font = UIFont.systemFont(ofSize: 16)
+        textView.isEditable = false
+        textView.textAlignment = .center
+        textView.dataDetectorTypes = .link
+
+        contentView.addSubview(textView)
+        textView.frame = contentView.bounds
+        textView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+
+        textView.text = "Images by Florian de Looij\n http://flrngif.tumblr.com"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
     }
 }

--- a/Demo/Sources/AppDelegate.swift
+++ b/Demo/Sources/AppDelegate.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/BasicDemoViewController.swift
+++ b/Demo/Sources/BasicDemoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/DataCachingDemoViewController.swift
+++ b/Demo/Sources/DataCachingDemoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/Helpers/Utilities.swift
+++ b/Demo/Sources/Helpers/Utilities.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke
@@ -8,21 +8,20 @@ import Nuke
 extension UIView {
     func pinToSuperview() {
         translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate(
-            [topAnchor.constraint(equalTo: superview!.topAnchor),
-             bottomAnchor.constraint(equalTo: superview!.bottomAnchor),
-             leftAnchor.constraint(equalTo: superview!.leftAnchor),
-             rightAnchor.constraint(equalTo: superview!.rightAnchor)]
-        )
-
+        NSLayoutConstraint.activate([
+            topAnchor.constraint(equalTo: superview!.topAnchor),
+            bottomAnchor.constraint(equalTo: superview!.bottomAnchor),
+            leftAnchor.constraint(equalTo: superview!.leftAnchor),
+            rightAnchor.constraint(equalTo: superview!.rightAnchor)
+        ])
     }
 
     func centerInSuperview() {
         translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate(
-            [centerXAnchor.constraint(equalTo: superview!.centerXAnchor),
-             centerYAnchor.constraint(equalTo: superview!.centerYAnchor)]
-        )
+        NSLayoutConstraint.activate([
+            centerXAnchor.constraint(equalTo: superview!.centerXAnchor),
+            centerYAnchor.constraint(equalTo: superview!.centerYAnchor)
+        ])
     }
 }
 

--- a/Demo/Sources/ImagePipelineSettingsViewController.swift
+++ b/Demo/Sources/ImagePipelineSettingsViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/ImageProcessingDemoViewController.swift
+++ b/Demo/Sources/ImageProcessingDemoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/MenuViewController.swift
+++ b/Demo/Sources/MenuViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/PrefetchingDemoViewController.swift
+++ b/Demo/Sources/PrefetchingDemoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/ProgressiveDecodingDemoViewController.swift
+++ b/Demo/Sources/ProgressiveDecodingDemoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Demo/Sources/RateLimiterDemoViewController.swift
+++ b/Demo/Sources/RateLimiterDemoViewController.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2019 Alexander Grebenyuk (github.com/kean).
+// Copyright (c) 2015-2020 Alexander Grebenyuk (github.com/kean).
 
 import UIKit
 import Nuke

--- a/Documentation/Guides/image-formats.md
+++ b/Documentation/Guides/image-formats.md
@@ -4,8 +4,8 @@ Nuke offers built-in support for basic image formats like `jpeg`, `png`, and `he
 
 - [`gif`](#gif)
 - [`svg`](#svg)
+- [`webp`](#webp)
 - `pdf`
-- [`webp`](https://developers.google.com/speed/webp)
 
 Nuke is capable of driving progressive decoding, animated image rendering, progressive animated image rendering, drawing vector images directly or converting them to bitmaps, parsing thumbnails included in the image containers, and more.
 
@@ -176,3 +176,7 @@ ImagePipeline.shared.loadImage(with: url) { [weak self] result in
 ```
 
 > Please keep in mind that most of these frameworks are limited in terms of supported SVG features.
+
+### WebP
+
+[WebP](https://developers.google.com/speed/webp) support is provided by [Nuke WebP Plugin](https://github.com/ryokosuge/Nuke-WebP-Plugin) built by [Ryo Kosuge](https://github.com/ryokosuge). Please follow the instructions from the repo.

--- a/Documentation/Guides/image-formats.md
+++ b/Documentation/Guides/image-formats.md
@@ -2,8 +2,8 @@
 
 Nuke offers built-in support for basic image formats like `jpeg`, `png`, and `heif`. But it also has infrastructure capable of supporting a variety of image formats and features of these formats, including but not limited to: 
 
-- `gif`
-- `svg`
+- [`gif`](#gif)
+- [`svg`](#svg)
 - `pdf`
 - [`webp`](https://developers.google.com/speed/webp)
 
@@ -145,3 +145,34 @@ final class ImageView: UIView {
 To see this code in action, check out the demo project attached in the repo.
 
 > `GIF` is not the most efficient format for transferring and displaying animated images. The current best practice is to [use short videos instead of GIFs](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/) (e.g. `MP4`, `WebM`). There is a PoC available in the demo project which uses Nuke to load, cache and display an `MP4` video.
+
+### SVG
+
+To render SVG, consider using [SwiftSVG](https://github.com/mchoe/SwiftSVG), [SVG](https://github.com/SVGKit/SVGKit), or other frameworks. Here is an example of `SwiftSVG` being used to render vector images.
+
+```swift
+ImageDecoderRegistry.shared.register { context in
+    // Replace this with whatever works for. There are no magic numbers
+    // for SVG like are used for other binary formats, it's just XML.
+    let isSVG = context.urlResponse?.url?.absoluteString.hasSuffix(".svg") ?? false
+    return isSVG ? ImageDecoders.Empty() : nil
+}
+
+let url = URL(string: "https://upload.wikimedia.org/wikipedia/commons/9/9d/Swift_logo.svg")!
+ImagePipeline.shared.loadImage(with: url) { [weak self] result in
+    guard let self = self, let data = try? result.get().container.data else {
+        return
+    }
+    // You can render image using whatever size you want, vector!
+    let targetBounds = CGRect(origin: .zero, size: CGSize(width: 300, height: 300))
+    let svgView = UIView(SVGData: data) { layer in
+        layer.fillColor = UIColor.orange.cgColor
+        layer.resizeToFit(targetBounds)
+    }
+    self.view.addSubview(svgView)
+    svgView.bounds = targetBounds
+    svgView.center = self.view.center
+}
+```
+
+> Please keep in mind that most of these frameworks are limited in terms of supported SVG features.

--- a/Documentation/Guides/image-formats.md
+++ b/Documentation/Guides/image-formats.md
@@ -14,6 +14,7 @@ Nuke is capable of driving progressive decoding, animated image rendering, progr
   * [`ImageEncoders.Default`](#-imageencodersdefault-)
   * [`ImageEncoders.ImageIO`](#-imageencodersimageio-)
 - [Supported Formats](#supported-formats)
+  * [Basic Formats (JPEG, PNG, etc)](#basic-image-formats--jpeg--png--etc-)
   * [Progressive JPEG](#progressive-jpeg)
   * [HEIF](#heif)
   * [GIF](#gif)
@@ -164,6 +165,21 @@ let data = encoder.encode(image: image)
 ```
 
 ## Supported Formats
+
+### Basic Image Formats (JPEG, PNG, etc)
+
+Any [format natively supported](https://developer.apple.com/library/archive/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/LoadingImages/LoadingImages.html#//apple_ref/doc/uid/TP40010156-CH17-SW7) by the platform, is also supported by Nuke. This includes:
+
+- PNG
+- TIFF
+- JPEG
+- GIF
+- BMP
+- ICO
+- CUR
+- XBM
+
+You can use the basic `UIImageView`/`NSImageView`/`WKInterfaceImage` to render the images of any of the natively supported formats.
 
 ### Progressive JPEG
 

--- a/Documentation/Guides/image-formats.md
+++ b/Documentation/Guides/image-formats.md
@@ -2,10 +2,10 @@
 
 Nuke offers built-in support for basic image formats like `jpeg`, `png`, and `heif`. But it also has infrastructure capable of supporting a variety of image formats and features of these formats, including but not limited to: 
 
+- [`heif`](#heif)
 - [`gif`](#gif)
 - [`svg`](#svg)
 - [`webp`](#webp)
-- `pdf`
 
 Nuke is capable of driving progressive decoding, animated image rendering, progressive animated image rendering, drawing vector images directly or converting them to bitmaps, parsing thumbnails included in the image containers, and more.
 
@@ -93,9 +93,36 @@ TBD:
 
 ## Supported Formats
 
+### HEIF
+
+**Decoding**
+
+The default image decoder `ImageDecoders.Default` supports [HEIF](https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format)
+
+**Encoding**
+
+The default image encoder `ImageEncoders.Default` supports [HEIF](https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format), however it doesn't use it by default. To enable it, use a new experimental `ImageEncoder._isHEIFPreferred` option.
+
+To encode images in HEIF directly, use `ImageEncoders.ImageIO`:
+
+```swift
+let image: UIImage
+let encoder = ImageEncoders.ImageIO(type: .heif, compressionRatio: 0.8)
+let data = encoder.encode(image: image)
+```
+One of the scenarios in which you may find this option useful is data caching. By default, the pipeline stores only the original image data. To store downloaded and processed images instead, set `dataCacheOptions.storedItems` to `[.finalImage]`. With HEIF encoding enabled, you can save a bit of disk space by transcoding downloaded images into HEIF.
+
+**Rendering**
+
+To render HEIF images, you can use the basic `UIImageView`/`NSImageView`/`WKInterfaceImage`.
+
 ### GIF
 
+**Decoding**
+
 The default image decoder `ImageDecoders.Default` automatically recognized GIFs. It creates an image container (`ImageContainer`) with the first frame of the GIF as placeholder and attaches the original image data to the container.
+
+**Rendering**
 
 To render animated GIFs, please consider using one of the open-souce GIF rendering engines, like [Gifu](https://github.com/kaishin/Gifu), [FLAnimatedImage](https://github.com/Flipboard/FLAnimatedImage), or other.
 
@@ -148,6 +175,12 @@ To see this code in action, check out the demo project attached in the repo.
 
 ### SVG
 
+**Decoding**
+
+There is currently no support for decoding SVG images and rendering them into bitmap (`UIImage`/`NSImage`). What you can do instead is use `ImageDecoders.Empty` to pass the original image data to your SVG-enabled view and render is using an external mechanism.
+
+**Rendering**
+
 To render SVG, consider using [SwiftSVG](https://github.com/mchoe/SwiftSVG), [SVG](https://github.com/SVGKit/SVGKit), or other frameworks. Here is an example of `SwiftSVG` being used to render vector images.
 
 ```swift
@@ -178,5 +211,7 @@ ImagePipeline.shared.loadImage(with: url) { [weak self] result in
 > Please keep in mind that most of these frameworks are limited in terms of supported SVG features.
 
 ### WebP
+
+**Decoding**
 
 [WebP](https://developers.google.com/speed/webp) support is provided by [Nuke WebP Plugin](https://github.com/ryokosuge/Nuke-WebP-Plugin) built by [Ryo Kosuge](https://github.com/ryokosuge). Please follow the instructions from the repo.

--- a/Documentation/Guides/image-formats.md
+++ b/Documentation/Guides/image-formats.md
@@ -69,6 +69,8 @@ The decoder is created once and is reused across a single image decoding session
 >
 > You can also take advantage of `ImageRequestOptions.userInfo` to pass any kind of information that you might want to the decoder. For example, you may pass the target image view size to the SVG decoder to let it know the size of the image to create.  
 
+The decoding is performed in the background on the operation queue provided in `ImagePipeline.Configuration`. There is always only one decoding request at a time. The pipeline is not going to call `decodePariallyDownloadedData(_:)` until you are finished with the previous chuck.
+
 ## Built-In Image Decoders
 
 ### `ImageDecoders.Default`
@@ -87,4 +89,10 @@ Why is it useful? Let's say you want to render SVG using a third party framework
 
 ## Image Encoding Infrastructure
 
+TBD:
 
+## Supported Formats
+
+### GIF
+
+TBD:

--- a/Documentation/Guides/image-formats.md
+++ b/Documentation/Guides/image-formats.md
@@ -142,4 +142,6 @@ final class ImageView: UIView {
 }
 ```
 
+To see this code in action, check out the demo project attached in the repo.
+
 > `GIF` is not the most efficient format for transferring and displaying animated images. The current best practice is to [use short videos instead of GIFs](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/) (e.g. `MP4`, `WebM`). There is a PoC available in the demo project which uses Nuke to load, cache and display an `MP4` video.

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		0C8D7BE81D9DC02B00D12EB7 /* Nuke Performance Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Nuke Performance Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C8DC722209B842600084AA6 /* cat.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = cat.gif; sourceTree = "<group>"; };
 		0C8EA64E242F951000E317C9 /* Troubleshooting.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Troubleshooting.md; sourceTree = "<group>"; };
+		0C8EA64F242FA2FD00E317C9 /* image-formats.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "image-formats.md"; sourceTree = "<group>"; };
 		0C9174901BAE99EE004A7905 /* Nuke.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nuke.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C94466D1D47EC0E006DB314 /* ImageViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewTests.swift; sourceTree = "<group>"; };
 		0C9B6E7520B9F3E2001924B8 /* ImagePipelineDeduplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDeduplicationTests.swift; sourceTree = "<group>"; };
@@ -448,6 +449,7 @@
 			isa = PBXGroup;
 			children = (
 				0CDB92791DAF9BA500002905 /* Installation Guide.md */,
+				0C8EA64F242FA2FD00E317C9 /* image-formats.md */,
 				0C8EA64E242F951000E317C9 /* Troubleshooting.md */,
 				0CDB927A1DAF9BA500002905 /* Performance Guide.md */,
 				0C66879A1E41EF2F00CEBFAE /* Third Party Libraries.md */,

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Nuke.loadImage(with: url, into: imageView)
 
 Nuke will check if the image exists in the memory cache, and if it does, will instantly display it. If not, the image data will be loaded, decoded, processed, and decompressed in the background.
 
-> See [Image Pipeline Overview](#h_design) to learn more.
+> See [Image Pipeline Overview](#h_design) to learn more about how images are downloaded and processed.
 
 ### In a List
 
@@ -93,6 +93,8 @@ let options = ImageLoadingOptions(
 ```
 
 > In case you want all image views to have the same behavior, you can modify `ImageLoadingOptions.shared`.
+
+Please keep in mind that the built-in extensions for image views are designed to get you up and running as quickly as possible. If you want to have more control, or use some of the advanced features, like animated images, it is recommended to use `ImagePipeline` directly in your custom views.
 
 ### `ImageRequest`
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuk
 
 To learn more about the pipeline and the supported formats, see the dedicated guides.
 
-- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg)
+- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg) | [WebP](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#webp) 
 - **Image Pipeline** ‣ [Overview](#h_design) | [Data Loading and Caching](#data-loading-and-caching) | [Resumable Downloads](#resumable-downloads) | [Memory Cache](#memory-cache) | [Deduplication](#deduplication) | [Performance](#performance) | [Extensions](#h_plugins)
 
 If you'd like to contribute to Nuke see [**Contributing**](#h_contribute).
@@ -475,10 +475,6 @@ let task = ImagePipeline.shared.loadImage(
     }
 )
 ```
-
-### WebP
-
-WebP support is provided by [Nuke WebP Plugin](https://github.com/ryokosuge/Nuke-WebP-Plugin) built by [Ryo Kosuge](https://github.com/ryokosuge). Please follow the instructions from the repo.
 
 ### RxNuke
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuk
 
 To learn more about the pipeline and the supported formats, see the dedicated guides.
 
-- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [HEIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#heif) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg) | [WebP](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#webp) 
+- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Progressive JPEG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#progressive-jpeg) | [HEIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#heif) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg) | [WebP](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#webp) 
 - **Image Pipeline** ‣ [Overview](#h_design) | [Data Loading and Caching](#data-loading-and-caching) | [Resumable Downloads](#resumable-downloads) | [Memory Cache](#memory-cache) | [Deduplication](#deduplication) | [Performance](#performance) | [Extensions](#h_plugins)
 
 If you'd like to contribute to Nuke see [**Contributing**](#h_contribute).

--- a/README.md
+++ b/README.md
@@ -351,8 +351,6 @@ isResumableDataEnabled = true
 And also a few global options shared between all pipelines:
 
 ```swift
-ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
-
 // Enable to start using `os_signpost` to monitor the pipeline
 // performance using Instruments.
 ImagePipeline.Configuration.isSignpostLoggingEnabled = false

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Nuke provides a simple and efficient way to download and display images in your 
 
 Nuke is easy to learn and use. Here is an overview of its APIs and features:
 
-- **Image View Extensions** ‣ [UI Extensions](#image-view-extensions) | [Placeholders, Transitions](#placeholders-transitions-content-modes) | [`ImageRequest`](#imagerequest) | [SwiftUI](#swiftui) | [Low Data Mode](#low-data-mode)
-- **Image Processing** ‣ [`Resize`](#resize) | [`GaussianBlur`, Core Image](#gaussianblur-core-image) | [Custom Processors](#custom-processors) | [Decompression](#decompression) | [Builder](#builder)
-- **Image Pipeline** ‣ [Load Image](#image-pipeline) | [`ImageTask`](#imagetask) | [Customize Image Pipeline](#customize-image-pipeline) | [Default Pipeline](#default-image-pipeline)
-- **Caching** ‣ [LRU Memory Cache](#lru-memory-cache) | [HTTP Disk Cache](#http-disk-cache) | [Aggressive LRU Disk Cache](#aggressive-lru-disk-cache)
-- **Advanced Features** ‣ [Preheat Images](#image-preheating) | [Progressive Decoding](#progressive-decoding) | [Combine](#combine) | [RxNuke](#rxnuke)
+- **Image View Extensions** ‣ [UI Extensions](#image-view-extensions) · [Placeholders, Transitions](#placeholders-transitions-content-modes) · [`ImageRequest`](#imagerequest) · [SwiftUI](#swiftui) · [Low Data Mode](#low-data-mode)
+- **Image Processing** ‣ [`Resize`](#resize) · [`GaussianBlur`, Core Image](#gaussianblur-core-image) · [Custom Processors](#custom-processors) · [Decompression](#decompression) · [Builder](#builder)
+- **Image Pipeline** ‣ [Load Image](#image-pipeline) · [`ImageTask`](#imagetask) · [Customize Image Pipeline](#customize-image-pipeline) · [Default Pipeline](#default-image-pipeline)
+- **Caching** ‣ [LRU Memory Cache](#lru-memory-cache) · [HTTP Disk Cache](#http-disk-cache) · [Aggressive LRU Disk Cache](#aggressive-lru-disk-cache)
+- **Advanced Features** ‣ [Preheat Images](#image-preheating) · [Progressive Decoding](#progressive-decoding) · [Combine](#combine) · [RxNuke](#rxnuke)
 
 To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuke/reference/8.0/index.html), and check out the demo project included in the repo. When you are ready to install, follow the [**Installation Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Installation%20Guide.md). See [**Requirements**](#h_requirements) for a list of supported platforms. If you encounter any issues, the [**Troubleshooting Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Troubleshooting.md) might help. 
 
@@ -35,8 +35,8 @@ To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuk
 
 To learn more about the pipeline and the supported formats, see the dedicated guides.
 
-- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Progressive JPEG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#progressive-jpeg) | [HEIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#heif) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg) | [WebP](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#webp) 
-- **Image Pipeline** ‣ [Overview](#h_design) | [Data Loading and Caching](#data-loading-and-caching) | [Resumable Downloads](#resumable-downloads) | [Memory Cache](#memory-cache) | [Deduplication](#deduplication) | [Performance](#performance) | [Extensions](#h_plugins)
+- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Progressive JPEG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#progressive-jpeg) · [HEIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#heif) · [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) · [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg) · [WebP](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#webp) 
+- **Image Pipeline** ‣ [Overview](#h_design) · [Data Loading and Caching](#data-loading-and-caching) · [Resumable Downloads](#resumable-downloads) · [Memory Cache](#memory-cache) · [Deduplication](#deduplication) · [Performance](#performance) · [Extensions](#h_plugins)
 
 If you'd like to contribute to Nuke see [**Contributing**](#h_contribute).
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ Nuke is easy to learn and use. Here is an overview of its APIs and features:
 - **Image Processing** ‣ [`Resize`](#resize) | [`GaussianBlur`, Core Image](#gaussianblur-core-image) | [Custom Processors](#custom-processors) | [Decompression](#decompression) | [Builder](#builder)
 - **Image Pipeline** ‣ [Load Image](#image-pipeline) | [`ImageTask`](#imagetask) | [Customize Image Pipeline](#customize-image-pipeline) | [Default Pipeline](#default-image-pipeline)
 - **Caching** ‣ [LRU Memory Cache](#lru-memory-cache) | [HTTP Disk Cache](#http-disk-cache) | [Aggressive LRU Disk Cache](#aggressive-lru-disk-cache)
-- **Advanced Features** ‣ [Preheat Images](#image-preheating) | [Progressive Decoding](#progressive-decoding) | [Animated Images](#animated-images) | [WebP](#webp) | [SVG](#svg) | [Combine](#combine) | [RxNuke](#rxnuke)
+- **Advanced Features** ‣ [Preheat Images](#image-preheating) | [Progressive Decoding](#progressive-decoding) | [WebP](#webp) | [SVG](#svg) | [Combine](#combine) | [RxNuke](#rxnuke)
 
 To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuke/reference/8.0/index.html), and check out the demo project included in the repo. When you are ready to install, follow the [**Installation Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Installation%20Guide.md). See [**Requirements**](#h_requirements) for a list of supported platforms. If you encounter any issues, the [**Troubleshooting Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Troubleshooting.md) might help. 
 
 <img src="https://img.shields.io/badge/supports-Swift%20Package%20Manager%2C%20CocoaPods%2C%20Carthage-green.svg">
 
-To learn about the image pipeline itself, see the dedicated section:
+To learn more about the pipeline and the supported formats, see the dedicated guides.
 
+- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif)
 - **Image Pipeline** ‣ [Overview](#h_design) | [Data Loading and Caching](#data-loading-and-caching) | [Resumable Downloads](#resumable-downloads) | [Memory Cache](#memory-cache) | [Deduplication](#deduplication) | [Performance](#performance) | [Extensions](#h_plugins)
 
 If you'd like to contribute to Nuke see [**Contributing**](#h_contribute).
@@ -472,40 +473,6 @@ let task = ImagePipeline.shared.loadImage(
     }
 )
 ```
-
-### Animated Images
-
-To enable animated image support, set `ImagePipeline.Configuration.isAnimatedImageDataEnabled` to `true`. If enabled, Nuke will attach `animatedImageData` to the downloaded animated images. You going to need data to render the images.
-
-There is no built-in way to render animated images, but there are multiple options available.
-
-**Option 1**. Install [FLAnimatedImage Plugin](https://github.com/kean/Nuke-FLAnimatedImage-Plugin) and follow the instructions.
-
-**Option 2**. Install [Gifu](https://github.com/kaishin/Gifu) directly. To configure Gifu to work with Nuke, all you need to do is add these lines in your project:
-
-```swift
-ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
-
-extension Gifu.GIFImageView {
-    @objc open override func nuke_display(image: Image?) {
-        prepareForReuse()
-        if let data = image?.animatedImageData {
-            animate(withGIFData: data)
-        } else {
-            self.image = image
-        }
-    }
-}
-```
-
-You can now start using Gifu.GIFImageView:
-
-```swift
-let view = Gifu.GIFImageView()
-Nuke.loadImage(with: URL(string: "http://.../cat.gif")!, into: view)
-```
-
-> `GIF` is not the most efficient format for transferring and displaying animated images. The current best practice is to [use short videos instead of GIFs](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/) (e.g. `MP4`, `WebM`). There is a PoC available in the demo project which uses Nuke to load, cache and display an `MP4` video.
 
 ### WebP
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuk
 
 To learn more about the pipeline and the supported formats, see the dedicated guides.
 
-- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg) | [WebP](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#webp) 
+- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [HEIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#heif) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg) | [WebP](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#webp) 
 - **Image Pipeline** ‣ [Overview](#h_design) | [Data Loading and Caching](#data-loading-and-caching) | [Resumable Downloads](#resumable-downloads) | [Memory Cache](#memory-cache) | [Deduplication](#deduplication) | [Performance](#performance) | [Extensions](#h_plugins)
 
 If you'd like to contribute to Nuke see [**Contributing**](#h_contribute).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Nuke is easy to learn and use. Here is an overview of its APIs and features:
 - **Image Processing** ‣ [`Resize`](#resize) | [`GaussianBlur`, Core Image](#gaussianblur-core-image) | [Custom Processors](#custom-processors) | [Decompression](#decompression) | [Builder](#builder)
 - **Image Pipeline** ‣ [Load Image](#image-pipeline) | [`ImageTask`](#imagetask) | [Customize Image Pipeline](#customize-image-pipeline) | [Default Pipeline](#default-image-pipeline)
 - **Caching** ‣ [LRU Memory Cache](#lru-memory-cache) | [HTTP Disk Cache](#http-disk-cache) | [Aggressive LRU Disk Cache](#aggressive-lru-disk-cache)
-- **Advanced Features** ‣ [Preheat Images](#image-preheating) | [Progressive Decoding](#progressive-decoding) | [WebP](#webp) | [Combine](#combine) | [RxNuke](#rxnuke)
+- **Advanced Features** ‣ [Preheat Images](#image-preheating) | [Progressive Decoding](#progressive-decoding) | [Combine](#combine) | [RxNuke](#rxnuke)
 
 To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuke/reference/8.0/index.html), and check out the demo project included in the repo. When you are ready to install, follow the [**Installation Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Installation%20Guide.md). See [**Requirements**](#h_requirements) for a list of supported platforms. If you encounter any issues, the [**Troubleshooting Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Troubleshooting.md) might help. 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Nuke provides a simple and efficient way to download and display images in your app. Behind its clear and concise API is an advanced architecture which enables its unique features and offers virtually unlimited possibilities for customization.
 
-> **Fast LRU memory and disk cache** · **SwiftUI** · **Smart background decompression** · **Image processing** · **Resumable downloads** · **Intelligent deduplication** · **Request prioritization** · **Prefetching** · **Rate limiting** · **Progressive JPEG, WebP, SVG** · **Animated images** · **Alamofire, Gifu** · **Combine** · **Reactive extensions**
+> **Fast LRU memory and disk cache** · **SwiftUI** · **Smart background decompression** · **Image processing** · **Resumable downloads** · **Intelligent deduplication** · **Request prioritization** · **Prefetching** · **Rate limiting** · **Progressive JPEG** · **WebP, SVG, GIF** · **Alamofire** · **Combine** · **Reactive extensions**
 
 <br/>
 
@@ -27,7 +27,7 @@ Nuke is easy to learn and use. Here is an overview of its APIs and features:
 - **Image Processing** ‣ [`Resize`](#resize) | [`GaussianBlur`, Core Image](#gaussianblur-core-image) | [Custom Processors](#custom-processors) | [Decompression](#decompression) | [Builder](#builder)
 - **Image Pipeline** ‣ [Load Image](#image-pipeline) | [`ImageTask`](#imagetask) | [Customize Image Pipeline](#customize-image-pipeline) | [Default Pipeline](#default-image-pipeline)
 - **Caching** ‣ [LRU Memory Cache](#lru-memory-cache) | [HTTP Disk Cache](#http-disk-cache) | [Aggressive LRU Disk Cache](#aggressive-lru-disk-cache)
-- **Advanced Features** ‣ [Preheat Images](#image-preheating) | [Progressive Decoding](#progressive-decoding) | [WebP](#webp) | [SVG](#svg) | [Combine](#combine) | [RxNuke](#rxnuke)
+- **Advanced Features** ‣ [Preheat Images](#image-preheating) | [Progressive Decoding](#progressive-decoding) | [WebP](#webp) | [Combine](#combine) | [RxNuke](#rxnuke)
 
 To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuke/reference/8.0/index.html), and check out the demo project included in the repo. When you are ready to install, follow the [**Installation Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Installation%20Guide.md). See [**Requirements**](#h_requirements) for a list of supported platforms. If you encounter any issues, the [**Troubleshooting Guide**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/Troubleshooting.md) might help. 
 
@@ -35,7 +35,7 @@ To learn more see a full [**API Reference**](https://kean-org.github.io/docs/nuk
 
 To learn more about the pipeline and the supported formats, see the dedicated guides.
 
-- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif)
+- [**Image Formats**](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) ‣ [Codecs](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md) | [GIF](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#gif) | [SVG](https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md#svg)
 - **Image Pipeline** ‣ [Overview](#h_design) | [Data Loading and Caching](#data-loading-and-caching) | [Resumable Downloads](#resumable-downloads) | [Memory Cache](#memory-cache) | [Deduplication](#deduplication) | [Performance](#performance) | [Extensions](#h_plugins)
 
 If you'd like to contribute to Nuke see [**Contributing**](#h_contribute).
@@ -479,37 +479,6 @@ let task = ImagePipeline.shared.loadImage(
 ### WebP
 
 WebP support is provided by [Nuke WebP Plugin](https://github.com/ryokosuge/Nuke-WebP-Plugin) built by [Ryo Kosuge](https://github.com/ryokosuge). Please follow the instructions from the repo.
-
-### SVG
-
-To render SVG, consider using [SwiftSVG](https://github.com/mchoe/SwiftSVG), [SVG](https://github.com/SVGKit/SVGKit), or other frameworks. Here is an example of `SwiftSVG` being used to render vector images.
-
-```swift
-ImageDecoderRegistry.shared.register { context in
-    // Replace this with whatever works for. There are no magic numbers
-    // for SVG like are used for other binary formats, it's just XML.
-    let isSVG = context.urlResponse?.url?.absoluteString.hasSuffix(".svg") ?? false
-    return isSVG ? ImageDecoders.Empty() : nil
-}
-
-let url = URL(string: "https://upload.wikimedia.org/wikipedia/commons/9/9d/Swift_logo.svg")!
-ImagePipeline.shared.loadImage(with: url) { [weak self] result in
-    guard let self = self, let data = try? result.get().container.data else {
-        return
-    }
-    // You can render image using whatever size you want, vector!
-    let targetBounds = CGRect(origin: .zero, size: CGSize(width: 300, height: 300))
-    let svgView = UIView(SVGData: data) { layer in
-        layer.fillColor = UIColor.orange.cgColor
-        layer.resizeToFit(targetBounds)
-    }
-    self.view.addSubview(svgView)
-    svgView.bounds = targetBounds
-    svgView.center = self.view.center
-}
-```
-
-> Please keep in mind that most of these frameworks are limited in terms of supported SVG features.
 
 ### RxNuke
 

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -315,4 +315,16 @@ public extension ImagePipeline.Configuration {
             }
         }
     }
+
+    /// If `true` pipeline will detects GIFs and set `animatedImageData`
+    /// (`UIImage` property). It will also disable processing of such images,
+    /// and alter the way cache cost is calculated. However, this will not
+    /// enable actual animated image rendering. To do that take a look at
+    /// satellite projects (FLAnimatedImage and Gifu plugins for Nuke).
+    /// `false` by default (to preserve resources).
+    @available(*, deprecated, message: "Image pipeline now automatically attaches image data to ImageContainer when it detects GIFs. The decompression of placeholders is no longet disabled, there is no technical limitation to do thay anymore.")
+    static var isAnimatedImageDataEnabled: Bool {
+        get { return _isAnimatedImageDataEnabled }
+        set { _isAnimatedImageDataEnabled = newValue }
+    }
 }

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -315,16 +315,4 @@ public extension ImagePipeline.Configuration {
             }
         }
     }
-
-    /// If `true` pipeline will detects GIFs and set `animatedImageData`
-    /// (`UIImage` property). It will also disable processing of such images,
-    /// and alter the way cache cost is calculated. However, this will not
-    /// enable actual animated image rendering. To do that take a look at
-    /// satellite projects (FLAnimatedImage and Gifu plugins for Nuke).
-    /// `false` by default (to preserve resources).
-    @available(*, deprecated, message: "Image pipeline now automatically attaches image data to ImageContainer when it detects GIFs. The decompression of placeholders is no longet disabled, there is no technical limitation to do thay anymore.")
-    static var isAnimatedImageDataEnabled: Bool {
-        get { return _isAnimatedImageDataEnabled }
-        set { _isAnimatedImageDataEnabled = newValue }
-    }
 }

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -288,7 +288,7 @@ public extension ImageProcessor.RoundedCorners {
 
 // Deprecated in 8.5
 public extension ImagePipeline.Configuration {
-    @available(*, deprecated, message: "Please use `dataCacheOptions.contents` instead.")
+    @available(*, deprecated, message: "Please use `dataCacheOptions.contents` instead.") // Deprecated in 8.5
     var isDataCachingForOriginalImageDataEnabled: Bool {
         get {
             return dataCacheOptions.storedItems.contains(.originalImageData)
@@ -302,7 +302,7 @@ public extension ImagePipeline.Configuration {
         }
     }
 
-    @available(*, deprecated, message: "Please use `dataCacheOptions.contents` instead. Please note that the new behavior is different from the previous versions. Now, instead of storing only processd image, it encodes and stores all downloaded images.")
+    @available(*, deprecated, message: "Please use `dataCacheOptions.contents` instead. Please note that the new behavior is different from the previous versions. Now, instead of storing only processd image, it encodes and stores all downloaded images.") // Deprecated in 8.5
     var isDataCachingForProcessedImagesEnabled: Bool {
         get {
             return dataCacheOptions.storedItems.contains(.finalImage)
@@ -314,5 +314,11 @@ public extension ImagePipeline.Configuration {
                 dataCacheOptions.storedItems.remove(.finalImage)
             }
         }
+    }
+
+    @available(*, deprecated, message: "The default image decoder now automatically attaches image data to the newly added ImageContainer type. To learn how to implement animated image support using this new type, see the new Image Formats guide https://github.com/kean/Nuke/blob/master/Documentation/Guides/image-formats.md") // Deprecated in 8.5
+    static var isAnimatedImageDataEnabled: Bool {
+        get { return _isAnimatedImageDataEnabled }
+        set { _isAnimatedImageDataEnabled = newValue }
     }
 }

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -322,3 +322,10 @@ public extension ImagePipeline.Configuration {
         set { _isAnimatedImageDataEnabled = newValue }
     }
 }
+
+public extension ImageProcessingContext {
+    @available(*, deprecated, message: "Please use `response.container.userInfo[ImageDecoders.Default.scanNumberKey]` instead.") // Deprecated in Nuke 8.5
+    var scanNumber: Int? {
+        return response.container.userInfo[ImageDecoders.Default.scanNumberKey] as? Int
+    }
+}

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -110,7 +110,7 @@ public final class ImageCache: ImageCaching {
 
     /// Stores the given `ImageResponse` in the cache using the given request.
     public func storeResponse(_ response: ImageResponse, for request: ImageRequest) {
-        impl.set(response, forKey: request.makeCacheKeyForFinalImage(), cost: self.cost(for: response.image))
+        impl.set(response, forKey: request.makeCacheKeyForFinalImage(), cost: self.cost(for: response.container))
     }
 
     /// Removes response stored with the given request.
@@ -135,18 +135,18 @@ public final class ImageCache: ImageCaching {
     }
 
     /// Returns cost for the given image by approximating its bitmap size in bytes in memory.
-    func cost(for image: PlatformImage) -> Int {
+    func cost(for container: ImageContainer) -> Int {
         let dataCost: Int
         if ImagePipeline.Configuration.isAnimatedImageDataEnabled {
-            dataCost = image.animatedImageData?.count ?? 0
+            dataCost = container.image.animatedImageData?.count ?? 0
         } else {
-            dataCost = 0
+            dataCost = container.data?.count ?? 0
         }
 
         // bytesPerRow * height gives a rough estimation of how much memory
         // image uses in bytes. In practice this algorithm combined with a
         // concervative default cost limit works OK.
-        guard let cgImage = image.cgImage else {
+        guard let cgImage = container.image.cgImage else {
             return 1 + dataCost
         }
         return cgImage.bytesPerRow * cgImage.height + dataCost

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -137,7 +137,7 @@ public final class ImageCache: ImageCaching {
     /// Returns cost for the given image by approximating its bitmap size in bytes in memory.
     func cost(for container: ImageContainer) -> Int {
         let dataCost: Int
-        if ImagePipeline.Configuration.isAnimatedImageDataEnabled {
+        if ImagePipeline.Configuration._isAnimatedImageDataEnabled {
             dataCost = container.image.animatedImageData?.count ?? 0
         } else {
             dataCost = container.data?.count ?? 0

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -137,7 +137,7 @@ public final class ImageCache: ImageCaching {
     /// Returns cost for the given image by approximating its bitmap size in bytes in memory.
     func cost(for container: ImageContainer) -> Int {
         let dataCost: Int
-        if ImagePipeline.Configuration._isAnimatedImageDataEnabled {
+        if ImagePipeline.Configuration.isAnimatedImageDataEnabled {
             dataCost = container.image.animatedImageData?.count ?? 0
         } else {
             dataCost = container.data?.count ?? 0

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -32,7 +32,8 @@ public extension ImageCaching {
         }
         set {
             if let newValue = newValue {
-                storeResponse(ImageResponse(image: newValue, urlResponse: nil, scanNumber: nil), for: request)
+                let response = ImageResponse(container: .init(image: newValue))
+                storeResponse(response, for: request)
             } else {
                 removeResponse(for: request)
             }

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -37,7 +37,7 @@ extension ImageDecoding {
                 // If it is the old implementation, call the old method. Otherwise,
                   // call the new APIs.
                 if isFinal {
-                    return newDecoder.decode(data: data)
+                    return newDecoder.decode(data)
                 } else {
                     return newDecoder.decodePartiallyDownloadedData(data)
                 }
@@ -89,14 +89,14 @@ public extension ImageDecoders {
 
         public init() { }
 
-        public func decode(data: Data) -> ImageContainer? {
+        public func decode(_ data: Data) -> ImageContainer? {
             let format = ImageFormat.format(for: data)
 
-            guard let image = ImageDecoders.Default.decode(data) else {
+            guard let image = ImageDecoders.Default._decode(data) else {
                 return nil
             }
             // Keep original data around in case of GIF
-            if ImagePipeline.Configuration._isAnimatedImageDataEnabled, case .gif? = format {
+            if ImagePipeline.Configuration.isAnimatedImageDataEnabled, case .gif? = format {
                 image.animatedImageData = data
             }
             var container = ImageContainer(image: image, data: image.animatedImageData)
@@ -150,7 +150,7 @@ public extension ImageDecoders {
             guard numberOfScans > 1 && lastStartOfScan > 0 else {
                 return nil
             }
-            guard let image = ImageDecoder.decode(data[0..<lastStartOfScan]) else {
+            guard let image = ImageDecoder._decode(data[0..<lastStartOfScan]) else {
                 return nil
             }
             return ImageContainer(image: image, userInfo: [ImageDecoders.Default.scanNumberKey: numberOfScans])
@@ -159,7 +159,7 @@ public extension ImageDecoders {
 }
 
 extension ImageDecoders.Default {
-    static func decode(_ data: Data) -> PlatformImage? {
+    static func _decode(_ data: Data) -> PlatformImage? {
         #if os(macOS)
         return NSImage(data: data)
         #else
@@ -186,7 +186,7 @@ public extension ImageDecoders {
             return isProgressive ? ImageContainer(image: PlatformImage(), data: data, userInfo: [:]) : nil
         }
 
-        public func decode(data: Data) -> ImageContainer? {
+        public func decode(_ data: Data) -> ImageContainer? {
             return ImageContainer(image: PlatformImage(), data: data, userInfo: [:])
         }
     }
@@ -202,7 +202,7 @@ public extension ImageDecoders {
 /// anything that you might need from the `ImageDecodingContext`.
 public protocol _ImageDecoding: ImageDecoding {
     /// Produces an image from the given image data.
-    func decode(data: Data) -> ImageContainer?
+    func decode(_ data: Data) -> ImageContainer?
 
     /// Produces an image from the given partially dowloaded image data.
     /// This method might be called multiple times during a single decoding
@@ -219,7 +219,7 @@ public extension _ImageDecoding {
 
     func decode(data: Data, isFinal: Bool) -> PlatformImage? {
         if isFinal {
-            return self.decode(data: data)?.image
+            return self.decode(data)?.image
         } else {
             return self.decodePartiallyDownloadedData(data)?.image
         }

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -39,7 +39,7 @@ extension ImageDecoding {
                 if isFinal {
                     return newDecoder.decode(data: data)
                 } else {
-                    return newDecoder.decodeProgressively(data: data)
+                    return newDecoder.decodePartiallyDownloadedData(data)
                 }
             } else {
                 guard let image = self.decode(data: data, isFinal: isFinal) else {
@@ -149,7 +149,7 @@ extension ImageDecoders.Default {
 // MARK: - ImageDecoders.Empty
 
 public extension ImageDecoders {
-    /// A decoder which returns an empty placeholder image and attached image
+    /// A decoder which returns an empty placeholder image and attaches image
     /// data to the image container.
     struct Empty: _ImageDecoding {
         public let isProgressive: Bool
@@ -160,7 +160,7 @@ public extension ImageDecoders {
             self.isProgressive = isProgressive
         }
 
-        public func decodeProgressively(data: Data) -> ImageContainer? {
+        public func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer? {
             return isProgressive ? ImageContainer(image: PlatformImage(), data: data, userInfo: [:]) : nil
         }
 
@@ -183,15 +183,15 @@ public protocol _ImageDecoding: ImageDecoding {
     func decode(data: Data) -> ImageContainer?
 
     /// Produces an image from the given partially dowloaded image data.
-    /// This method might be called multiple times during the a single decoding
+    /// This method might be called multiple times during a single decoding
     /// session. When the image download is complete, `decode(data:)` method is called.
     ///
     /// - returns: nil by default.
-    func decodeProgressively(data: Data) -> ImageContainer?
+    func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer?
 }
 
 public extension _ImageDecoding {
-    func decodeProgressively(data: Data) -> ImageContainer? {
+    func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer? {
         return nil
     }
 
@@ -199,7 +199,7 @@ public extension _ImageDecoding {
         if isFinal {
             return self.decode(data: data)?.image
         } else {
-            return self.decodeProgressively(data: data)?.image
+            return self.decodePartiallyDownloadedData(data)?.image
         }
     }
 }
@@ -220,7 +220,7 @@ public final class ImageDecoderRegistry {
                 return decoder
             }
         }
-        return ImageDecoder() // Return default decoder if couldn't find a custom one.
+        return ImageDecoders.Default() // Return default decoder if couldn't find a custom one.
     }
 
     /// Registers a decoder to be used in a given decoding context. The closure

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -96,7 +96,7 @@ public extension ImageDecoders {
                 return nil
             }
             // Keep original data around in case of GIF
-            if ImagePipeline.Configuration.isAnimatedImageDataEnabled, case .gif? = format {
+            if ImagePipeline.Configuration._isAnimatedImageDataEnabled, case .gif? = format {
                 image.animatedImageData = data
             }
             var container = ImageContainer(image: image, data: image.animatedImageData)

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -82,6 +82,9 @@ public extension ImageDecoders {
         private var lastStartOfScan: Int = 0 // Index of the last found Start of Scan
         private var scannedIndex: Int = -1 // Index at which previous scan was finished
 
+        /// A user info key to get the scan number (Int).
+        public static let scanNumberKey = "ImageDecoders.Default.scanNumberKey"
+
         public init() { }
 
         public func decode(data: Data) -> ImageContainer? {
@@ -94,7 +97,11 @@ public extension ImageDecoders {
             if ImagePipeline.Configuration.isAnimatedImageDataEnabled, case .gif? = format {
                 image.animatedImageData = data
             }
-            return ImageContainer(image: image, data: image.animatedImageData)
+            var container = ImageContainer(image: image, data: image.animatedImageData)
+            if isProgressive == true {
+                container.userInfo[ImageDecoders.Default.scanNumberKey] = numberOfScans
+            }
+            return container
         }
 
         public func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer? {
@@ -141,7 +148,7 @@ public extension ImageDecoders {
             guard let image = ImageDecoder.decode(data[0..<lastStartOfScan]) else {
                 return nil
             }
-            return ImageContainer(image: image)
+            return ImageContainer(image: image, userInfo: [ImageDecoders.Default.scanNumberKey: numberOfScans])
         }
     }
 }

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -55,8 +55,7 @@ extension ImageDecoding {
         ImageDecompression.setDecompressionNeeded(true, for: container.image)
         #endif
 
-        let scanNumber: Int? = (self as? ImageDecoders.Default)?.numberOfScans
-        return ImageResponse(container: container, urlResponse: urlResponse, scanNumber: scanNumber)
+        return ImageResponse(container: container, urlResponse: urlResponse)
     }
 }
 
@@ -78,7 +77,7 @@ public extension ImageDecoders {
         private(set) var isProgressive: Bool?
         // Number of scans that the decoder has found so far. The last scan might be
         // incomplete at this point.
-        private(set) var numberOfScans = 0
+        private var numberOfScans = 0
         private var lastStartOfScan: Int = 0 // Index of the last found Start of Scan
         private var scannedIndex: Int = -1 // Index at which previous scan was finished
 

--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -77,12 +77,15 @@ public extension ImageDecoders {
         private(set) var isProgressive: Bool?
         // Number of scans that the decoder has found so far. The last scan might be
         // incomplete at this point.
-        private var numberOfScans = 0
+        private(set) var numberOfScans = 0
         private var lastStartOfScan: Int = 0 // Index of the last found Start of Scan
         private var scannedIndex: Int = -1 // Index at which previous scan was finished
 
         /// A user info key to get the scan number (Int).
         public static let scanNumberKey = "ImageDecoders.Default.scanNumberKey"
+
+        // Not sure if this is a useful configuration option and whether it needs to exist.
+        public static var _isAttachingAnimatedImageData: Bool = true
 
         public init() { }
 
@@ -97,6 +100,9 @@ public extension ImageDecoders {
                 image.animatedImageData = data
             }
             var container = ImageContainer(image: image, data: image.animatedImageData)
+            if ImageDecoders.Default._isAttachingAnimatedImageData, case .gif? = format {
+                container.data = data
+            }
             if isProgressive == true {
                 container.userInfo[ImageDecoders.Default.scanNumberKey] = numberOfScans
             }

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -535,7 +535,7 @@ private extension ImagePipeline {
 
             let log = Log(self.log, "Process Image")
             log.signpost(.begin, "\(processor), \(isCompleted ? "final" : "progressive") image")
-            let context = ImageProcessingContext(request: request, isFinal: isCompleted, scanNumber: response.scanNumber)
+            let context = ImageProcessingContext(request: request, response: response, isFinal: isCompleted)
             let response = response.map { processor.process(image: $0, context: context) }
             log.signpost(.end)
 

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -451,7 +451,7 @@ private extension ImagePipeline {
     func isDecompressionNeeded(for response: ImageResponse) -> Bool {
         return configuration.isDecompressionEnabled &&
             ImageDecompression.isDecompressionNeeded(for: response.image) ?? false &&
-            !(Configuration._isAnimatedImageDataEnabled && response.image.animatedImageData != nil)
+            !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil)
     }
     #endif
 
@@ -519,7 +519,7 @@ private extension ImagePipeline {
     }
 
     func processImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, processor: ImageProcessing, task: ProcessedImageTask) {
-        guard !(Configuration._isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
+        guard !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
             task.send(value: response, isCompleted: isCompleted)
             return
         }

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -455,7 +455,7 @@ private extension ImagePipeline {
     func isDecompressionNeeded(for response: ImageResponse) -> Bool {
         return configuration.isDecompressionEnabled &&
             ImageDecompression.isDecompressionNeeded(for: response.image) ?? false &&
-            !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil)
+            !(Configuration._isAnimatedImageDataEnabled && response.image.animatedImageData != nil)
     }
     #endif
 
@@ -523,7 +523,7 @@ private extension ImagePipeline {
     }
 
     func processImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, processor: ImageProcessing, task: ProcessedImageTask) {
-        guard !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
+        guard !(Configuration._isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
             task.send(value: response, isCompleted: isCompleted)
             return
         }

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -250,6 +250,10 @@ public /* final */ class ImagePipeline {
 // MARK: - Image Cache
 
 public extension ImagePipeline {
+    /// Returns a cached response from the memory cache.
+    func cachedResponse(for url: URL) -> ImageResponse? {
+        return cachedResponse(for: ImageRequest(url: url))
+    }
 
     /// Returns a cached response from the memory cache. Returns `nil` if the request disables
     /// memory cache reads.

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -451,7 +451,7 @@ private extension ImagePipeline {
     func isDecompressionNeeded(for response: ImageResponse) -> Bool {
         return configuration.isDecompressionEnabled &&
             ImageDecompression.isDecompressionNeeded(for: response.image) ?? false &&
-            !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil)
+            !(Configuration._isAnimatedImageDataEnabled && response.image.animatedImageData != nil)
     }
     #endif
 
@@ -519,7 +519,7 @@ private extension ImagePipeline {
     }
 
     func processImage(_ response: ImageResponse, isCompleted: Bool, for request: ImageRequest, processor: ImageProcessing, task: ProcessedImageTask) {
-        guard !(Configuration.isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
+        guard !(Configuration._isAnimatedImageDataEnabled && response.image.animatedImageData != nil) else {
             task.send(value: response, isCompleted: isCompleted)
             return
         }

--- a/Sources/ImagePipelineConfiguration.swift
+++ b/Sources/ImagePipelineConfiguration.swift
@@ -146,7 +146,7 @@ extension ImagePipeline {
         /// attaches image data to ImageContainer when it detects GIFs.
         /// The decompression of placeholders is no longet disabled,
         /// there is no technical limitation to do thay anymore.")
-        public static var isAnimatedImageDataEnabled = false // Deprecated in Nuke 8.5
+        static var _isAnimatedImageDataEnabled = false
 
         /// `false` by default. If `true`, enables `os_signpost` logging for
         /// measuring performance. You can visually see all the performance

--- a/Sources/ImagePipelineConfiguration.swift
+++ b/Sources/ImagePipelineConfiguration.swift
@@ -141,7 +141,12 @@ extension ImagePipeline {
         /// enable actual animated image rendering. To do that take a look at
         /// satellite projects (FLAnimatedImage and Gifu plugins for Nuke).
         /// `false` by default (to preserve resources).
-        static var _isAnimatedImageDataEnabled = false // Deprecated in Nuke 8.5
+        ///
+        /// - warning: Soft-deprecated in Nuke 8.5. Image pipeline now automatically
+        /// attaches image data to ImageContainer when it detects GIFs.
+        /// The decompression of placeholders is no longet disabled,
+        /// there is no technical limitation to do thay anymore.")
+        public static var isAnimatedImageDataEnabled = false // Deprecated in Nuke 8.5
 
         /// `false` by default. If `true`, enables `os_signpost` logging for
         /// measuring performance. You can visually see all the performance

--- a/Sources/ImagePipelineConfiguration.swift
+++ b/Sources/ImagePipelineConfiguration.swift
@@ -141,7 +141,7 @@ extension ImagePipeline {
         /// enable actual animated image rendering. To do that take a look at
         /// satellite projects (FLAnimatedImage and Gifu plugins for Nuke).
         /// `false` by default (to preserve resources).
-        public static var isAnimatedImageDataEnabled = false
+        static var _isAnimatedImageDataEnabled = false // Deprecated in Nuke 8.5
 
         /// `false` by default. If `true`, enables `os_signpost` logging for
         /// measuring performance. You can visually see all the performance

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -125,14 +125,14 @@ extension ImageProcessors {
         ///
         /// - parameter unit: Unit of the target size, `.points` by default.
         public init(width: CGFloat, unit: ImageProcessingOptions.Unit = .points, crop: Bool = false, upscale: Bool = false) {
-            self.init(size: CGSize(width: width, height: .greatestFiniteMagnitude), unit: unit, contentMode: .aspectFit, crop: crop, upscale: upscale)
+            self.init(size: CGSize(width: width, height: 4096), unit: unit, contentMode: .aspectFit, crop: crop, upscale: upscale)
         }
 
         /// Resizes the image to fill the given height.
         ///
         /// - parameter unit: Unit of the target size, `.points` by default.
         public init(height: CGFloat, unit: ImageProcessingOptions.Unit = .points, crop: Bool = false, upscale: Bool = false) {
-            self.init(size: CGSize(width: .greatestFiniteMagnitude, height: height), unit: unit, contentMode: .aspectFit, crop: crop, upscale: upscale)
+            self.init(size: CGSize(width: 4096, height: height), unit: unit, contentMode: .aspectFit, crop: crop, upscale: upscale)
         }
 
         public func process(image: PlatformImage, context: ImageProcessingContext?) -> PlatformImage? {

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -52,13 +52,18 @@ public extension ImageProcessing {
 /// Image processing context used when selecting which processor to use.
 public struct ImageProcessingContext {
     public let request: ImageRequest
+    public let response: ImageResponse
     public let isFinal: Bool
-    public let scanNumber: Int? // need a more general purpose way to implement this
 
-    public init(request: ImageRequest, isFinal: Bool, scanNumber: Int?) {
+    @available(*, deprecated, message: "Please use `container.userInfo[ImageDecoders.Default.scanNumberKey]` instead.") // Deprecated in Nuke 8.5
+    public var scanNumber: Int? {
+        return response.container.userInfo[ImageDecoders.Default.scanNumberKey] as? Int
+    }
+
+    public init(request: ImageRequest, response: ImageResponse, isFinal: Bool) {
         self.request = request
+        self.response = response
         self.isFinal = isFinal
-        self.scanNumber = scanNumber
     }
 }
 

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -55,11 +55,6 @@ public struct ImageProcessingContext {
     public let response: ImageResponse
     public let isFinal: Bool
 
-    @available(*, deprecated, message: "Please use `container.userInfo[ImageDecoders.Default.scanNumberKey]` instead.") // Deprecated in Nuke 8.5
-    public var scanNumber: Int? {
-        return response.container.userInfo[ImageDecoders.Default.scanNumberKey] as? Int
-    }
-
     public init(request: ImageRequest, response: ImageResponse, isFinal: Bool) {
         self.request = request
         self.response = response

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -144,6 +144,7 @@ public final class ImageResponse {
     /// A convenience computed property which returns an image from the container.
     public var image: PlatformImage { return container.image }
     public let urlResponse: URLResponse?
+
     // the response is only nil when new disk cache is enabled (it only stores
     // data for now, but this might change in the future).
     @available(*, deprecated, message: "Please use `container.userInfo[ImageDecoders.Default.scanNumberKey]` instead.") // Deprecated in Nuke 8.5

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -128,7 +128,7 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
 
 public struct ImageContainer {
     public let image: PlatformImage
-    public let data: Data?
+    public var data: Data?
     public var userInfo: [AnyHashable: Any]
 
     public init(image: PlatformImage, data: Data? = nil, userInfo: [AnyHashable: Any] = [:]) {

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -144,22 +144,29 @@ public final class ImageResponse {
     /// A convenience computed property which returns an image from the container.
     public var image: PlatformImage { return container.image }
     public let urlResponse: URLResponse?
-    // Soft-deprecated in Nuke 8.5.
     // the response is only nil when new disk cache is enabled (it only stores
     // data for now, but this might change in the future).
-    public let scanNumber: Int?
+    @available(*, deprecated, message: "Please use `container.userInfo[ImageDecoders.Default.scanNumberKey]` instead.") // Deprecated in Nuke 8.5
+    public var scanNumber: Int? {
+        if let number = _scanNumber {
+            return number // Deprecated version
+        }
+        return container.userInfo[ImageDecoders.Default.scanNumberKey] as? Int
+    }
 
-    @available(*, deprecated, message: "Please use `ImageResponse.init(container:urlResponse:)` instead.")
+    private let _scanNumber: Int?
+
+    @available(*, deprecated, message: "Please use `ImageResponse.init(container:urlResponse:)` instead.") // Deprecated in Nuke 8.5
     public init(image: PlatformImage, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
         self.container = ImageContainer(image: image)
         self.urlResponse = urlResponse
-        self.scanNumber = scanNumber
+        self._scanNumber = scanNumber
     }
 
-    public init(container: ImageContainer, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
+    public init(container: ImageContainer, urlResponse: URLResponse? = nil) {
         self.container = container
         self.urlResponse = urlResponse
-        self.scanNumber = scanNumber
+        self._scanNumber = nil
     }
 
     func map(_ transformation: (PlatformImage) -> PlatformImage?) -> ImageResponse? {
@@ -168,7 +175,7 @@ public final class ImageResponse {
                 return nil
             }
             let container = ImageContainer(image: output, data: self.container.data, userInfo: self.container.userInfo)
-            return ImageResponse(container: container, urlResponse: urlResponse, scanNumber: scanNumber)
+            return ImageResponse(container: container, urlResponse: urlResponse)
         }
     }
 }

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -129,7 +129,7 @@ public /* final */ class ImageTask: Hashable, CustomStringConvertible {
 public struct ImageContainer {
     public let image: PlatformImage
     public let data: Data?
-    public let userInfo: [AnyHashable: Any]
+    public var userInfo: [AnyHashable: Any]
 
     public init(image: PlatformImage, data: Data? = nil, userInfo: [AnyHashable: Any] = [:]) {
         self.image = image
@@ -144,10 +144,12 @@ public final class ImageResponse {
     /// A convenience computed property which returns an image from the container.
     public var image: PlatformImage { return container.image }
     public let urlResponse: URLResponse?
+    // Soft-deprecated in Nuke 8.5.
     // the response is only nil when new disk cache is enabled (it only stores
     // data for now, but this might change in the future).
     public let scanNumber: Int?
 
+    @available(*, deprecated, message: "Please use `ImageResponse.init(container:urlResponse:)` instead.")
     public init(image: PlatformImage, urlResponse: URLResponse? = nil, scanNumber: Int? = nil) {
         self.container = ImageContainer(image: image)
         self.urlResponse = urlResponse

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -41,9 +41,8 @@ enum Test {
     )
 
     static let response = ImageResponse(
-        image: Test.image,
-        urlResponse: urlResponse,
-        scanNumber: nil
+        container: .init(image: Test.image),
+        urlResponse: urlResponse
     )
 }
 

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -119,11 +119,11 @@ class ImageCacheTests: XCTestCase {
     #if !os(macOS)
 
     func testDefaultImageCost() {
-        XCTAssertEqual(cache.cost(for: Test.image), 1228800)
+        XCTAssertEqual(cache.cost(for: ImageContainer(image: Test.image)), 1228800)
     }
 
     func testThatTotalCostChanges() {
-        let imageCost = cache.cost(for: Test.image)
+        let imageCost = cache.cost(for: ImageContainer(image: Test.image))
         XCTAssertEqual(cache.totalCost, 0)
 
         cache[request1] = Test.image
@@ -141,7 +141,7 @@ class ImageCacheTests: XCTestCase {
 
     func testThatCostLimitChanged() {
         // Given
-        let cost = cache.cost(for: Test.image)
+        let cost = cache.cost(for: ImageContainer(image: Test.image))
 
         // When
         cache.costLimit = Int(Double(cost) * 1.5)
@@ -152,7 +152,7 @@ class ImageCacheTests: XCTestCase {
 
     func testThatItemsAreRemoveImmediatelyWhenCostLimitIsReached() {
         // Given
-        let cost = cache.cost(for: Test.image)
+        let cost = cache.cost(for: ImageContainer(image: Test.image))
         cache.costLimit = Int(Double(cost) * 1.5)
 
         // When/Then
@@ -172,7 +172,7 @@ class ImageCacheTests: XCTestCase {
         cache[request2] = Test.image
 
         // When
-        let cost = cache.cost(for: Test.image)
+        let cost = cache.cost(for: ImageContainer(image: Test.image))
         cache.trim(toCost: Int(Double(cost) * 1.5))
 
         // Then
@@ -182,7 +182,7 @@ class ImageCacheTests: XCTestCase {
 
     func testThatImagesAreRemovedOnCostLimitChange() {
         // Given
-        let cost = cache.cost(for: Test.image)
+        let cost = cache.cost(for: ImageContainer(image: Test.image))
         cache.costLimit = Int(Double(cost) * 2.5)
 
         cache[request1] = Test.image
@@ -203,12 +203,12 @@ class ImageCacheTests: XCTestCase {
         image.animatedImageData = data
 
         // Then
-        XCTAssertFalse(ImagePipeline.Configuration.isAnimatedImageDataEnabled)
-        XCTAssertEqual(cache.cost(for: image), 558000)
+        XCTAssertFalse(ImagePipeline.Configuration._isAnimatedImageDataEnabled)
+        XCTAssertEqual(cache.cost(for: ImageContainer(image: image)), 558000)
 
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
-        XCTAssertEqual(cache.cost(for: image), 558000 + 427672)
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
+        XCTAssertEqual(cache.cost(for: ImageContainer(image: image)), 558000 + 427672)
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
     }
 
     #endif
@@ -217,7 +217,7 @@ class ImageCacheTests: XCTestCase {
 
     func testThatLeastRecentItemsAreRemoved() {
         // Given
-        let cost = cache.cost(for: Test.image)
+        let cost = cache.cost(for: ImageContainer(image: Test.image))
         cache.costLimit = Int(Double(cost) * 2.5)
 
         cache[request1] = Test.image
@@ -232,7 +232,7 @@ class ImageCacheTests: XCTestCase {
 
     func testThatItemsAreTouched() {
         // Given
-        let cost = cache.cost(for: Test.image)
+        let cost = cache.cost(for: ImageContainer(image: Test.image))
         cache.costLimit = Int(Double(cost) * 2.5)
 
         cache[request1] = Test.image
@@ -294,7 +294,7 @@ class ImageCacheTests: XCTestCase {
 
     func testThatSomeImagesAreRemovedBasedOnCostOnDidEnterBackground() {
         // Given
-        let cost = cache.cost(for: Test.image)
+        let cost = cache.cost(for: ImageContainer(image: Test.image))
         cache.costLimit = cost * 10
         cache.countLimit = Int.max
 

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -203,12 +203,12 @@ class ImageCacheTests: XCTestCase {
         image.animatedImageData = data
 
         // Then
-        XCTAssertFalse(ImagePipeline.Configuration.isAnimatedImageDataEnabled)
+        XCTAssertFalse(ImagePipeline.Configuration._isAnimatedImageDataEnabled)
         XCTAssertEqual(cache.cost(for: ImageContainer(image: image)), 558000)
 
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
         XCTAssertEqual(cache.cost(for: ImageContainer(image: image)), 558000 + 427672)
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
     }
 
     func testImageContainerWithoutAssociatedDataCost() {

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -203,12 +203,32 @@ class ImageCacheTests: XCTestCase {
         image.animatedImageData = data
 
         // Then
-        XCTAssertFalse(ImagePipeline.Configuration._isAnimatedImageDataEnabled)
+        XCTAssertFalse(ImagePipeline.Configuration.isAnimatedImageDataEnabled)
         XCTAssertEqual(cache.cost(for: ImageContainer(image: image)), 558000)
 
-        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
+        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
         XCTAssertEqual(cache.cost(for: ImageContainer(image: image)), 558000 + 427672)
-        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
+    }
+
+    func testImageContainerWithoutAssociatedDataCost() {
+        // Given
+        let data = Test.data(name: "cat", extension: "gif")
+        let image = PlatformImage(data: data)!
+        let container = ImageContainer(image: image, data: nil)
+
+        // Then
+        XCTAssertEqual(cache.cost(for: container), 558000)
+    }
+
+    func testImageContainerWithAssociatedDataCost() {
+        // Given
+        let data = Test.data(name: "cat", extension: "gif")
+        let image = PlatformImage(data: data)!
+        let container = ImageContainer(image: image, data: data)
+
+        // Then
+        XCTAssertEqual(cache.cost(for: container), 558000 + 427672)
     }
 
     #endif

--- a/Tests/ImageDecoderTests.swift
+++ b/Tests/ImageDecoderTests.swift
@@ -36,8 +36,8 @@ class ImageDecoderTests: XCTestCase {
             XCTAssertEqual(image.size.width, 450)
             XCTAssertEqual(image.size.height, 300)
             #else
-            XCTAssertEqual(image.size.width * scan1.scale, 450)
-            XCTAssertEqual(image.size.height * scan1.scale, 300)
+            XCTAssertEqual(image.size.width * image.scale, 450)
+            XCTAssertEqual(image.size.height * image.scale, 300)
             #endif
         }
         XCTAssertEqual(decoder.numberOfScans, 2)

--- a/Tests/ImageDecoderTests.swift
+++ b/Tests/ImageDecoderTests.swift
@@ -52,15 +52,27 @@ class ImageDecoderTests: XCTestCase {
         XCTAssertEqual(decoder.numberOfScans, 10)
     }
 
-    func testDecodingGIFs() {
-        XCTAssertFalse(ImagePipeline.Configuration._isAnimatedImageDataEnabled)
+    func testDecodingGIFsSoftDeprecated() {
+        XCTAssertFalse(ImagePipeline.Configuration.isAnimatedImageDataEnabled)
 
         let data = Test.data(name: "cat", extension: "gif")
-        XCTAssertNil(ImageDecoder().decode(data: data)?.animatedImageData)
+        XCTAssertNil(ImageDecoders.Default().decode(data: data)?.animatedImageData)
 
-        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
-        XCTAssertNotNil(ImageDecoder().decode(data: data)?.animatedImageData)
-        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
+        XCTAssertNotNil(ImageDecoders.Default().decode(data: data)?.animatedImageData)
+        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
+    }
+
+    func testDecodingGIFDataAttached() {
+        let data = Test.data(name: "cat", extension: "gif")
+        XCTAssertNotNil(ImageDecoders.Default().decode(data)?.data)
+    }
+
+    func testDecodingPNGDataNotAttached() {
+        let data = Test.data(name: "fixture", extension: "png")
+        let container = ImageDecoders.Default().decode(data)
+        XCTAssertNotNil(container)
+        XCTAssertNil(container?.data)
     }
 }
 

--- a/Tests/ImageDecoderTests.swift
+++ b/Tests/ImageDecoderTests.swift
@@ -53,14 +53,14 @@ class ImageDecoderTests: XCTestCase {
     }
 
     func testDecodingGIFs() {
-        XCTAssertFalse(ImagePipeline.Configuration.isAnimatedImageDataEnabled)
+        XCTAssertFalse(ImagePipeline.Configuration._isAnimatedImageDataEnabled)
 
         let data = Test.data(name: "cat", extension: "gif")
         XCTAssertNil(ImageDecoder().decode(data: data)?.animatedImageData)
 
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
         XCTAssertNotNil(ImageDecoder().decode(data: data)?.animatedImageData)
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
     }
 }
 

--- a/Tests/ImageDecoderTests.swift
+++ b/Tests/ImageDecoderTests.swift
@@ -53,14 +53,14 @@ class ImageDecoderTests: XCTestCase {
     }
 
     func testDecodingGIFsSoftDeprecated() {
-        XCTAssertFalse(ImagePipeline.Configuration.isAnimatedImageDataEnabled)
+        XCTAssertFalse(ImagePipeline.Configuration._isAnimatedImageDataEnabled)
 
         let data = Test.data(name: "cat", extension: "gif")
         XCTAssertNil(ImageDecoders.Default().decode(data: data)?.animatedImageData)
 
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
         XCTAssertNotNil(ImageDecoders.Default().decode(data: data)?.animatedImageData)
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
     }
 
     func testDecodingGIFDataAttached() {

--- a/Tests/ImagePipelineDecodingTests.swift
+++ b/Tests/ImagePipelineDecodingTests.swift
@@ -51,7 +51,7 @@ class ImagePipelineDecodingTests: XCTestCase {
 private final class MockExperimentalDecoder: _ImageDecoding {
     var _decode: ((Data) -> ImageContainer?)!
 
-    func decode(data: Data) -> ImageContainer? {
+    func decode(_ data: Data) -> ImageContainer? {
         return _decode(data)
     }
 }

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -431,7 +431,7 @@ class ImagePipelineMemoryCacheTests: XCTestCase {
 
     func testCacheRead() {
         // Given
-        cache.storeResponse(ImageResponse(image: Test.image, urlResponse: nil, scanNumber: nil), for: Test.request)
+        cache.storeResponse(ImageResponse(container: .init(image: Test.image), urlResponse: nil), for: Test.request)
 
         // When
         expect(pipeline).toLoadImage(with: Test.request)
@@ -458,7 +458,7 @@ class ImagePipelineMemoryCacheTests: XCTestCase {
 
     func testCacheReadDisabled() {
         // Given
-        cache.storeResponse(ImageResponse(image: Test.image, urlResponse: nil, scanNumber: nil), for: Test.request)
+        cache.storeResponse(ImageResponse(container: .init(image: Test.image), urlResponse: nil), for: Test.request)
 
         var request = Test.request
         request.options.memoryCacheOptions.isReadAllowed = false

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -121,7 +121,7 @@ class ImagePipelineTests: XCTestCase {
 
     func testAnimatedImagesArentProcessed() {
         // Given
-        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
+        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
 
         dataLoader.results[Test.url] = .success(
             (Test.data(name: "cat", extension: "gif"), Test.urlResponse)
@@ -140,7 +140,7 @@ class ImagePipelineTests: XCTestCase {
         }
         wait()
 
-        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
     }
 
     // MARK: - Updating Priority

--- a/Tests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests.swift
@@ -121,7 +121,7 @@ class ImagePipelineTests: XCTestCase {
 
     func testAnimatedImagesArentProcessed() {
         // Given
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = true
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = true
 
         dataLoader.results[Test.url] = .success(
             (Test.data(name: "cat", extension: "gif"), Test.urlResponse)
@@ -140,7 +140,7 @@ class ImagePipelineTests: XCTestCase {
         }
         wait()
 
-        ImagePipeline.Configuration.isAnimatedImageDataEnabled = false
+        ImagePipeline.Configuration._isAnimatedImageDataEnabled = false
     }
 
     // MARK: - Updating Priority

--- a/Tests/ImageProcessingTests.swift
+++ b/Tests/ImageProcessingTests.swift
@@ -298,11 +298,9 @@ class ImageProcessorAnonymousTests: XCTestCase {
             $0.nk_test_processorIDs = ["1"]
             return $0
         }
-        let request = ImageRequest(url: Test.url, processors: [processor])
 
         // When
-        let context = ImageProcessingContext(request: request, isFinal: true, scanNumber: nil)
-        let image = processor.process(image: Test.image, context: context)
+        let image = processor.process(image: Test.image, context: nil)
 
         // Then
         XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])


### PR DESCRIPTION
- Add "Image Decoding Guide" (WIP)
- Rewrite `ImageDecoders.Default` to `_ImageDecoding` protocol
- `ImageDecoders.Default` now automatically attached the original image data to the image container for .gif
- Nuke now supports decompression and processing of images that require image data to work
- Deprecate `ImageResponse.scanNumber`, the scan number is now passed in `ImageContainer.userInfo[ImageDecoders.Default.scanNumberKey]` (this is a format-specific feature and that's why I made it non-type safe and somewhat hidden). Previusly it was also only working for the default `ImageDecoders.Default`. Now any decoder can pass scan number, or any other information using `ImageContainer.userInfo`
- Deprecate `isAnimatedImageDataEnabled`
- Add convenience `cachedResponse(for url: URL)` thing
