### PR TITLE
Add tint colors to ImageLoadingOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ func tableView(_ tableView: UITableView, cellForItemAt indexPath: IndexPaths) ->
 
 > When the view is deallocated, an associated request gets canceled automatically. To manually cancel the request, call `Nuke.cancelRequest(for: imageView)`.
 
-### Placeholders, Transitions, Content Modes
+### Placeholders, Transitions, Content Modes, Tint Colors
 
 Use `ImageLoadingOptions` to set a `placeholder`, select one of the built-in `transitions`, or provide a custom one.
 
@@ -84,13 +84,14 @@ let options = ImageLoadingOptions(
 Nuke.loadImage(with: url, options: options, into: imageView)
 ```
 
-You can even customize content modes per image type:
+You can even customize content modes or tint colors per image type:
 
 ```swift
 let options = ImageLoadingOptions(
     placeholder: UIImage(named: "placeholder"),
     failureImage: UIImage(named: "failureImage"),
-    contentModes: .init(success: .scaleAspectFill, failure: .center, placeholder: .center)
+    contentModes: .init(success: .scaleAspectFill, failure: .center, placeholder: .center),
+    tintColors: .init(success: .green, failure: .red, placeholder: .yellow)
 )
 ```
 

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -6,12 +6,18 @@ import Foundation
 
 #if !os(macOS)
 import UIKit.UIImage
+import UIKit.UIColor
 /// Alias for `UIImage`.
 public typealias PlatformImage = UIImage
+/// Alias for `UIColor`.
+public typealias PlatformColor = UIColor
 #else
 import AppKit.NSImage
+import AppKit.NSColor
 /// Alias for `NSImage`.
 public typealias PlatformImage = NSImage
+/// Alias for `NSColor`.
+public typealias PlatformColor = NSColor
 #endif
 
 /// Displays images. Add the conformance to this protocol to your views to make
@@ -200,6 +206,28 @@ public struct ImageLoadingOptions {
         }
     }
 
+    /// Tint colors to be used for each image type (placeholder, success,
+    /// failure). `nil`  by default (don't change tint color or rendering mode).
+    public var tintColors: TintColors?
+
+    /// Custom tint color to be used for each image type (placeholder, success,
+    /// failure).
+    public struct TintColors {
+        /// Tint color to be used for the loaded image.
+        public var success: PlatformColor?
+        /// Tint color to be used when displaying a `failureImage`.
+        public var failure: PlatformColor?
+        /// Tint color to be used when displaying a `placeholder`.
+        public var placeholder: PlatformColor?
+
+        /// - parameter success: A tint color to be used with a loaded image.
+        /// - parameter failure: A tint color to be used with a `failureImage`.
+        /// - parameter placeholder: A tint color to be used with a `placeholder`.
+        public init(success: PlatformColor?, failure: PlatformColor?, placeholder: PlatformColor?) {
+            self.success = success; self.failure = failure; self.placeholder = placeholder
+        }
+    }
+
     #endif
 
     #if os(iOS) || os(tvOS)
@@ -215,12 +243,13 @@ public struct ImageLoadingOptions {
     /// performed when displaying a failure image. `nil` by default.
     /// - parameter contentModes: Content modes to be used for each image type
     /// (placeholder, success, failure). `nil` by default (don't change content mode).
-    public init(placeholder: UIImage? = nil, transition: Transition? = nil, failureImage: UIImage? = nil, failureImageTransition: Transition? = nil, contentModes: ContentModes? = nil) {
+    public init(placeholder: UIImage? = nil, transition: Transition? = nil, failureImage: UIImage? = nil, failureImageTransition: Transition? = nil, contentModes: ContentModes? = nil, tintColors: TintColors? = nil) {
         self.placeholder = placeholder
         self.transition = transition
         self.failureImage = failureImage
         self.failureImageTransition = failureImageTransition
         self.contentModes = contentModes
+        self.tintColors = tintColors
     }
 
     #elseif os(macOS)
@@ -370,7 +399,13 @@ private final class ImageViewController {
         }
 
         // Display a placeholder.
-        if let placeholder = options.placeholder {
+        if var placeholder = options.placeholder {
+            #if os(iOS) || os(tvOS)
+            if let tintColor = options.tintColors?.placeholder {
+                placeholder = placeholder.withRenderingMode(.alwaysTemplate)
+                imageView.tintColor = tintColor
+            }
+            #endif
             imageView.nuke_display(image: placeholder)
             #if os(iOS) || os(tvOS)
             if let contentMode = options.contentModes?.placeholder {
@@ -417,22 +452,29 @@ private final class ImageViewController {
     private func handle(result: Result<ImageResponse, ImagePipeline.Error>, fromMemCache: Bool, options: ImageLoadingOptions) {
         switch result {
         case let .success(response):
-            display(response.image, options.transition, options.alwaysTransition, fromMemCache, options.contentModes?.success)
+            display(response.image, options.transition, options.alwaysTransition, fromMemCache, options.contentModes?.success, options.tintColors?.success)
         case .failure:
             if let failureImage = options.failureImage {
-                display(failureImage, options.failureImageTransition, options.alwaysTransition, fromMemCache, options.contentModes?.failure)
+                display(failureImage, options.failureImageTransition, options.alwaysTransition, fromMemCache, options.contentModes?.failure, options.tintColors?.failure)
             }
         }
         self.task = nil
     }
 
     private func handle(partialImage response: ImageResponse, options: ImageLoadingOptions) {
-        display(response.image, options.transition, options.alwaysTransition, false, options.contentModes?.success)
+        display(response.image, options.transition, options.alwaysTransition, false, options.contentModes?.success, options.tintColors?.success)
     }
 
-    private func display(_ image: UIImage, _ transition: ImageLoadingOptions.Transition?, _ alwaysTransition: Bool, _ fromMemCache: Bool, _ newContentMode: UIView.ContentMode?) {
+    private func display(_ image: UIImage, _ transition: ImageLoadingOptions.Transition?, _ alwaysTransition: Bool, _ fromMemCache: Bool, _ newContentMode: UIView.ContentMode?, _ newTintColor: PlatformColor?) {
         guard let imageView = imageView else {
             return
+        }
+
+        var image = image
+
+        if let newTintColor = newTintColor {
+            image = image.withRenderingMode(.alwaysTemplate)
+            imageView.tintColor = newTintColor
         }
 
         if !fromMemCache || alwaysTransition, let transition = transition {

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -457,7 +457,7 @@ class ImageViewLoadingOptionsTests: XCTestCase {
 
         mockCache[Test.request] = Test.container
 
-        // Whem
+        // When
         Nuke.loadImage(with: Test.request, options: options, into: imageView)
 
         // Then
@@ -484,6 +484,74 @@ class ImageViewLoadingOptionsTests: XCTestCase {
 
         // Then
         XCTAssertEqual(imageView.contentMode, .center)
+    }
+    
+    #endif
+    
+    #if os(iOS) || os(tvOS)
+    
+    // MARK: - Tint Colors
+    
+    func testPlaceholderAndSuccessTintColorApplied() {
+        // Given
+        var options = ImageLoadingOptions()
+        options.tintColors = .init(
+            success: .blue,
+            failure: nil,
+            placeholder: .yellow
+        )
+        options.placeholder = PlatformImage()
+        
+        // When
+        expectToFinishLoadingImage(with: Test.request, options: options, into: imageView)
+        
+        // Then
+        XCTAssertEqual(imageView.tintColor, .yellow)
+        wait()
+        XCTAssertEqual(imageView.tintColor, .blue)
+        XCTAssertEqual(imageView.image?.renderingMode, .alwaysTemplate)
+    }
+    
+    func testSuccessTintColorAppliedWhenFromMemoryCache() {
+        // Given
+        var options = ImageLoadingOptions()
+        options.tintColors = .init(
+            success: .blue,
+            failure: nil,
+            placeholder: nil
+        )
+        
+        mockCache[Test.request] = Test.container
+        
+        // When
+        Nuke.loadImage(with: Test.request, options: options, into: imageView)
+        
+        // Then
+        XCTAssertEqual(imageView.tintColor, .blue)
+        XCTAssertEqual(imageView.image?.renderingMode, .alwaysTemplate)
+    }
+    
+    func testFailureTintColorApplied() {
+        // Given
+        var options = ImageLoadingOptions()
+        options.tintColors = .init(
+            success: nil,
+            failure: .red,
+            placeholder: nil
+        )
+        options.failureImage = PlatformImage()
+        
+        dataLoader.results[Test.url] = .failure(
+            NSError(domain: "t", code: 42, userInfo: nil)
+        )
+        
+        // When
+        expectToFinishLoadingImage(with: Test.request, options: options, into: imageView)
+        wait()
+        
+        // Then
+        XCTAssertEqual(imageView.tintColor, .red)
+        XCTAssertEqual(imageView.image?.renderingMode, .alwaysTemplate)
     }
 
     #endif


### PR DESCRIPTION
When retrieving icons from the cloud, it's useful to set tint colours to them based on the app theme. I've made the assumption if tint colours are set, then rendering mode must be set to `.alwaysTemplate` which I think is a fair assumption? Looking forward to hearing your thoughts or if there's a better place to implement this.