### PR TITLE
Make imageView unowned in ImageViewController

### DIFF
--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -332,9 +332,7 @@ public struct ImageLoadingOptions {
 /// however as it stands today `ImageViewController` is just a helper class,
 /// making it public wouldn't expose any additional functionality to the users.
 private final class ImageViewController {
-    // Ideally should be `unowned` but can't because of the Swift bug
-    // https://bugs.swift.org/browse/SR-7369
-    private weak var imageView: ImageDisplayingView?
+    private unowned var imageView: ImageDisplayingView?
     private var task: ImageTask?
 
     // Automatically cancel the request when the view is deallocated.

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -332,7 +332,7 @@ public struct ImageLoadingOptions {
 /// however as it stands today `ImageViewController` is just a helper class,
 /// making it public wouldn't expose any additional functionality to the users.
 private final class ImageViewController {
-    private unowned var imageView: ImageDisplayingView?
+    private weak var imageView: ImageDisplayingView?
     private var task: ImageTask?
 
     // Automatically cancel the request when the view is deallocated.


### PR DESCRIPTION
Hi! Looks like the referenced bug was fixed long ago. So, here it is - `unowned imageView`
I'm not sure if it changes any performance characteristics but theoretically, it should, right?