### PR TITLE
Fix a bug where ImagePipeline.loadImage could retain its completion block indefinitely

### DIFF
--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -887,3 +887,10 @@ public extension ImagePipeline {
         }
     }
 }
+
+// MARK: - Testing
+internal extension ImagePipeline {
+    var taskCount: Int {
+        return tasks.count
+    }
+}

--- a/Sources/Task.swift
+++ b/Sources/Task.swift
@@ -86,6 +86,9 @@ final class Task<Value, Error>: TaskSubscriptionDelegate {
         starter?(self)
         starter = nil
 
+        // The task may have been completed synchronously by `starter`.
+        guard !isDisposed else { return nil }
+
         return subscription
     }
 

--- a/Tests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineTests.swift
@@ -471,6 +471,20 @@ class ImagePipelineMemoryCacheTests: XCTestCase {
         XCTAssertEqual(dataLoader.createdTaskCount, 1)
         XCTAssertNotNil(cache[Test.request])
     }
+
+    func testTaskCountAfterCachedLoad() {
+        // Given
+        cache[Test.request] = ImageContainer(image: Test.image)
+
+        // When
+        expect(pipeline).toLoadImage(with: Test.request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 0)
+        XCTAssertNotNil(cache[Test.request])
+        XCTAssertEqual(pipeline.taskCount, 0)
+    }
 }
 
 class ImagePipelineErrorHandlingTests: XCTestCase {

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -155,6 +155,23 @@ class TaskTests: XCTestCase {
         XCTAssertNil(task.subscribe { _ in })
     }
 
+    func testSubscribeToTaskWithSynchronousCompletionReturnsNil() {
+        // Given
+        let task = Task<Int, MyError> { (task) in
+            task.send(value: 0, isCompleted: true)
+        }
+
+        // When
+        let expectation = self.expectation(description: "Observer called")
+        let subscription = task.subscribe { _ in
+            expectation.fulfill()
+        }
+
+        // Then
+        XCTAssertNil(subscription)
+        wait()
+    }
+
     // MARK: - Ubsubscribe
 
     func testWhenSubscriptionIsRemovedNoEventsAreSent() {


### PR DESCRIPTION
A task can be synchronously terminated by its `starter` block during a call to Task.subscribe(), for instance when the result is cached. This in turn causes ImagePipeline's startImageTask/startDataTask to retain the task and subscription in the `tasks` dictionary indefinitely.

This fix changes Task.subscribe() to return nil if the task is terminated before the method returns. This appears to be in line with the documented intent for the method, and resolves the issue.