### PR TITLE
Cache Type

### DIFF
--- a/Sources/ImageDecoding.swift
+++ b/Sources/ImageDecoding.swift
@@ -41,7 +41,7 @@ public extension ImageDecoding {
 }
 
 extension ImageDecoding {
-    func decode(_ data: Data, urlResponse: URLResponse?, isCompleted: Bool) -> ImageResponse? {
+    func decode(_ data: Data, urlResponse: URLResponse?, isCompleted: Bool, cacheType: ImageResponse.CacheType?) -> ImageResponse? {
         func _decode() -> ImageContainer? {
             if isCompleted {
                 return decode(data)
@@ -55,7 +55,7 @@ extension ImageDecoding {
         #if !os(macOS)
         ImageDecompression.setDecompressionNeeded(true, for: container.image)
         #endif
-        return ImageResponse(container: container, urlResponse: urlResponse)
+        return ImageResponse(container: container, urlResponse: urlResponse, cacheType: cacheType)
     }
 }
 

--- a/Sources/ImagePipelineCache.swift
+++ b/Sources/ImagePipelineCache.swift
@@ -182,7 +182,7 @@ public extension ImagePipeline {
             guard let decoder = configuration.makeImageDecoder(context) else {
                 return nil
             }
-            return decoder.decode(data, urlResponse: nil, isCompleted: true)?.container
+            return decoder.decode(data, urlResponse: nil, isCompleted: true, cacheType: .disk)?.container
         }
 
         private func encodeImage(_ image: ImageContainer, for request: ImageRequest) -> Data? {

--- a/Sources/ImagePublisher.swift
+++ b/Sources/ImagePublisher.swift
@@ -49,7 +49,7 @@ public struct ImagePublisher: Publisher {
         subscriber.receive(subscription: subscription)
 
         if let image = pipeline.cache.cachedImage(for: request) {
-            _ = subscriber.receive(ImageResponse(container: image))
+            _ = subscriber.receive(ImageResponse(container: image, cacheType: .memory))
             subscriber.receive(completion: .finished)
             return
         }

--- a/Sources/ImageTask.swift
+++ b/Sources/ImageTask.swift
@@ -154,10 +154,14 @@ public final class ImageResponse {
     /// A convenience computed property which returns an image from the container.
     public var image: PlatformImage { container.image }
     public let urlResponse: URLResponse?
+    /// Contains a cache type in case the image was returned from one of the
+    /// pipeline caches (not including any of the HTTP caches if enabled).
+    public let cacheType: CacheType?
 
-    public init(container: ImageContainer, urlResponse: URLResponse? = nil) {
+    public init(container: ImageContainer, urlResponse: URLResponse? = nil, cacheType: CacheType? = nil) {
         self.container = container
         self.urlResponse = urlResponse
+        self.cacheType = cacheType
     }
 
     func map(_ transformation: (ImageContainer) -> ImageContainer?) -> ImageResponse? {
@@ -165,7 +169,12 @@ public final class ImageResponse {
             guard let output = transformation(container) else {
                 return nil
             }
-            return ImageResponse(container: output, urlResponse: urlResponse)
+            return ImageResponse(container: output, urlResponse: urlResponse, cacheType: cacheType)
         }
+    }
+
+    public enum CacheType {
+        case memory
+        case disk
     }
 }

--- a/Sources/ImageViewExtensions.swift
+++ b/Sources/ImageViewExtensions.swift
@@ -373,7 +373,7 @@ private final class ImageViewController {
 
         // Quick synchronous memory cache lookup.
         if let image = pipeline.cache.cachedImage(for: request) {
-            let response = ImageResponse(container: image)
+            let response = ImageResponse(container: image, cacheType: .memory)
             handle(result: .success(response), fromMemCache: true, options: options)
             if !image.isPreview { // Final image was downloaded
                 completion?(.success(response))

--- a/Sources/Tasks/TaskFetchDecodedImage.swift
+++ b/Sources/Tasks/TaskFetchDecodedImage.swift
@@ -47,7 +47,7 @@ final class TaskFetchDecodedImage: ImagePipelineTask<ImageResponse> {
         // initialization anyway.
         let decode = {
             signpost(log, "DecodeImageData", isCompleted ? "FinalImage" : "ProgressiveImage") {
-                decoder.decode(data, urlResponse: urlResponse, isCompleted: isCompleted)
+                decoder.decode(data, urlResponse: urlResponse, isCompleted: isCompleted, cacheType: nil)
             }
         }
         if ImagePipeline.Configuration.isFastTrackDecodingEnabled(for: decoder) {

--- a/Sources/Tasks/TaskLoadImage.swift
+++ b/Sources/Tasks/TaskLoadImage.swift
@@ -13,7 +13,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
     override func start() {
         // Memory cache lookup
         if let image = pipeline.cache.cachedImage(for: request) {
-            let response = ImageResponse(container: image)
+            let response = ImageResponse(container: image, cacheType: .memory)
             send(value: response, isCompleted: !image.isPreview)
             if !image.isPreview {
                 return // Already got the result!
@@ -60,7 +60,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
 
         let decode = {
             signpost(log, "DecodeCachedProcessedImageData") {
-                decoder.decode(data, urlResponse: nil, isCompleted: true)
+                decoder.decode(data, urlResponse: nil, isCompleted: true, cacheType: .disk)
             }
         }
         if ImagePipeline.Configuration.isFastTrackDecodingEnabled(for: decoder) {
@@ -102,7 +102,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
             }
             while !processors.isEmpty {
                 if let image = pipeline.cache.cachedImage(for: request.withProcessors(processors)) {
-                    let response = ImageResponse(container: image)
+                    let response = ImageResponse(container: image, cacheType: .memory)
                     process(response, isCompleted: !image.isPreview, processors: remaining)
                     if !image.isPreview {
                         return  // Nothing left to do, just apply the processors

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -60,7 +60,8 @@ enum Test {
 
     static let response = ImageResponse(
         container: .init(image: Test.image),
-        urlResponse: urlResponse
+        urlResponse: urlResponse,
+        cacheType: nil
     )
 
     static func save(_ image: PlatformImage) {

--- a/Tests/ImagePipelineTests/ImagePipelineImageCacheTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineImageCacheTests.swift
@@ -193,6 +193,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertTrue(record.image === processedImage.image)
+        XCTAssertEqual(record.response?.cacheType, .memory)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 1)
@@ -210,6 +211,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertTrue(record.image === processedImage.image)
+        XCTAssertEqual(record.response?.cacheType, .memory)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 1)
@@ -227,6 +229,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertNotNil(record.image)
+        XCTAssertEqual(record.response?.cacheType, .disk)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 1)
@@ -245,6 +248,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertNotNil(record.image)
+        XCTAssertEqual(record.response?.cacheType, .disk)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 1)
@@ -264,6 +268,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertEqual(record.image?.nk_test_processorIDs, ["1", "2"])
+        XCTAssertEqual(record.response?.cacheType, .memory)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 2) // Processed + intermediate
@@ -284,6 +289,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertEqual(record.image?.nk_test_processorIDs, ["1", "2"])
+        XCTAssertEqual(record.response?.cacheType, .memory)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 2) // Processed + intermediate
@@ -304,6 +310,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertEqual(record.image?.nk_test_processorIDs, ["1", "2"])
+        XCTAssertEqual(record.response?.cacheType, .memory)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 3) // Processed + intermediate + original
@@ -323,6 +330,7 @@ class ImagePipelineCacheLayerPriorityTests: XCTestCase {
         let record = expect(pipeline).toLoadImage(with: request)
         wait()
         XCTAssertEqual(record.image?.nk_test_processorIDs, ["1", "2"])
+        XCTAssertEqual(record.response?.cacheType, .disk)
 
         // THEN
         XCTAssertEqual(imageCache.readCount, 3) // Processed + intermediate + original


### PR DESCRIPTION
Addresses https://github.com/kean/Nuke/issues/435 and https://github.com/kean/Nuke/issues/361. Next step is also to keep track of some cache metrics, like hit/miss count.