### PR TITLE
Add Low Data Mode

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		0C8684FF20BDD578009FF7CC /* ImagePipelineProgressiveDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2A8CFA20970D8D0013FD65 /* ImagePipelineProgressiveDecodingTests.swift */; };
 		0C86AB6A228B3B5100A81BA1 /* ImageTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C86AB69228B3B5100A81BA1 /* ImageTask.swift */; };
 		0C880532242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C880531242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift */; };
+		0C88C579263DAF1E0061A008 /* ImagePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C88C578263DAF1E0061A008 /* ImagePublisherTests.swift */; };
 		0C8D7BD31D9DBF1600D12EB7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD21D9DBF1600D12EB7 /* AppDelegate.swift */; };
 		0C8D7BD51D9DBF1600D12EB7 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD41D9DBF1600D12EB7 /* ViewController.swift */; };
 		0C8D7BD81D9DBF1600D12EB7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0C8D7BD61D9DBF1600D12EB7 /* Main.storyboard */; };
@@ -246,6 +247,7 @@
 		0C7CE29C243941A20018C8C3 /* s-sepia-less-intense.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "s-sepia-less-intense.png"; sourceTree = "<group>"; };
 		0C86AB69228B3B5100A81BA1 /* ImageTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTask.swift; sourceTree = "<group>"; };
 		0C880531242E7B1500F8C5B3 /* ImagePipelineDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDecodingTests.swift; sourceTree = "<group>"; };
+		0C88C578263DAF1E0061A008 /* ImagePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePublisherTests.swift; sourceTree = "<group>"; };
 		0C8D74201D9D6EEB0036349E /* DataCachePeformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCachePeformanceTests.swift; sourceTree = "<group>"; };
 		0C8D7BD01D9DBF1600D12EB7 /* Nuke Tests Host.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Nuke Tests Host.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C8D7BD21D9DBF1600D12EB7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				0C4AF1E91FE8551D002F86CB /* LinkedListTest.swift */,
 				0CB2EFD52110F52C00F7C63F /* RateLimiterTests.swift */,
 				0C0F7BF02287F6EE0034E656 /* TaskTests.swift */,
+				0C88C578263DAF1E0061A008 /* ImagePublisherTests.swift */,
 				0C4F8FE722E4B7260070ECFD /* ThreadSafety */,
 				0C2CD7B225B7BFBF0017018F /* MemoryManagementTests */,
 				0CC6276525C0A16300466F04 /* PerformanceTests */,
@@ -997,6 +1000,7 @@
 				0CAAB0101E45D6DA00924450 /* NukeExtensions.swift in Sources */,
 				0CE745751D4767B900123F65 /* MockImageDecoder.swift in Sources */,
 				0C70D9782089017500A49DAC /* ImageDecoderTests.swift in Sources */,
+				0C88C579263DAF1E0061A008 /* ImagePublisherTests.swift in Sources */,
 				0CB2EFD22110F38600F7C63F /* ImagePipelineConfigurationTests.swift in Sources */,
 				0C6B5BE1257010D300D763F2 /* ImagePipelineFormatsTests.swift in Sources */,
 				0C7527A01D473AF100EC6222 /* MockImagePipeline.swift in Sources */,

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -447,6 +447,16 @@ public extension ImagePipeline {
             case .processingFailed: return "Failed to process the image"
             }
         }
+
+        /// Returns underlying data loading error.
+        public var dataLoadingError: Swift.Error? {
+            switch self {
+            case .dataLoadingFailed(let error):
+                return error
+            default:
+                return nil
+            }
+        }
     }
 }
 

--- a/Tests/ImagePublisherTests.swift
+++ b/Tests/ImagePublisherTests.swift
@@ -1,0 +1,75 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+import Combine
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+class ImagePublisherTests: XCTestCase {
+    var dataLoader: MockDataLoader!
+    var pipeline: ImagePipeline!
+    var cancellable: AnyCancellable?
+
+    override func setUp() {
+        super.setUp()
+
+        dataLoader = MockDataLoader()
+        pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+    }
+
+    func testLowDataMode() {
+        // GIVEN
+        let highQualityImageURL = URL(string: "https://example.com/high-quality-image.jpeg")!
+        let lowQualityImageURL = URL(string: "https://example.com/low-quality-image.jpeg")!
+
+        dataLoader.results[highQualityImageURL] = .failure(URLError(networkUnavailableReason: .constrained) as NSError)
+        dataLoader.results[lowQualityImageURL] = .success((Test.data, Test.urlResponse))
+
+        // WHEN
+        let pipeline = self.pipeline!
+
+        // Create the default request to fetch the high quality image.
+        var urlRequest = URLRequest(url: highQualityImageURL)
+        urlRequest.allowsConstrainedNetworkAccess = false
+        let request = ImageRequest(urlRequest: urlRequest)
+
+        // WHEN
+        let image = pipeline.imagePublisher(with: request).tryCatch { error -> ImagePublisher in
+            guard (error.dataLoadingError as? URLError)?.networkUnavailableReason == .constrained else {
+                throw error
+            }
+            return pipeline.imagePublisher(with: lowQualityImageURL)
+        }
+
+        let expectation = self.expectation(description: "LowDataImageFetched")
+        cancellable = image.sink(receiveCompletion: { result in
+            switch result {
+            case .finished:
+                break // Expected result
+            case .failure:
+                XCTFail()
+            }
+        }, receiveValue: {
+            XCTAssertNotNil($0.image)
+            expectation.fulfill()
+        })
+        wait()
+    }
+}
+
+/// We have to mock it because there is no way to construct native `URLError`
+/// with a `networkUnavailableReason`.
+private struct URLError: Swift.Error {
+    var networkUnavailableReason: NetworkUnavailableReason?
+
+    enum NetworkUnavailableReason {
+        case cellular
+        case expensive
+        case constrained
+    }
+}

--- a/Tests/MockDataLoader.swift
+++ b/Tests/MockDataLoader.swift
@@ -19,7 +19,7 @@ class MockDataLoader: DataLoading {
     static let DidCancelTask = Notification.Name("com.github.kean.Nuke.Tests.MockDataLoader.DidCancelTask")
     
     var createdTaskCount = 0
-    var results = [URL: _Result<(Data, URLResponse), NSError>]()
+    var results = [URL: Result<(Data, URLResponse), NSError>]()
     let queue = OperationQueue()
 
     func loadData(with request: URLRequest, didReceiveData: @escaping (Data, URLResponse) -> Void, completion: @escaping (Error?) -> Void) -> Cancellable {
@@ -58,22 +58,5 @@ class MockDataLoader: DataLoading {
 
     func removeData(for request: URLRequest) {
         
-    }
-}
-
-// MARK: - Result
-
-// we're still using Result internally, but don't pollute user's space
-enum _Result<T, Error: Swift.Error> {
-    case success(T), failure(Error)
-
-    /// Returns a `value` if the result is success.
-    var value: T? {
-        if case let .success(val) = self { return val } else { return nil }
-    }
-
-    /// Returns an `error` if the result is failure.
-    var error: Error? {
-        if case let .failure(err) = self { return err } else { return nil }
     }
 }


### PR DESCRIPTION
- Add "Low Data Mode" tests for `ImagePublisher`
- Add convenience `dataLoadingError` property to `ImagePipeline.Error`
- Document "Low Data Mode" in [Nuke Docs](https://kean.blog/nuke/guides/combine)