### PR TITLE
Add ImageRequest.CachePolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Nuke is easy to learn and use. Here is an overview of its APIs and features:
 - **Image View Extensions** ‣ [UI Extensions](#image-view-extensions) · [Table View](#in-a-table-view) · [Placeholders, Transitions](#placeholders-transitions-content-modes) · [`ImageRequest`](#imagerequest)
 - **Image Processing** ‣ [`Resize`](#resize) · [`Circle`](#circle) · [`RoundedCorners`](#roundedcorners) · [`GaussianBlur`](#gaussianblur) · [`CoreImage`](#coreimagefilter) · [Custom Processors](#custom-processors)
 - **Image Pipeline** ‣ [Load Image](#image-pipeline) · [`ImageTask`](#imagetask) · [Customize Image Pipeline](#customize-image-pipeline) · [Default Pipeline](#default-image-pipeline)
-- **Caching** ‣ [LRU Memory Cache](#lru-memory-cache) · [HTTP Disk Cache](#http-disk-cache) · [Aggressive LRU Disk Cache](#aggressive-lru-disk-cache)
+- **Caching** ‣ [LRU Memory Cache](#lru-memory-cache) · [HTTP Disk Cache](#http-disk-cache) · [Aggressive LRU Disk Cache](#aggressive-lru-disk-cache) · [Reloading Images](#reloading-images)
 - **Advanced Features** ‣ [Preheat Images](#image-preheating) · [Progressive Decoding](#progressive-decoding)
 - [**Extensions**](#h_plugins) ‣ [FetchImage](#fetch-image) · [Builder](#builder) · [Combine](#combine) · [RxNuke](#rxnuke) · [And More](#h_plugins) 
 
@@ -105,6 +105,7 @@ Please keep in mind that the built-in extensions for image views are designed to
 let request = ImageRequest(
     url: URL(string: "http://..."),
     processors: [ImageProcessors.Resize(size: imageView.bounds.size)],
+    cachePolicy: .reloadIgnoringCacheData,
     priority: .high
 )
 ```
@@ -398,6 +399,24 @@ ImagePipeline {
 By default, the pipeline stores only the original image data. To store downloaded and processed images instead, set `dataCacheOptions.storedItems` to `[.finalImage]`. This option is useful if you want to store processed, e.g. downsampled images, or if you want to transcode images to a more efficient format, like HEIF.
 
 > To save disk space see `ImageEncoders.ImageIO` and  `ImageEncoder.isHEIFPreferred` option for HEIF support.
+
+### Reloading Images
+
+There are two options available. You can remove an image from all cache layers:
+
+```swift
+let request = ImageRequest(url: url)
+pipeline.removeCachedImage(for: request)
+```
+
+Another option is to keep the image in cache, but instruct the pipeline to ignore the cached data:
+
+```swift
+let request = ImageRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
+Nuke.loadImage(with: request, into: imageView)
+```
+
+> If you are manually constucting a `URLRequest`, make sure to update the respective cache policy of the URL request.
 
 <br/>
 

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -223,7 +223,7 @@ public extension ImagePipeline {
     /// Returns a cached response from the memory cache. Returns `nil` if the request disables
     /// memory cache reads.
     func cachedImage(for request: ImageRequest) -> ImageContainer? {
-        guard request.options.memoryCacheOptions.isReadAllowed else { return nil }
+        guard request.options.memoryCacheOptions.isReadAllowed && request.cachePolicy != .reloadIgnoringCachedData else { return nil }
 
         let request = inheritOptions(request)
         return configuration.imageCache?[request]
@@ -354,7 +354,7 @@ private extension ImagePipeline {
             }
         }
 
-        guard let dataCache = configuration.dataCache, configuration.dataCacheOptions.storedItems.contains(.finalImage) else {
+        guard let dataCache = configuration.dataCache, configuration.dataCacheOptions.storedItems.contains(.finalImage), request.cachePolicy != .reloadIgnoringCachedData else {
             return loadDecompressedImage(for: request, task: task)
         }
 
@@ -679,7 +679,7 @@ private extension ImagePipeline {
     }
 
     func performOriginalImageDataTask(_ task: OriginalImageDataTask, context: OriginalImageDataTaskContext) {
-        guard let cache = configuration.dataCache, configuration.dataCacheOptions.storedItems.contains(.originalImageData) else {
+        guard let cache = configuration.dataCache, configuration.dataCacheOptions.storedItems.contains(.originalImageData), context.request.cachePolicy != .reloadIgnoringCachedData else {
             loadImageData(for: task, context: context) // Skip disk cache lookup, load data
             return
         }

--- a/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
@@ -88,6 +88,37 @@ class ImagePipelineDataCachingTests: XCTestCase {
         task.cancel()
         wait() // Wait till operation is created
     }
+
+    // MARK: - Cache Policy
+
+    func testReloadIgnoringCacheData() {
+        // Given
+        dataCache.store[Test.url.absoluteString] = Test.data
+
+        var request = Test.request
+        request.cachePolicy = .reloadIgnoringCachedData
+
+        // When
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 1)
+    }
+
+    func testReloadRemovingCacheData() {
+        // Given
+        let request = Test.request
+        dataCache.store[request.urlRequest.url!.absoluteString] = Test.data
+
+        // When
+        pipeline.removeCachedImage(for: request)
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 1)
+    }
 }
 
 class ImagePipelineProcessedDataCachingTests: XCTestCase {

--- a/Tests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineTests.swift
@@ -485,6 +485,37 @@ class ImagePipelineMemoryCacheTests: XCTestCase {
         XCTAssertNotNil(cache[Test.request])
         XCTAssertEqual(pipeline.taskCount, 0)
     }
+
+    func testReloadIgnoringCacheData() {
+        // Given
+        cache[Test.request] = ImageContainer(image: Test.image)
+
+        var request = Test.request
+        request.cachePolicy = .reloadIgnoringCachedData
+
+        // When
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 1)
+        XCTAssertNotNil(cache[Test.request])
+    }
+
+    func testReloadRemovingCacheData() {
+        // Given
+        let request = Test.request
+        cache[request] = ImageContainer(image: Test.image)
+
+        // When
+        pipeline.removeCachedImage(for: request)
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 1)
+        XCTAssertNotNil(cache[request])
+    }
 }
 
 class ImagePipelineErrorHandlingTests: XCTestCase {

--- a/Tests/ImageViewTests.swift
+++ b/Tests/ImageViewTests.swift
@@ -597,6 +597,22 @@ class ImageViewLoadingOptionsTests: XCTestCase {
         XCTAssertEqual(imageView.image, placeholder)
 
         ImageLoadingOptions.popShared()
+    }
 
+    // MARK: - Cache Policy
+
+    func testReloadIgnoringCacheData() {
+        // When the requested image is stored in memory cache
+        var request = Test.request
+        mockCache[request] = ImageContainer(image: PlatformImage())
+
+        request.cachePolicy = .reloadIgnoringCachedData
+
+        // When
+        expectToFinishLoadingImage(with: request, into: imageView)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 1)
     }
 }

--- a/Tests/MockDataCache.swift
+++ b/Tests/MockDataCache.swift
@@ -15,4 +15,8 @@ final class MockDataCache: DataCaching {
     func storeData(_ data: Data, for key: String) {
         store[key] = data
     }
+
+    func removeData(for key: String) {
+        store[key] = nil
+    }
 }


### PR DESCRIPTION
Add an option to keep the images in cache, but instruct the pipeline to ignore the cached data.

```swift
let request = ImageRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
Nuke.loadImage(with: request, into: imageView)
```