### PR TITLE
Avoid storing local files in disk cache

### DIFF
--- a/Sources/ImageRequest.swift
+++ b/Sources/ImageRequest.swift
@@ -33,6 +33,16 @@ public struct ImageRequest: CustomStringConvertible {
         }
     }
 
+    /// Returns the request URL.
+    public var url: URL? {
+        switch ref.resource {
+        case .url(let url):
+            return url
+        case .urlRequest(let request):
+            return request.url
+        }
+    }
+
     var urlString: String? {
         ref.urlString
     }

--- a/Sources/Internal/Extensions.swift
+++ b/Sources/Internal/Extensions.swift
@@ -34,3 +34,11 @@ extension NSLock {
         return closure()
     }
 }
+
+extension URL {
+    var isCacheable: Bool {
+        let scheme = self.scheme
+        return scheme != "file" && scheme != "data"
+    }
+}
+

--- a/Sources/Tasks/TaskLoadImage.swift
+++ b/Sources/Tasks/TaskLoadImage.swift
@@ -141,7 +141,10 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
     }
 
     private func shouldStoreImageInDiskCache() -> Bool {
+        guard request.url?.isCacheable ?? false else {
+            return false
+        }
         let policy = pipeline.configuration.diskCachePolicy
-        return (policy == .automatic && !request.processors.isEmpty) || policy == .storeEncodedImages
+        return ((policy == .automatic && !request.processors.isEmpty) || policy == .storeEncodedImages)
     }
 }

--- a/Sources/Tasks/TaskLoadImageData.swift
+++ b/Sources/Tasks/TaskLoadImageData.swift
@@ -183,6 +183,9 @@ final class TaskLoadImageData: ImagePipelineTask<(Data, URLResponse?)> {
     }
 
     private func shouldStoreDataInDiskCache() -> Bool {
+        guard request.url?.isCacheable ?? false else {
+            return false
+        }
         let policy = pipeline.configuration.diskCachePolicy
         return policy == .storeOriginalImageData || (policy == .automatic && imageTasks.contains { $0.request.processors.isEmpty })
     }

--- a/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineDataCachingTests.swift
@@ -462,6 +462,46 @@ class ImagePipelineDataCacheOptionsTests: XCTestCase {
         XCTAssertEqual(dataCache.store.count, 1)
     }
 
+    // MARK: Local Storage
+
+    func testImagesFromLocalStorageNotCached() {
+        // GIVEN
+        pipeline = pipeline.reconfigured {
+            $0.diskCachePolicy = .automatic
+        }
+
+        // GIVEN request without a processor
+        let request = ImageRequest(url: URL(string: "file://example/image.jpeg")!)
+
+        // WHEN
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // THEN original image data is stored in disk cache
+        XCTAssertEqual(encoder.encodeCount, 0)
+        XCTAssertEqual(dataCache.writeCount, 0)
+        XCTAssertEqual(dataCache.store.count, 0)
+    }
+
+    func testImagesFromMemoryNotCached() {
+        // GIVEN
+        pipeline = pipeline.reconfigured {
+            $0.diskCachePolicy = .automatic
+        }
+
+        // GIVEN request without a processor
+        let request = ImageRequest(url: URL(string: "data://example/image.jpeg")!)
+
+        // WHEN
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // THEN original image data is stored in disk cache
+        XCTAssertEqual(encoder.encodeCount, 0)
+        XCTAssertEqual(dataCache.writeCount, 0)
+        XCTAssertEqual(dataCache.store.count, 0)
+    }
+
     // MARK Misc
 
     func testSetCustomImageEncoder() {


### PR DESCRIPTION
The pipeline now automatically doesn't store images fetched using file:// and data:// schemes in the disk cache