### PR TITLE
Use DispatchSourceMemoryPressure

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -161,7 +161,7 @@ final class Cache<Key: Hashable, Value> {
             self?.removeAll()
         }
         self.memoryPressure.resume()
-    
+
         #if os(iOS) || os(tvOS)
         let center = NotificationCenter.default
         center.addObserver(self, selector: #selector(didEnterBackground),

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -284,17 +284,6 @@ class ImageCacheTests: XCTestCase {
     }
 
     #if os(iOS) || os(tvOS)
-    func testThatImagesAreRemovedOnMemoryWarnings() {
-        // Given
-        cache[Test.request] = ImageContainer(image: PlatformImage())
-
-        // When
-        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
-
-        // Then
-        XCTAssertNil(cache[Test.request])
-    }
-
     func testThatSomeImagesAreRemovedOnDidEnterBackground() {
         // Given
         cache.costLimit = Int.max


### PR DESCRIPTION
Use DispatchSourceMemoryPressure instead of UIApplication.didReceiveMemoryWarningNotification. This should work in other targets then iOS and tvOS as well.

Unfortunately I'm not sure how to cover this in a test. Maybe it would be better to use it only on other targets and keep the current implementation on iOS/tvOS