### PR TITLE
Add initial ImagePipeline.Cache implementation

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		0C75279E1D473AEF00EC6222 /* MockImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C06891BCA888800089D7F /* MockImageCache.swift */; };
 		0C75279F1D473AEF00EC6222 /* MockImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068A1BCA888800089D7F /* MockImageProcessor.swift */; };
 		0C7527A01D473AF100EC6222 /* MockImagePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01287F1D43E85100668A1F /* MockImagePipeline.swift */; };
+		0C78A2A7263F4E680051E0FF /* ImagePipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C78A2A6263F4E680051E0FF /* ImagePipelineCache.swift */; };
+		0C78A2A9263F560A0051E0FF /* ImagePipelineCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C78A2A8263F560A0051E0FF /* ImagePipelineCacheTests.swift */; };
 		0C7C067C1BCA882A00089D7F /* Nuke.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C9174901BAE99EE004A7905 /* Nuke.framework */; };
 		0C7C06971BCA888800089D7F /* MockDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068C1BCA888800089D7F /* MockDataLoader.swift */; };
 		0C7C06981BCA888800089D7F /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068D1BCA888800089D7F /* Helpers.swift */; };
@@ -231,6 +233,8 @@
 		0C70D9772089017500A49DAC /* ImageDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDecoderTests.swift; sourceTree = "<group>"; };
 		0C70D97B2089042400A49DAC /* fixture.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = fixture.png; sourceTree = "<group>"; };
 		0C7150081FC9724C00B880AC /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		0C78A2A6263F4E680051E0FF /* ImagePipelineCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineCache.swift; sourceTree = "<group>"; };
+		0C78A2A8263F560A0051E0FF /* ImagePipelineCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineCacheTests.swift; sourceTree = "<group>"; };
 		0C7C06771BCA882A00089D7F /* Nuke Unit Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Nuke Unit Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C7C06871BCA888800089D7F /* ImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		0C7C06891BCA888800089D7F /* MockImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockImageCache.swift; sourceTree = "<group>"; };
@@ -382,6 +386,7 @@
 				0C0FD5D91CA47FE1002A78FB /* ImageRequest.swift */,
 				0C86AB69228B3B5100A81BA1 /* ImageTask.swift */,
 				0C0FD5D31CA47FE1002A78FB /* ImagePipeline.swift */,
+				0C78A2A6263F4E680051E0FF /* ImagePipelineCache.swift */,
 				0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */,
 				0C0FD5D71CA47FE1002A78FB /* ImageCache.swift */,
 				0C0FD5D81CA47FE1002A78FB /* ImageProcessing.swift */,
@@ -463,6 +468,7 @@
 				0C91B0E82438E245007F9100 /* ImagePipelineTests */,
 				0C91B0EA2438E269007F9100 /* ImageProcessorsTests */,
 				0C94466D1D47EC0E006DB314 /* ImageViewTests.swift */,
+				0C78A2A8263F560A0051E0FF /* ImagePipelineCacheTests.swift */,
 				0CCBB52F217D0B6A0026F552 /* ImageViewIntegrationTests.swift */,
 				0C1E620A1D6F817700AD5CF5 /* ImageRequestTests.swift */,
 				0CC6272025BDF7EA00466F04 /* ImageRequestConvertibleTests.swift */,
@@ -1005,6 +1011,7 @@
 				0C6B5BE1257010D300D763F2 /* ImagePipelineFormatsTests.swift in Sources */,
 				0C7527A01D473AF100EC6222 /* MockImagePipeline.swift in Sources */,
 				0C4B341C2572E288000FDDBA /* DecompressionTests.swift in Sources */,
+				0C78A2A9263F560A0051E0FF /* ImagePipelineCacheTests.swift in Sources */,
 				0C49232920BACA81001DFCC8 /* XCTestCase+Nuke.swift in Sources */,
 				0C75279E1D473AEF00EC6222 /* MockImageCache.swift in Sources */,
 				0CCBB534217D0B980026F552 /* MockProgressiveDataLoader.swift in Sources */,
@@ -1083,6 +1090,7 @@
 				0CB4030125B6639200F5A241 /* TaskLoadImage.swift in Sources */,
 				0CA5D954263CCEA500E08E17 /* ImagePublisher.swift in Sources */,
 				0CC36A2525B8BC4900811018 /* Operation.swift in Sources */,
+				0C78A2A7263F4E680051E0FF /* ImagePipelineCache.swift in Sources */,
 				0CB402DB25B656D200F5A241 /* TaskDecodeImage.swift in Sources */,
 				0CC36A3325B8BC7900811018 /* ResumableData.swift in Sources */,
 				0C0FD61C1CA47FE1002A78FB /* ImageViewExtensions.swift in Sources */,

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -44,7 +44,6 @@ public extension DataLoading {
     func removeData(for request: URLRequest) {}
 }
 
-
 public extension DataCache {
     // Deprecated in 9.3.1
     @available(*, deprecated, message: "Count limit is deprecated and will be removed in the next major release")

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -98,3 +98,24 @@ public extension ImagePrefetcher {
         stopPrefetching()
     }
 }
+
+public extension ImagePipeline {
+    // Deprecated in 10.0.0
+    @available(*, deprecated, message: "Use pipeline.cache[url] instead")
+    func cachedImage(for url: URL) -> ImageContainer? {
+        cachedImage(for: ImageRequest(url: url))
+    }
+
+    @available(*, deprecated, message: "Use pipeline.cache[request] instead")
+    func cachedImage(for request: ImageRequest) -> ImageContainer? {
+        cache.cachedImageFromMemoryCache(for: request)
+    }
+
+    @available(*, deprecated, message: "If needed, use pipeline.cache.makeDiskCacheKey(for:) instead. For original image data, remove the processors from the request. In general, there should be no need to create the keys manually anymore.")
+    func cacheKey(for request: ImageRequest, item: DataCacheItem) -> String {
+        switch item {
+        case .originalImageData: return request.makeCacheKeyForOriginalImageData()
+        case .finalImage: return request.makeCacheKeyForFinalImageData()
+        }
+    }
+}

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -106,11 +106,13 @@ public extension ImagePipeline {
         cachedImage(for: ImageRequest(url: url))
     }
 
+    // Deprecated in 10.0.0
     @available(*, deprecated, message: "Use pipeline.cache[request] instead")
     func cachedImage(for request: ImageRequest) -> ImageContainer? {
         cache.cachedImageFromMemoryCache(for: request)
     }
 
+    // Deprecated in 10.0.0
     @available(*, deprecated, message: "If needed, use pipeline.cache.makeDiskCacheKey(for:) instead. For original image data, remove the processors from the request. In general, there should be no need to create the keys manually anymore.")
     func cacheKey(for request: ImageRequest, item: DataCacheItem) -> String {
         switch item {

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -23,12 +23,11 @@ public protocol ImageCaching: AnyObject {
 public struct ImageCacheKey: Hashable {
     let key: Inner
 
-    /// This is faster than using AnyHashable (and it shows up on performance tests).
+    // This is faster than using AnyHashable (and it shows in performance tests).
     enum Inner: Hashable {
         case custom(AnyHashable)
         case `default`(ImageRequest.CacheKey)
     }
-    // This primarily exists as a performance optimization (faster than AnyHashable)
 
     public init(key: AnyHashable) {
         self.key = .custom(key)

--- a/Sources/ImagePipelineCache.swift
+++ b/Sources/ImagePipelineCache.swift
@@ -1,0 +1,119 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+public extension ImagePipeline {
+    /// Thread-safe.
+    struct Cache {
+        let pipeline: ImagePipeline
+
+        /// Returns processed image from the memory cache for the given request.
+        public subscript(request: ImageRequestConvertible) -> PlatformImage? {
+            get {
+                cachedImageFromMemoryCache(for: request.asImageRequest())?.image
+            }
+            set {
+                fatalError("Not implemented")
+            }
+        }
+
+        // MARK: Cached Images
+
+        /// Returns a cached image from the memory cache. Add `.disk` as a source
+        /// to also check the disk cache.
+        ///
+        /// - note: Respects request options such as `cachePolicy`.
+        ///
+        /// - parameter request: The request. Make sure to remove the processors
+        /// if you want to retrieve an original image (if it's stored).
+        /// - parameter sources: `[.memory]`, by default.
+        public func cachedImage(for request: ImageRequest, sources: Set<ImageCacheType> = [.memory]) -> ImageContainer? {
+            if sources.contains(.memory) {
+                if let image = cachedImageFromMemoryCache(for: request) {
+                    return image
+                }
+            }
+            if sources.contains(.disk) {
+                if let data = cachedData(for: request),
+                   let image = decodeImageData(data, for: request) {
+                    return image
+                }
+            }
+            return nil
+        }
+
+        func cachedImageFromMemoryCache(for request: ImageRequest) -> ImageContainer? {
+            guard request.cachePolicy != .reloadIgnoringCachedData && request.options.memoryCacheOptions.isReadAllowed else {
+                return nil
+            }
+            let request = pipeline.inheritOptions(request)
+            let key = makeMemoryCacheKey(for: request)
+            if let imageCache = pipeline.imageCache {
+                return imageCache[key] // Fast path for a default cache (no protocol call)
+            } else {
+                return pipeline.configuration.imageCache?[key]
+            }
+        }
+
+        func decodeImageData(_ data: Data, for request: ImageRequest) -> ImageContainer? {
+            let context = ImageDecodingContext(request: request, data: data, isCompleted: true, urlResponse: nil)
+            guard let decoder = pipeline.configuration.makeImageDecoder(context) else {
+                return nil
+            }
+            return decoder.decode(data, urlResponse: nil, isCompleted: true)?.container
+        }
+
+        public func storeCachedImage(_ container: ImageContainer, for request: ImageRequest, sources: Set<ImageCacheType> = [.memory, .disk]) {
+            fatalError("Not implemented")
+        }
+
+        public func removeCachedImage(for request: ImageRequest, sources: Set<ImageCacheType> = [.memory, .disk]) {
+            fatalError("Not implemented")
+        }
+
+        // MARK: Cached Data
+
+        #warning("Should it also work for a URL cache?")
+        public func cachedData(for request: ImageRequest) -> Data? {
+            guard request.cachePolicy != .reloadIgnoringCachedData else {
+                return nil
+            }
+            guard let dataCache = pipeline.configuration.dataCache else {
+                return nil
+            }
+            let key = makeDiskCacheKey(for: request)
+            return dataCache.cachedData(for: key)
+        }
+
+        public func storeCachedData(_ data: Data, for request: ImageRequest) {
+            fatalError("Not implemented")
+        }
+
+        public func removeCachedData(request: ImageRequest) {
+            fatalError("Not implemented")
+        }
+
+        // MARK: Keys
+
+        public func makeMemoryCacheKey(for request: ImageRequest) -> ImageCacheKey {
+            ImageCacheKey(request: request)
+        }
+
+        public func makeDiskCacheKey(for request: ImageRequest) -> String {
+            request.makeCacheKeyForFinalImageData()
+        }
+
+        // MARK: Misc
+
+        public func removeAll(sources: Set<ImageCacheType> = [.memory, .disk]) {
+            fatalError("Not implemented")
+        }
+    }
+}
+
+public enum ImageCacheType {
+    case memory
+    case disk
+}

--- a/Sources/ImagePublisher.swift
+++ b/Sources/ImagePublisher.swift
@@ -48,7 +48,7 @@ public struct ImagePublisher: Publisher {
         let subscription = ImageSubscription()
         subscriber.receive(subscription: subscription)
 
-        if let image = pipeline.cachedImage(for: request) {
+        if let image = pipeline.cache.cachedImageFromMemoryCache(for: request) {
             _ = subscriber.receive(ImageResponse(container: image))
             subscriber.receive(completion: .finished)
             return

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -371,8 +371,9 @@ private final class ImageViewController {
 
         let pipeline = options.pipeline ?? ImagePipeline.shared
 
-        // Quick synchronous memory cache lookup
-        if let image = pipeline.cachedImage(for: request) {
+        // Quick synchronous memory cache lookup.
+        // Equivalent to pipeline.cache[request] but with a bit less overhead
+        if let image = pipeline.cache.cachedImageFromMemoryCache(for: request) {
             let response = ImageResponse(container: image)
             handle(result: .success(response), fromMemCache: true, options: options)
             if !image.isPreview { // Final image was downloaded

--- a/Sources/Tasks/TaskLoadImage.swift
+++ b/Sources/Tasks/TaskLoadImage.swift
@@ -8,7 +8,7 @@ import Foundation
 /// `ProcessedImageTask` and subscribes to it.
 final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
     override func start() {
-        if let image = pipeline.cachedImage(for: request) {
+        if let image = pipeline.cache.cachedImageFromMemoryCache(for: request) {
             let response = ImageResponse(container: image)
             if image.isPreview {
                 send(value: response)
@@ -44,8 +44,8 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
     private func decodeProcessedImageData(_ data: Data) {
         guard !isDisposed else { return }
 
-        let decoderContext = ImageDecodingContext(request: request, data: data, isCompleted: true, urlResponse: nil)
-        guard let decoder = pipeline.configuration.makeImageDecoder(decoderContext) else {
+        let context = ImageDecodingContext(request: request, data: data, isCompleted: true, urlResponse: nil)
+        guard let decoder = pipeline.configuration.makeImageDecoder(context) else {
             // This shouldn't happen in practice unless encoder/decoder pair
             // for data cache is misconfigured.
             return loadDecompressedImage()

--- a/Sources/Tasks/TaskProcessImage.swift
+++ b/Sources/Tasks/TaskProcessImage.swift
@@ -11,7 +11,8 @@ final class TaskProcessImage: ImagePipelineTask<ImageResponse> {
         assert(!request.processors.isEmpty)
         guard !isDisposed, !request.processors.isEmpty else { return }
 
-        if let image = pipeline.cachedImage(for: request), !image.isPreview {
+        // Equivalent to pipeline.cache[request], but with a bit less overhead
+        if let image = pipeline.cache.cachedImageFromMemoryCache(for: request), !image.isPreview {
             return send(value: ImageResponse(container: image), isCompleted: true)
         }
 

--- a/Tests/ImagePipelineCacheTests.swift
+++ b/Tests/ImagePipelineCacheTests.swift
@@ -1,0 +1,127 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+
+class ImagePipelineCacheTests: XCTestCase {
+    var memoryCache: MockImageCache!
+    var diskCache: MockDataCache!
+    var dataLoader: MockDataLoader!
+    var pipeline: ImagePipeline!
+    var cache: ImagePipeline.Cache { pipeline.cache }
+
+    override func setUp() {
+        super.setUp()
+
+        dataLoader = MockDataLoader()
+        diskCache = MockDataCache()
+        memoryCache = MockImageCache()
+
+        pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = memoryCache
+            $0.dataCache = diskCache
+        }
+    }
+
+    // MARK: Cached Image
+
+    func testGetCachedImageDefaultFromMemoryCache() {
+        // GIVEN
+        let request = Test.request
+        memoryCache[cache.makeMemoryCacheKey(for: request)] = Test.container
+
+        // WHEN
+        let image = cache.cachedImage(for: request)
+
+        // THEN
+        XCTAssertNotNil(image)
+    }
+
+    func testGetCachedImageDefaultFromDiskCache() {
+        // GIVEN
+        let request = Test.request
+        diskCache.storeData(Test.data, for: cache.makeDiskCacheKey(for: request))
+
+        // WHEN
+        let image = cache.cachedImage(for: request)
+
+        // THEN returns nil because queries only memory cache by default
+        XCTAssertNil(image)
+    }
+
+    func testGetCachedImageDefaultFromDiskCacheWhenOptionEnabled() {
+        // GIVEN
+        let request = Test.request
+        diskCache.storeData(Test.data, for: cache.makeDiskCacheKey(for: request))
+
+        // WHEN
+        let image = cache.cachedImage(for: request, sources: [.disk])
+
+        // THEN returns nil because queries only memory cache by default
+        XCTAssertNotNil(image)
+    }
+
+    func testGetCachedImageDefaultNotStored() {
+        // GIVEN
+        let request = Test.request
+
+        // WHEN
+        let image = cache.cachedImage(for: request)
+
+        // THEN
+        XCTAssertNil(image)
+    }
+
+    func testGetCachedImageDefaultFromMemoryCacheWhenCachePolicyPreventsLookup() {
+        // GIVEN
+        var request = Test.request
+        memoryCache[cache.makeMemoryCacheKey(for: request)] = Test.container
+
+        // WHEN
+        request.cachePolicy = .reloadIgnoringCachedData
+        let image = cache.cachedImage(for: request)
+
+        // THEN
+        XCTAssertNil(image)
+    }
+
+    func testGetCachedImageDefaultFromDiskCacheWhenCachePolicyPreventsLookup() {
+        // GIVEN
+        var request = Test.request
+        diskCache.storeData(Test.data, for: cache.makeDiskCacheKey(for: request))
+
+        // WHEN
+        request.cachePolicy = .reloadIgnoringCachedData
+        let image = cache.cachedImage(for: request, sources: [.disk])
+
+        // THEN
+        XCTAssertNil(image)
+    }
+
+    func testGetCachedImageOnlyFromMemoryStoredInMemory() {
+        // GIVEN
+        let request = Test.request
+        memoryCache[cache.makeMemoryCacheKey(for: request)] = Test.container
+
+        // WHEN
+        let image = cache.cachedImage(for: request, sources: [.memory])
+
+        // THEN
+        XCTAssertNotNil(image)
+    }
+
+    func testGetCachedImageOnlyFromMemoryStoredOnDisk() {
+        // GIVEN
+        let request = Test.request
+        diskCache.storeData(Test.data, for: cache.makeDiskCacheKey(for: request))
+
+        // WHEN
+        let image = cache.cachedImage(for: request, sources: [.memory])
+
+        // THEN
+        XCTAssertNil(image)
+    }
+}

--- a/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
@@ -297,7 +297,7 @@ class ImagePipelineProcessedDataCachingTests: XCTestCase {
         wait()
 
         // Then
-        let key = pipeline.cacheKey(for: request, item: .finalImage)
+        let key = pipeline.cache.makeDiskCacheKey(for: request)
         XCTAssertNotNil(dataCache.cachedData(for: key), "Expected processed image data to be stored")
         XCTAssertEqual(dataCache.store.count, 1)
     }
@@ -318,7 +318,7 @@ class ImagePipelineProcessedDataCachingTests: XCTestCase {
         wait()
 
         // Then
-        let key = pipeline.cacheKey(for: request, item: .originalImageData)
+        let key = pipeline.cache.makeDiskCacheKey(for: request)
         XCTAssertNotNil(dataCache.cachedData(for: key), "Expected processed image data to be stored")
         XCTAssertEqual(dataCache.store.count, 1)
     }

--- a/Tests/ImagePipelineTests/ImagePipelineProcessorTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineProcessorTests.swift
@@ -125,9 +125,9 @@ class ImagePipelineProcessorTests: XCTestCase {
         mockImageCache[underlyingRequest] = ImageContainer(image: image)
 
         // When
-        let container = pipeline.cachedImage(for: ImageRequest(url: Test.url))
+        let cachedImage = pipeline.cache[Test.url]
 
         // Then
-        XCTAssertEqual(container?.image, image)
+        XCTAssertEqual(cachedImage, image)
     }
 }

--- a/Tests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineTests.swift
@@ -398,14 +398,15 @@ class ImagePipelineTests: XCTestCase {
 
     // MARK: - CacheKey
 
-    func testCacheKeyForOriginalData() {
-        XCTAssertEqual(pipeline.cacheKey(for: Test.request, item: .originalImageData), Test.url.absoluteString)
+    func testCacheKeyForRequest() {
+        let request = Test.request
+        XCTAssertEqual(pipeline.cache.makeDiskCacheKey(for: request), Test.url.absoluteString)
     }
 
-    func testCacheKeyForFinalImage() {
+    func testCacheKeyForRequestWithProcessors() {
         var request = Test.request
         request.processors = [ImageProcessors.Anonymous(id: "1", { $0 })]
-        XCTAssertEqual(pipeline.cacheKey(for: request, item: .finalImage), Test.url.absoluteString + "1")
+        XCTAssertEqual(pipeline.cache.makeDiskCacheKey(for: request), Test.url.absoluteString + "1")
     }
 
     // MARK: - Invalidate

--- a/Tests/MockImageCache.swift
+++ b/Tests/MockImageCache.swift
@@ -12,7 +12,7 @@ class MockImageCache: ImageCaching {
     
     init() {}
 
-    subscript(key: AnyHashable) -> ImageContainer? {
+    subscript(key: ImageCacheKey) -> ImageContainer? {
         get {
             return queue.sync {
                 enabled ? images[key] : nil

--- a/Tests/MockImageCache.swift
+++ b/Tests/MockImageCache.swift
@@ -12,18 +12,18 @@ class MockImageCache: ImageCaching {
     
     init() {}
 
-    subscript(request: ImageRequest) -> ImageContainer? {
+    subscript(key: AnyHashable) -> ImageContainer? {
         get {
             return queue.sync {
-                enabled ? images[ImageRequest.CacheKey(request: request)] : nil
+                enabled ? images[key] : nil
             }
         }
         set {
             queue.sync {
                 if let image = newValue {
-                    if enabled { images[ImageRequest.CacheKey(request: request)] = image }
+                    if enabled { images[key] = image }
                 } else {
-                    images[ImageRequest.CacheKey(request: request)] = nil
+                    images[key] = nil
                 }
             }
         }


### PR DESCRIPTION
- `ImageCaching` (now `MemoryCaching`) now works with `ImageCacheKey` (an opaque container) instead of `ImageRequest`. If you are providing a custom implementation of the `MemoryCaching` protocol, it needs to be updated accordingly.
- Add initial `ImagePipeline.Cache` implementation to give users more high-level APIs for dealing with cache layers in the pipeline