### PR TITLE
Add ImageRequest.CachePolicy.returnCacheDataDontLoad

### DIFF
--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -71,6 +71,9 @@ public struct ImageRequest: CustomStringConvertible {
         /// If you initialize the request with `URLRequest`, make sure to provide
         /// the correct policy in the request too.
         case reloadIgnoringCachedData
+
+        /// Use existing cache data, regardless or age or expiration date, and fail if no cached data is available.
+        case returnCacheDataDontLoad
     }
 
     public var cachePolicy: CachePolicy {

--- a/Sources/Tasks/TaskLoadImageData.swift
+++ b/Sources/Tasks/TaskLoadImageData.swift
@@ -37,6 +37,14 @@ final class TaskLoadImageData: ImagePipelineTask<(Data, URLResponse?)> {
     }
 
     private func loadData() {
+        guard request.cachePolicy != .returnCacheDataDontLoad else {
+            // Same error that URLSession produces when .returnCacheDataDontLoad is specified and the
+            // data is no found in the cache.
+            let error = NSError(domain: URLError.errorDomain, code: URLError.resourceUnavailable.rawValue, userInfo: nil)
+            self.send(error: .dataLoadingFailed(error))
+            return
+        }
+
         if let rateLimiter = pipeline.rateLimiter {
             // Rate limiter is synchronized on pipeline's queue. Delayed work is
             // executed asynchronously also on this same queue.

--- a/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
@@ -119,6 +119,53 @@ class ImagePipelineDataCachingTests: XCTestCase {
         // Then
         XCTAssertEqual(dataLoader.createdTaskCount, 1)
     }
+
+    func testLoadFromCacheOnlyDataCache() {
+        // Given
+        dataCache.store[Test.url.absoluteString] = Test.data
+
+        var request = Test.request
+        request.cachePolicy = .returnCacheDataDontLoad
+
+        // When
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 0)
+    }
+
+    func testLoadFromCacheOnlyMemoryCache() {
+        // Given
+        let imageCache = MockImageCache()
+        imageCache[Test.request] = ImageContainer(image: Test.image)
+        pipeline = pipeline.reconfigured {
+            $0.imageCache = imageCache
+        }
+
+        var request = Test.request
+        request.cachePolicy = .returnCacheDataDontLoad
+
+        // When
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 0)
+    }
+
+    func testLoadFromCacheOnlyFailsIfNoMemoryCache() {
+        // Given no cache
+        var request = Test.request
+        request.cachePolicy = .returnCacheDataDontLoad
+
+        // When
+        expect(pipeline).toFailRequest(request)
+        wait()
+
+        // Then
+        XCTAssertEqual(dataLoader.createdTaskCount, 0)
+    }
 }
 
 class ImagePipelineProcessedDataCachingTests: XCTestCase {


### PR DESCRIPTION
This new policy works similar to `URLRequest` [cachePolicy](https://developer.apple.com/documentation/foundation/urlrequest/cachepolicy) with the same name but will work with the custom data cache that you provide using `ImagePipeline.Configuration`. It covers a couple of scenarios that currently are unnecessarily hard to implement using Nuke.