### PR TITLE
Fix cache memory pressure monitoring

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -156,7 +156,7 @@ final class Cache<Key: Hashable, Value> {
     init(costLimit: Int, countLimit: Int) {
         self.costLimit = costLimit
         self.countLimit = countLimit
-        self.memoryPressure = DispatchSource.makeMemoryPressureSource(eventMask: .all, queue: .main)
+        self.memoryPressure = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)
         self.memoryPressure.setEventHandler { [weak self] in
             self?.removeAll()
         }


### PR DESCRIPTION
Fixes an issue introduced in #370 where caches are cleared when the memory pressure changes to a `normal` level.
Limits image cache clearing to `warning` and `critical` memory pressure level changes.