### PR TITLE
Fix broken link in Nuke 9 Migration Guide

### DIFF
--- a/Documentation/Migrations/Nuke 9 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 9 Migration Guide.md
@@ -2,7 +2,7 @@
 
 This guide is provided in order to ease the transition of existing applications using Nuke 8.x to the latest version, as well as explain the design and structure of new and changed functionality.
 
-> To learn about the new features in Nuke 9 see the [release notes](https://github.com/kean/Nuke/releases/tag/9.0-beta.2).
+> To learn about the new features in Nuke 9 see the [release notes](https://github.com/kean/Nuke/releases/tag/9.0.0).
 
 ## Minimum Requirements
 


### PR DESCRIPTION
Looks like the link to release notes is broken for pointing at `9.0-beta.2` instead of `9.0.0-beta.2`. Anyways, it seems like this should be pointing at `9.0.0` now.