### PR TITLE
WIP: Switch to UIGraphicsImageRendererFormat

### DIFF
--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -475,26 +475,13 @@ extension PlatformImage {
     ///
     /// - parameter drawRect: `nil` by default. If `nil` will use the canvas rect.
     func draw(inCanvasWithSize canvasSize: CGSize, drawRect: CGRect? = nil) -> PlatformImage? {
-        guard let cgImage = cgImage else {
-            return nil
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: canvasSize, format: format)
+        let output = renderer.image { _ in
+            draw(in: drawRect ?? CGRect(origin: .zero, size: canvasSize))
         }
-
-        // For more info see:
-        // - Quartz 2D Programming Guide
-        // - https://github.com/kean/Nuke/issues/35
-        // - https://github.com/kean/Nuke/issues/57
-        let alphaInfo: CGImageAlphaInfo = cgImage.isOpaque ? .noneSkipLast : .premultipliedLast
-
-        guard let ctx = CGContext(
-            data: nil,
-            width: Int(canvasSize.width), height: Int(canvasSize.height),
-            bitsPerComponent: 8, bytesPerRow: 0,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: alphaInfo.rawValue) else {
-                return nil
-        }
-        ctx.draw(cgImage, in: drawRect ?? CGRect(origin: .zero, size: canvasSize))
-        guard let outputCGImage = ctx.makeImage() else {
+        guard let outputCGImage = output.cgImage else {
             return nil
         }
         return PlatformImage.make(cgImage: outputCGImage, source: self)

--- a/Tests/ImageProcessorsTests/RoundedCornersTests.swift
+++ b/Tests/ImageProcessorsTests/RoundedCornersTests.swift
@@ -108,7 +108,7 @@ class ImageProcessorsRoundedCornersTests: XCTestCase {
 
     func testDescriptionWithBorder() {
         // Given
-        let processor = ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red))
+        let processor = ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red, width: 2, unit: .pixels))
 
         // Then
         XCTAssertEqual(processor.description, "RoundedCorners(radius: 16.0 pixels, border: Border(color: #FF0000, width: 2.0 pixels))")

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -169,6 +169,17 @@ class RequestPerformanceTests: XCTestCase {
 }
 
 class ImageProcessingPerformanceTests: XCTestCase {
+    func testResizeProcessor() {
+        let processor = ImageProcessors.Resize(width: 100)
+        let image = Test.image
+
+        measure {
+            for _ in 0..<500 {
+                _ = processor.process(image)
+            }
+        }
+    }
+
     func testCreatingProcessorIdentifiers() {
         let decompressor = ImageProcessors.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)
 


### PR DESCRIPTION
`UIGraphicsImageRendererFormat` is a relatively new API.

There are some potential issues with using it:

- It seems to default to `.premultipliedLast` alpha mask. It results in about 30% performance reduction for opaque images compared to `.noneSkipLast`. I'm not sure how it affects rendering down the line.

Overall, I' not it's the best approach for resizing. It seems to be designed for creating new images by drawing some basic shapes and/or composing with existing images. The existing approach is not great either because it hardcodes color space (doesn't support extended range), etc.