### PR TITLE
Add DiskCachePolicy

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		0C6CF0CD1DAF789C007B8C0E /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068E1BCA888800089D7F /* XCTestCaseExtensions.swift */; };
 		0C6D0A8820E574400037B68F /* MockDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6D0A8720E574400037B68F /* MockDataCache.swift */; };
 		0C6D0A8C20E57C810037B68F /* ImagePipelineDataCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6D0A8B20E57C810037B68F /* ImagePipelineDataCachingTests.swift */; };
+		0C7082612640521900C62638 /* MockImageEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7082602640521900C62638 /* MockImageEncoder.swift */; };
+		0C7082622640521900C62638 /* MockImageEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7082602640521900C62638 /* MockImageEncoder.swift */; };
 		0C70D9712089016800A49DAC /* progressive.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 0C70D96F2089016700A49DAC /* progressive.jpeg */; };
 		0C70D9742089016800A49DAC /* baseline.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 0C70D9702089016800A49DAC /* baseline.jpeg */; };
 		0C70D9782089017500A49DAC /* ImageDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70D9772089017500A49DAC /* ImageDecoderTests.swift */; };
@@ -228,6 +230,7 @@
 		0C6B5BE0257010D300D763F2 /* ImagePipelineFormatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineFormatsTests.swift; sourceTree = "<group>"; };
 		0C6D0A8720E574400037B68F /* MockDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataCache.swift; sourceTree = "<group>"; };
 		0C6D0A8B20E57C810037B68F /* ImagePipelineDataCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDataCachingTests.swift; sourceTree = "<group>"; };
+		0C7082602640521900C62638 /* MockImageEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageEncoder.swift; sourceTree = "<group>"; };
 		0C70D96F2089016700A49DAC /* progressive.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = progressive.jpeg; sourceTree = "<group>"; };
 		0C70D9702089016800A49DAC /* baseline.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = baseline.jpeg; sourceTree = "<group>"; };
 		0C70D9772089017500A49DAC /* ImageDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDecoderTests.swift; sourceTree = "<group>"; };
@@ -504,6 +507,7 @@
 				0CE745741D4767B900123F65 /* MockImageDecoder.swift */,
 				0C6D0A8720E574400037B68F /* MockDataCache.swift */,
 				0CCBB533217D0B980026F552 /* MockProgressiveDataLoader.swift */,
+				0C7082602640521900C62638 /* MockImageEncoder.swift */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -984,6 +988,7 @@
 				0C4F8FF322E4B8D60070ECFD /* MockDataLoader.swift in Sources */,
 				0C4F8FF622E4B8D60070ECFD /* MockDataCache.swift in Sources */,
 				0C4F8FF522E4B8D60070ECFD /* MockImageDecoder.swift in Sources */,
+				0C7082622640521900C62638 /* MockImageEncoder.swift in Sources */,
 				0C4F8FF722E4B8D60070ECFD /* MockProgressiveDataLoader.swift in Sources */,
 				0C4F8FF222E4B8D60070ECFD /* MockImageProcessor.swift in Sources */,
 				0C4F8FF922E4B8DA0070ECFD /* XCTestCase+Nuke.swift in Sources */,
@@ -1008,6 +1013,7 @@
 				0C70D9782089017500A49DAC /* ImageDecoderTests.swift in Sources */,
 				0C88C579263DAF1E0061A008 /* ImagePublisherTests.swift in Sources */,
 				0CB2EFD22110F38600F7C63F /* ImagePipelineConfigurationTests.swift in Sources */,
+				0C7082612640521900C62638 /* MockImageEncoder.swift in Sources */,
 				0C6B5BE1257010D300D763F2 /* ImagePipelineFormatsTests.swift in Sources */,
 				0C7527A01D473AF100EC6222 /* MockImagePipeline.swift in Sources */,
 				0C4B341C2572E288000FDDBA /* DecompressionTests.swift in Sources */,

--- a/Sources/Deprecated.swift
+++ b/Sources/Deprecated.swift
@@ -120,4 +120,12 @@ public extension ImagePipeline {
         case .finalImage: return request.makeCacheKeyForFinalImageData()
         }
     }
+
+    @available(*, deprecated, message: "Please use `diskCachePolicy` instead. The recommended policy is the new `.automatic` policy.")
+    enum DataCacheItem {
+        /// Same as the new `DiskCachePolicy.storeOriginalImageData`
+        case originalImageData
+        /// Same as the new `DiskCachePolicy.storeEncodedImages`
+        case finalImage
+    }
 }

--- a/Sources/ImagePipeline.swift
+++ b/Sources/ImagePipeline.swift
@@ -244,7 +244,7 @@ private extension ImagePipeline {
         self.send(.started, task)
 
         tasks[task] = makeTaskLoadImage(for: task.request)
-            .subscribe(priority: task._priority.taskPriority) { [weak self, weak task] event in
+            .subscribe(priority: task._priority.taskPriority, subscriber: task) { [weak self, weak task] event in
                 guard let self = self, let task = task else { return }
 
                 self.send(ImageTaskEvent(event), task)
@@ -280,7 +280,7 @@ private extension ImagePipeline {
         guard !isInvalidated else { return }
 
         tasks[task] = makeTaskLoadImageData(for: task.request)
-            .subscribe(priority: task._priority.taskPriority) { [weak self, weak task] event in
+            .subscribe(priority: task._priority.taskPriority, subscriber: task) { [weak self, weak task] event in
                 guard let self = self, let task = task else { return }
 
                 if event.isCompleted {

--- a/Sources/ImagePrefetcher.swift
+++ b/Sources/ImagePrefetcher.swift
@@ -44,11 +44,11 @@ public final class ImagePrefetcher {
 
     /// Prefetching destination.
     public enum Destination {
-        /// Prefetches the image and stores it in both memory and disk caches
-        /// (they should be enabled).
+        /// Prefetches the image and stores it in both the memory and the disk
+        /// cache (make sure to enable it).
         case memoryCache
 
-        /// Prefetches image data and stores it in disk caches. This does not
+        /// Prefetches the image data and stores it in disk caches. This does not
         /// require decoding the image data and therefore uses less CPU.
         case diskCache
     }

--- a/Sources/Tasks/Task.swift
+++ b/Sources/Tasks/Task.swift
@@ -89,7 +89,7 @@ class Task<Value, Error>: TaskSubscriptionDelegate {
     // MARK: - Managing Observers
 
     /// - notes: Returns `nil` if the task was disposed.
-    private func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
+    private func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject? = nil, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
         guard !isDisposed else { return nil }
 
         let subscriptionKey = nextSubscriptionKey
@@ -234,7 +234,7 @@ extension Task {
 
         /// Attaches the subscriber to the task.
         /// - notes: Returns `nil` if the task is already disposed.
-        func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
+        func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject? = nil, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
             task.subscribe(priority: priority, subscriber: subscriber, closure)
         }
 

--- a/Sources/Tasks/Task.swift
+++ b/Sources/Tasks/Task.swift
@@ -18,7 +18,8 @@ import Foundation
 class Task<Value, Error>: TaskSubscriptionDelegate {
 
     private struct Subscription {
-        let observer: (Event) -> Void
+        let closure: (Event) -> Void
+        weak var subscriber: AnyObject?
         var priority: TaskPriority
     }
 
@@ -27,6 +28,13 @@ class Task<Value, Error>: TaskSubscriptionDelegate {
     private var inlineSubscription: Subscription?
     private var subscriptions: [TaskSubscriptionKey: Subscription]? // Create lazily
     private var nextSubscriptionKey = 0
+
+    var subscribers: [AnyObject] {
+        var output = [AnyObject?]()
+        output.append(inlineSubscription?.subscriber)
+        subscriptions?.values.forEach { output.append($0.subscriber) }
+        return output.compactMap { $0 }
+    }
 
     /// Returns `true` if the task was either cancelled, or was completed.
     private(set) var isDisposed = false
@@ -81,7 +89,7 @@ class Task<Value, Error>: TaskSubscriptionDelegate {
     // MARK: - Managing Observers
 
     /// - notes: Returns `nil` if the task was disposed.
-    private func subscribe(priority: TaskPriority = .normal, _ observer: @escaping (Event) -> Void) -> TaskSubscription? {
+    private func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
         guard !isDisposed else { return nil }
 
         let subscriptionKey = nextSubscriptionKey
@@ -89,10 +97,10 @@ class Task<Value, Error>: TaskSubscriptionDelegate {
         let subscription = TaskSubscription(task: self, key: subscriptionKey)
 
         if subscriptionKey == 0 {
-            inlineSubscription = Subscription(observer: observer, priority: priority)
+            inlineSubscription = Subscription(closure: closure, subscriber: subscriber, priority: priority)
         } else {
             if subscriptions == nil { subscriptions = [:] }
-            subscriptions![subscriptionKey] = Subscription(observer: observer, priority: priority)
+            subscriptions![subscriptionKey] = Subscription(closure: closure, subscriber: subscriber, priority: priority)
         }
 
         updatePriority(suggestedPriority: priority)
@@ -166,10 +174,10 @@ class Task<Value, Error>: TaskSubscriptionDelegate {
             terminate(reason: .finished)
         }
 
-        inlineSubscription?.observer(event)
+        inlineSubscription?.closure(event)
         if let subscriptions = subscriptions {
             for subscription in subscriptions.values {
-                subscription.observer(event)
+                subscription.closure(event)
             }
         }
     }
@@ -226,15 +234,15 @@ extension Task {
 
         /// Attaches the subscriber to the task.
         /// - notes: Returns `nil` if the task is already disposed.
-        func subscribe(priority: TaskPriority = .normal, _ observer: @escaping (Event) -> Void) -> TaskSubscription? {
-            task.subscribe(priority: priority, observer)
+        func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
+            task.subscribe(priority: priority, subscriber: subscriber, closure)
         }
 
         /// Attaches the subscriber to the task. Automatically forwards progress
         /// andd error events to the given task.
         /// - notes: Returns `nil` if the task is already disposed.
         func subscribe<NewValue>(_ task: Task<NewValue, Error>, onValue: @escaping (Value, Bool) -> Void) -> TaskSubscription? {
-            subscribe { [weak task] event in
+            subscribe(subscriber: task) { [weak task] event in
                 guard let task = task else { return }
                 switch event {
                 case let .value(value, isCompleted):

--- a/Tests/ImagePipelineTests/ImagePipelineDeduplicationTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineDeduplicationTests.swift
@@ -577,7 +577,6 @@ class ImagePipelineProcessingDeduplicationTests: XCTestCase {
 
         pipeline = pipeline.reconfigured {
             $0.dataCache = dataCache
-            $0.dataCacheOptions.storedItems = [.originalImageData, .finalImage]
         }
 
         // When
@@ -632,7 +631,6 @@ class ImagePipelineProcessingDeduplicationTests: XCTestCase {
 
         pipeline = pipeline.reconfigured {
             $0.dataCache = dataCache
-            $0.dataCacheOptions.storedItems = [.originalImageData]
         }
 
         // When
@@ -655,7 +653,6 @@ class ImagePipelineProcessingDeduplicationTests: XCTestCase {
 
         pipeline = pipeline.reconfigured {
             $0.dataCache = dataCache
-            $0.dataCacheOptions.storedItems = [.originalImageData]
         }
 
         // When

--- a/Tests/MockDataCache.swift
+++ b/Tests/MockDataCache.swift
@@ -7,12 +7,14 @@ import Nuke
 
 final class MockDataCache: DataCaching {
     var store = [String: Data]()
+    var writeCount = 0
 
     func cachedData(for key: String) -> Data? {
         return store[key]
     }
 
     func storeData(_ data: Data, for key: String) {
+        writeCount += 1
         store[key] = data
     }
 

--- a/Tests/MockDataLoader.swift
+++ b/Tests/MockDataLoader.swift
@@ -25,8 +25,6 @@ class MockDataLoader: DataLoading {
     func loadData(with request: URLRequest, didReceiveData: @escaping (Data, URLResponse) -> Void, completion: @escaping (Error?) -> Void) -> Cancellable {
         let task = MockDataTask()
 
-        print("retry")
-
         NotificationCenter.default.post(name: MockDataLoader.DidStartTask, object: self)
 
         createdTaskCount += 1

--- a/Tests/MockImageEncoder.swift
+++ b/Tests/MockImageEncoder.swift
@@ -1,0 +1,20 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+import Nuke
+
+final class MockImageEncoder: ImageEncoding {
+    let result: Data?
+    var encodeCount = 0
+
+    init(result: Data?) {
+        self.result = result
+    }
+
+    func encode(_ image: PlatformImage) -> Data? {
+        encodeCount += 1
+        return result
+    }
+}

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -466,6 +466,6 @@ private final class SimpleTask<T, E>: Task<T, E> {
 
 extension Task {
     func subscribe(priority: TaskPriority = .normal, _ observer: @escaping (Event) -> Void) -> TaskSubscription? {
-        publisher.subscribe(priority: priority, observer)
+        publisher.subscribe(priority: priority, subscriber: NSObject(), observer)
     }
 }

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -466,6 +466,6 @@ private final class SimpleTask<T, E>: Task<T, E> {
 
 extension Task {
     func subscribe(priority: TaskPriority = .normal, _ observer: @escaping (Event) -> Void) -> TaskSubscription? {
-        publisher.subscribe(priority: priority, subscriber: NSObject(), observer)
+        publisher.subscribe(priority: priority, observer)
     }
 }


### PR DESCRIPTION
Add `DiskCachePolicy` that replaces `DataCacheOptions.storedItems`. The new policy fixes some of the inefficiencies of the previous model and provides more control. The main addition is an `.automatic` policy, which is also a default. The policy is: for requests with processors, it encodes and stores processed images; for requests with no processors, store original image data.