### PR TITLE
Make ImageProcessors.Circle and ImageProcessors.RoundedCorners available on macOS

### DIFF
--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -464,7 +464,7 @@ extension ImageProcessors {
 
 // MARK: - Image Processing (Internal)
 
-extension PlatformImage {
+private extension PlatformImage {
     /// Draws the image in a `CGContext` in a canvas with the given size using
     /// the specified draw rect.
     ///
@@ -499,13 +499,13 @@ extension PlatformImage {
 
 // MARK: - ImageProcessingExtensions
 
-extension PlatformImage {
+private extension PlatformImage {
     var processed: ImageProcessingExtensions {
         ImageProcessingExtensions(image: self)
     }
 }
 
-struct ImageProcessingExtensions {
+private struct ImageProcessingExtensions {
     let image: PlatformImage
 
     func byResizing(to targetSize: CGSize,
@@ -603,7 +603,7 @@ struct ImageProcessingExtensions {
 // MARK: - CoreGraphics Helpers (Internal)
 
 #if os(macOS)
-extension NSImage {
+private extension NSImage {
     var cgImage: CGImage? {
         cgImage(forProposedRect: nil, context: nil, hints: nil)
     }
@@ -613,7 +613,7 @@ extension NSImage {
     }
 }
 #else
-extension UIImage {
+private extension UIImage {
     static func make(cgImage: CGImage, source: UIImage) -> UIImage {
         UIImage(cgImage: cgImage, scale: source.scale, orientation: source.imageOrientation)
     }
@@ -641,6 +641,7 @@ private extension CGFloat {
     }
 }
 
+// Adds Hashable without making changes to public CGSize API
 private struct Size: Hashable {
     let cgSize: CGSize
 
@@ -650,7 +651,7 @@ private struct Size: Hashable {
     }
 }
 
-extension CGSize {
+private extension CGSize {
     /// Creates the size in pixels by scaling to the input size to the screen scale
     /// if needed.
     init(size: CGSize, unit: ImageProcessingOptions.Unit) {

--- a/Sources/ImageProcessing.swift
+++ b/Sources/ImageProcessing.swift
@@ -97,7 +97,7 @@ public enum ImageProcessors {}
 extension ImageProcessors {
     /// Scales an image to a specified size.
     public struct Resize: ImageProcessing, Hashable, CustomStringConvertible {
-        private let size: CGSize
+        private let size: Size
         private let contentMode: ContentMode
         private let crop: Bool
         private let upscale: Bool
@@ -129,7 +129,7 @@ extension ImageProcessors {
         /// Does nothing with content mode .aspectFill. `false` by default.
         /// - parameter upscale: `false` by default.
         public init(size: CGSize, unit: ImageProcessingOptions.Unit = .points, contentMode: ContentMode = .aspectFill, crop: Bool = false, upscale: Bool = false) {
-            self.size = CGSize(size: size, unit: unit)
+            self.size = Size(cgSize: CGSize(size: size, unit: unit))
             self.contentMode = contentMode
             self.crop = crop
             self.upscale = upscale
@@ -151,20 +151,20 @@ extension ImageProcessors {
 
         public func process(_ image: PlatformImage) -> PlatformImage? {
             if crop && contentMode == .aspectFill {
-                return image.processed.byResizingAndCropping(to: size)
+                return image.processed.byResizingAndCropping(to: size.cgSize)
             } else {
-                return image.processed.byResizing(to: size, contentMode: contentMode, upscale: upscale)
+                return image.processed.byResizing(to: size.cgSize, contentMode: contentMode, upscale: upscale)
             }
         }
 
         public var identifier: String {
-            "com.github.kean/nuke/resize?s=\(size),cm=\(contentMode),crop=\(crop),upscale=\(upscale)"
+            "com.github.kean/nuke/resize?s=\(size.cgSize),cm=\(contentMode),crop=\(crop),upscale=\(upscale)"
         }
 
         public var hashableIdentifier: AnyHashable { self }
 
         public var description: String {
-            "Resize(size: \(size) pixels, contentMode: \(contentMode), crop: \(crop), upscale: \(upscale))"
+            "Resize(size: \(size.cgSize) pixels, contentMode: \(contentMode), crop: \(crop), upscale: \(upscale))"
         }
     }
 }
@@ -632,7 +632,7 @@ extension CGImage {
     }
 }
 
-extension CGFloat {
+private extension CGFloat {
     func converted(to unit: ImageProcessingOptions.Unit) -> CGFloat {
         switch unit {
         case .pixels: return self
@@ -641,10 +641,12 @@ extension CGFloat {
     }
 }
 
-extension CGSize: Hashable { // For some reason `CGSize` isn't `Hashable`
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(width)
-        hasher.combine(height)
+private struct Size: Hashable {
+    let cgSize: CGSize
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(cgSize.width)
+        hasher.combine(cgSize.height)
     }
 }
 

--- a/Tests/ImageProcessorsTests/RoundedCornersTests.swift
+++ b/Tests/ImageProcessorsTests/RoundedCornersTests.swift
@@ -9,7 +9,6 @@ import XCTest
     import UIKit
 #endif
 
-#if os(iOS) || os(tvOS)
 class ImageProcessorsRoundedCornersTests: XCTestCase {
 
     func _testThatCornerRadiusIsAdded() throws {
@@ -21,7 +20,8 @@ class ImageProcessorsRoundedCornersTests: XCTestCase {
         let output = try XCTUnwrap(processor.process(input), "Failed to process an image")
 
         // Then
-        XCTAssertEqualImages(output, Test.image(named: "s-rounded-corners.png"))
+        let expected = Test.image(named: "s-rounded-corners.png")
+        XCTAssertEqualImages(output, expected)
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 200, height: 150))
     }
 
@@ -35,7 +35,8 @@ class ImageProcessorsRoundedCornersTests: XCTestCase {
         let output = try XCTUnwrap(processor.process(input), "Failed to process an image")
 
         // Then
-        XCTAssertEqualImages(output, Test.image(named: "s-rounded-corners-border.png"))
+        let expected = Test.image(named: "s-rounded-corners-border.png")
+        XCTAssertEqualImages(output, expected)
     }
 
     func testExtendedColorSpaceSupport() throws {
@@ -71,10 +72,21 @@ class ImageProcessorsRoundedCornersTests: XCTestCase {
             ImageProcessors.RoundedCorners(radius: 16).identifier,
             ImageProcessors.RoundedCorners(radius: 8).identifier
         )
-        XCTAssertNotEqual(
-            ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).identifier,
-            ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).identifier
-        )
+        if Screen.scale == 1 {
+            XCTAssertEqual(
+                ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).identifier,
+                ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).identifier
+            )
+            XCTAssertNotEqual(
+                ImageProcessors.RoundedCorners(radius: 32, unit: .pixels, border: .init(color: .red)).identifier,
+                ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).identifier
+            )
+        } else {
+            XCTAssertNotEqual(
+                ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).identifier,
+                ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).identifier
+            )
+        }
         XCTAssertNotEqual(
             ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).identifier,
             ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .blue)).identifier
@@ -101,10 +113,21 @@ class ImageProcessorsRoundedCornersTests: XCTestCase {
             ImageProcessors.RoundedCorners(radius: 16).hashableIdentifier,
             ImageProcessors.RoundedCorners(radius: 8).hashableIdentifier
         )
-        XCTAssertNotEqual(
-            ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).hashableIdentifier,
-            ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).hashableIdentifier
-        )
+        if Screen.scale == 1 {
+            XCTAssertEqual(
+                ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).hashableIdentifier,
+                ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).hashableIdentifier
+            )
+            XCTAssertNotEqual(
+                ImageProcessors.RoundedCorners(radius: 32, unit: .pixels, border: .init(color: .red)).hashableIdentifier,
+                ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).hashableIdentifier
+            )
+        } else {
+            XCTAssertNotEqual(
+                ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).hashableIdentifier,
+                ImageProcessors.RoundedCorners(radius: 16, unit: .points, border: .init(color: .red)).hashableIdentifier
+            )
+        }
         XCTAssertNotEqual(
             ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .red)).hashableIdentifier,
             ImageProcessors.RoundedCorners(radius: 16, unit: .pixels, border: .init(color: .blue)).hashableIdentifier
@@ -127,4 +150,3 @@ class ImageProcessorsRoundedCornersTests: XCTestCase {
         XCTAssertEqual(processor.description, "RoundedCorners(radius: 16.0 pixels, border: Border(color: #FF0000, width: 2.0 pixels))")
     }
 }
-#endif


### PR DESCRIPTION
- Make `ImageProcessors.Circle` and `ImageProcessors.RoundedCorners` available on macOS
- Remove public `CGSize: Hashable` conformance