### PR TITLE
Add Publisher<Data> support to  ImageRequest

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -149,6 +149,9 @@
 		0CE2D9BA2084FDDD00934B28 /* ImageDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE2D9B92084FDDD00934B28 /* ImageDecoding.swift */; };
 		0CE3992D1D4697CE00A87D47 /* ImagePipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE3992C1D4697CE00A87D47 /* ImagePipelineTests.swift */; };
 		0CE5F6832156386B0046609F /* ResumableDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE5F681215638300046609F /* ResumableDataTests.swift */; };
+		0CE6202126542F7200AAB8C3 /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE6202026542F7200AAB8C3 /* Combine.swift */; };
+		0CE6202326543B6A00AAB8C3 /* TaskFetchWithPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE6202226543B6A00AAB8C3 /* TaskFetchWithPublisher.swift */; };
+		0CE6202526543EC700AAB8C3 /* ImagePipelinePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE6202426543EC700AAB8C3 /* ImagePipelinePublisherTests.swift */; };
 		0CE745751D4767B900123F65 /* MockImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE745741D4767B900123F65 /* MockImageDecoder.swift */; };
 		0CF1754C22913F9800A8946E /* ImagePipelineConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */; };
 		0CF4DE7D1D412A9E00170289 /* ImagePrefetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF4DE7C1D412A9E00170289 /* ImagePrefetcher.swift */; };
@@ -323,6 +326,9 @@
 		0CE5F681215638300046609F /* ResumableDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumableDataTests.swift; sourceTree = "<group>"; };
 		0CE5F78720A22ABF00BC3283 /* Nuke 6 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 6 Migration Guide.md"; sourceTree = "<group>"; };
 		0CE5F78820A22ABF00BC3283 /* Nuke 7 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 7 Migration Guide.md"; sourceTree = "<group>"; };
+		0CE6202026542F7200AAB8C3 /* Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.swift; sourceTree = "<group>"; };
+		0CE6202226543B6A00AAB8C3 /* TaskFetchWithPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskFetchWithPublisher.swift; sourceTree = "<group>"; };
+		0CE6202426543EC700AAB8C3 /* ImagePipelinePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelinePublisherTests.swift; sourceTree = "<group>"; };
 		0CE745741D4767B900123F65 /* MockImageDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockImageDecoder.swift; sourceTree = "<group>"; };
 		0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineConfiguration.swift; sourceTree = "<group>"; };
 		0CF4DE7C1D412A9E00170289 /* ImagePrefetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagePrefetcher.swift; sourceTree = "<group>"; };
@@ -574,6 +580,7 @@
 				0C6B5BE0257010D300D763F2 /* ImagePipelineFormatsTests.swift */,
 				0CD37C9925BA36D5006C2C36 /* ImagePipelineLoadDataTests.swift */,
 				0C53C8AE263C7B1700E62D03 /* ImagePipelineDelegateTests.swift */,
+				0CE6202426543EC700AAB8C3 /* ImagePipelinePublisherTests.swift */,
 			);
 			path = ImagePipelineTests;
 			sourceTree = "<group>";
@@ -615,6 +622,7 @@
 				0C2A368A26437BF100F1D000 /* TaskLoadData.swift */,
 				0CB402DA25B656D200F5A241 /* TaskFetchDecodedImage.swift */,
 				0CB402D425B6569700F5A241 /* TaskFetchOriginalImageData.swift */,
+				0CE6202226543B6A00AAB8C3 /* TaskFetchWithPublisher.swift */,
 				0C9165E526431942006B1D4F /* OperationTask.swift */,
 			);
 			path = Tasks;
@@ -632,6 +640,7 @@
 				0CC36A4025B8BCAC00811018 /* Log.swift */,
 				0C7150081FC9724C00B880AC /* Extensions.swift */,
 				0C42D4C422A283140094CB5A /* Deprecated.swift */,
+				0CE6202026542F7200AAB8C3 /* Combine.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -1081,6 +1090,7 @@
 				0C91B0EC2438E287007F9100 /* ResizeTests.swift in Sources */,
 				0C6D0A8C20E57C810037B68F /* ImagePipelineDataCacheTests.swift in Sources */,
 				0C68F609208A1F40007DC696 /* ImageDecoderRegistryTests.swift in Sources */,
+				0CE6202526543EC700AAB8C3 /* ImagePipelinePublisherTests.swift in Sources */,
 				0C91B0EE2438E307007F9100 /* CircleTests.swift in Sources */,
 				0C0F7BF12287F6EE0034E656 /* TaskTests.swift in Sources */,
 				0CC6271525BDF7A100466F04 /* ImagePipelineImageCacheTests.swift in Sources */,
@@ -1136,7 +1146,9 @@
 				0C53C8B1263C968200E62D03 /* ImagePipelineDelegate.swift in Sources */,
 				0C9165E626431942006B1D4F /* OperationTask.swift in Sources */,
 				0CB402DB25B656D200F5A241 /* TaskFetchDecodedImage.swift in Sources */,
+				0CE6202126542F7200AAB8C3 /* Combine.swift in Sources */,
 				0CC36A3325B8BC7900811018 /* ResumableData.swift in Sources */,
+				0CE6202326543B6A00AAB8C3 /* TaskFetchWithPublisher.swift in Sources */,
 				0C0FD61C1CA47FE1002A78FB /* ImageViewExtensions.swift in Sources */,
 				0CB26802208F2565004C83F4 /* DataCache.swift in Sources */,
 				0C2A368B26437BF100F1D000 /* TaskLoadData.swift in Sources */,

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		0CE6202126542F7200AAB8C3 /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE6202026542F7200AAB8C3 /* Combine.swift */; };
 		0CE6202326543B6A00AAB8C3 /* TaskFetchWithPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE6202226543B6A00AAB8C3 /* TaskFetchWithPublisher.swift */; };
 		0CE6202526543EC700AAB8C3 /* ImagePipelinePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE6202426543EC700AAB8C3 /* ImagePipelinePublisherTests.swift */; };
+		0CE6202726546FD100AAB8C3 /* CombineExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE6202626546FD100AAB8C3 /* CombineExtensions.swift */; };
 		0CE745751D4767B900123F65 /* MockImageDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE745741D4767B900123F65 /* MockImageDecoder.swift */; };
 		0CF1754C22913F9800A8946E /* ImagePipelineConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */; };
 		0CF4DE7D1D412A9E00170289 /* ImagePrefetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF4DE7C1D412A9E00170289 /* ImagePrefetcher.swift */; };
@@ -329,6 +330,7 @@
 		0CE6202026542F7200AAB8C3 /* Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.swift; sourceTree = "<group>"; };
 		0CE6202226543B6A00AAB8C3 /* TaskFetchWithPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskFetchWithPublisher.swift; sourceTree = "<group>"; };
 		0CE6202426543EC700AAB8C3 /* ImagePipelinePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelinePublisherTests.swift; sourceTree = "<group>"; };
+		0CE6202626546FD100AAB8C3 /* CombineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineExtensions.swift; sourceTree = "<group>"; };
 		0CE745741D4767B900123F65 /* MockImageDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockImageDecoder.swift; sourceTree = "<group>"; };
 		0CF1754B22913F9800A8946E /* ImagePipelineConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineConfiguration.swift; sourceTree = "<group>"; };
 		0CF4DE7C1D412A9E00170289 /* ImagePrefetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagePrefetcher.swift; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 				0C49232820BACA81001DFCC8 /* XCTestCase+Nuke.swift */,
 				0C7C068D1BCA888800089D7F /* Helpers.swift */,
 				0CAAB00F1E45D6DA00924450 /* NukeExtensions.swift */,
+				0CE6202626546FD100AAB8C3 /* CombineExtensions.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1059,6 +1062,7 @@
 				0C88C579263DAF1E0061A008 /* ImagePublisherTests.swift in Sources */,
 				0CB2EFD22110F38600F7C63F /* ImagePipelineConfigurationTests.swift in Sources */,
 				0C7082612640521900C62638 /* MockImageEncoder.swift in Sources */,
+				0CE6202726546FD100AAB8C3 /* CombineExtensions.swift in Sources */,
 				0C6B5BE1257010D300D763F2 /* ImagePipelineFormatsTests.swift in Sources */,
 				0CF52DCC26516F6B0094BC66 /* FetchImageTests.swift in Sources */,
 				0C7527A01D473AF100EC6222 /* MockImagePipeline.swift in Sources */,

--- a/Sources/Core/ImageRequest.swift
+++ b/Sources/Core/ImageRequest.swift
@@ -15,7 +15,6 @@ public struct ImageRequest: CustomStringConvertible {
 
     // MARK: Parameters of the Request
 
-    #warning("should URLRequest return non-nill value")
     /// The `URLRequest` used for loading an image.
     public var urlRequest: URLRequest? {
         switch ref.resource {

--- a/Sources/Core/ImageRequest.swift
+++ b/Sources/Core/ImageRequest.swift
@@ -148,7 +148,6 @@ public struct ImageRequest: CustomStringConvertible {
         self.ref = Container(resource: Resource.urlRequest(urlRequest), imageId: urlRequest.url?.absoluteString, processors: processors, cachePolicy: cachePolicy, priority: priority, options: options)
     }
 
-    #warning("default cache policy to disable caching?")
     #if canImport(Combine)
     /// Initializes a request with the given data publisher.
     ///
@@ -158,15 +157,17 @@ public struct ImageRequest: CustomStringConvertible {
     /// - parameter options: Advanced image loading options.
     /// - parameter processors: Image processors to be applied after the image is loaded.
     ///
-    /// `ImageRequest` allows you to set image processors, change the request priority and more:
+    /// For example, here is how you can use it with Photos framework (the
+    /// `imageDataPublisher()` API is a convenience extension).
+    ///
+    /// - warning: If you don't want data to be stored in the disk cache, make
+    /// sure to create a pipeline without it or disable it on a per-request basis.
+    /// You can also disable it dynamically using `ImagePipeline.Delegate`.
     ///
     /// ```swift
     /// let request = ImageRequest(
     ///     id: asset.localIdentifier,
-    ///     data: PHAssetManager.imageDataPublisher(for: asset),
-    ///     url: URLRequest(url: URL(string: "http://...")!),
-    ///     processors: [ImageProcessors.Resize(size: imageView.bounds.size)],
-    ///     priority: .high
+    ///     data: PHAssetManager.imageDataPublisher(for: asset)
     /// )
     /// ```
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)

--- a/Sources/Core/ImageRequest.swift
+++ b/Sources/Core/ImageRequest.swift
@@ -148,9 +148,27 @@ public struct ImageRequest: CustomStringConvertible {
         self.ref = Container(resource: Resource.urlRequest(urlRequest), imageId: urlRequest.url?.absoluteString, processors: processors, cachePolicy: cachePolicy, priority: priority, options: options)
     }
 
-    #warning("document")
     #warning("default cache policy to disable caching?")
     #if canImport(Combine)
+    /// Initializes a request with the given data publisher.
+    ///
+    /// - parameter id: Uniquely identifies the image data.
+    /// - parameter data: A data publisher to be used for fetching image data.
+    /// - parameter priority: The priority of the request, `.normal` by default.
+    /// - parameter options: Advanced image loading options.
+    /// - parameter processors: Image processors to be applied after the image is loaded.
+    ///
+    /// `ImageRequest` allows you to set image processors, change the request priority and more:
+    ///
+    /// ```swift
+    /// let request = ImageRequest(
+    ///     id: asset.localIdentifier,
+    ///     data: PHAssetManager.imageDataPublisher(for: asset),
+    ///     url: URLRequest(url: URL(string: "http://...")!),
+    ///     processors: [ImageProcessors.Resize(size: imageView.bounds.size)],
+    ///     priority: .high
+    /// )
+    /// ```
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
     public init<P>(id: String, data: P,
                    processors: [ImageProcessing] = [],

--- a/Sources/Internal/Combine.swift
+++ b/Sources/Internal/Combine.swift
@@ -21,7 +21,7 @@ struct BCAnyPublisher<Output, Failure: Error> {
 
     #if canImport(Combine)
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-    public init<P: Publisher>(_ publisher: P) where P.Output == Output, P.Failure == Failure {
+    init<P: Publisher>(_ publisher: P) where P.Output == Output, P.Failure == Failure {
         self._sink = { onCompletion, onValue in
             let cancellable = publisher.sink(receiveCompletion: {
                 switch $0 {

--- a/Sources/Internal/Combine.swift
+++ b/Sources/Internal/Combine.swift
@@ -1,0 +1,65 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+#if canImport(Combine)
+import Combine
+#endif
+
+struct BCAnyPublisher<Output, Failure: Error> {
+    private let _sink: (@escaping ((BCCompletion<Failure>) -> Void), @escaping ((Output) -> Void)) -> Cancellable
+
+    init(data: Data) where Output == Data {
+        self._sink = { onCompletion, onValue in
+            onValue(data)
+            onCompletion(.finished)
+            return NoopCancellable()
+        }
+    }
+
+    #if canImport(Combine)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    public init<P: Publisher>(_ publisher: P) where P.Output == Output, P.Failure == Failure {
+        self._sink = { onCompletion, onValue in
+            let cancellable = publisher.sink(receiveCompletion: {
+                switch $0 {
+                case .finished: onCompletion(.finished)
+                case .failure(let error): onCompletion(.failure(error))
+                }
+            }, receiveValue: {
+                onValue($0)
+            })
+            return BCAnyCancellable(cancellable.cancel)
+        }
+    }
+    #endif
+
+    func sink(receiveCompletion: @escaping ((BCCompletion<Failure>) -> Void), receiveValue: @escaping ((Output) -> Void)) -> Cancellable {
+        _sink(receiveCompletion, receiveValue)
+    }
+}
+
+private final class NoopCancellable: Cancellable {
+    func cancel() {
+        // Do nothing
+    }
+}
+
+private final class BCAnyCancellable: Cancellable {
+    let closure: () -> Void
+
+    init(_ closure: @escaping () -> Void) {
+        self.closure = closure
+    }
+
+    func cancel() {
+        closure()
+    }
+}
+
+enum BCCompletion<Failure> where Failure: Error {
+    case finished
+    case failure(Failure)
+}

--- a/Sources/Internal/ResumableData.swift
+++ b/Sources/Internal/ResumableData.swift
@@ -122,11 +122,11 @@ final class ResumableDataStorage {
         let url: String
 
         init?(request: ImageRequest, pipeline: ImagePipeline) {
-            guard let url = request.urlString else {
+            guard let imageId = request.imageId else {
                 return nil
             }
             self.pipelineId = pipeline.id
-            self.url = url
+            self.url = imageId
         }
     }
 }

--- a/Sources/Internal/Tasks/TaskFetchWithPublisher.swift
+++ b/Sources/Internal/Tasks/TaskFetchWithPublisher.swift
@@ -1,0 +1,60 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+/// Fetches data using the publisher provided with the request.
+/// Unlike `TaskFetchOriginalImageData`, there is no resumable data involved.
+final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
+    private lazy var data = Data()
+
+    override func start() {
+        // Wrap data request in an operation to limit the maximum number of
+        // concurrent data tasks.
+        operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
+            guard let self = self else {
+                return finish()
+            }
+            self.async {
+                self.loadData(finish: finish)
+            }
+        }
+    }
+
+    // This methods gets called inside data loading operation (Operation).
+    private func loadData(finish: @escaping () -> Void) {
+        guard !isDisposed else {
+            return finish()
+        }
+
+        guard let publisher = request.publisher else {
+            self.send(error: .dataLoadingFailed(URLError(.unknown, userInfo: [:])))
+            return assertionFailure("This should never happen")
+        }
+
+        let cancellable = publisher.sink(receiveCompletion: { [weak self] result in
+            finish() // Finish the operation!
+            guard let self = self else { return }
+            self.async {
+                switch result {
+                case .finished:
+                    #warning("make sure we are never sending an empty value")
+                    self.send(value: (self.data, nil), isCompleted: true)
+                case .failure(let error):
+                    self.send(error: .dataLoadingFailed(error))
+                }
+            }
+        }, receiveValue: { [weak self] data in
+            guard let self = self else { return }
+            self.async {
+                #warning("add progressive decoding support")
+                self.data.append(data)
+            }
+        })
+
+        onCancelled = {
+            cancellable.cancel()
+        }
+    }
+}

--- a/Sources/Internal/Tasks/TaskFetchWithPublisher.swift
+++ b/Sources/Internal/Tasks/TaskFetchWithPublisher.swift
@@ -39,7 +39,9 @@ final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
             self.async {
                 switch result {
                 case .finished:
-                    #warning("make sure we are never sending an empty value")
+                    guard !self.data.isEmpty else {
+                        return self.send(error: .dataLoadingFailed(URLError(.resourceUnavailable, userInfo: [:])))
+                    }
                     self.send(value: (self.data, nil), isCompleted: true)
                 case .failure(let error):
                     self.send(error: .dataLoadingFailed(error))
@@ -48,7 +50,6 @@ final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
         }, receiveValue: { [weak self] data in
             guard let self = self else { return }
             self.async {
-                #warning("add progressive decoding support")
                 self.data.append(data)
             }
         })

--- a/Tests/CombineExtensions.swift
+++ b/Tests/CombineExtensions.swift
@@ -60,5 +60,4 @@ extension AnyPublisher {
     }
 
 }
-
 #endif

--- a/Tests/CombineExtensions.swift
+++ b/Tests/CombineExtensions.swift
@@ -1,0 +1,64 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import Nuke
+
+#if canImport(Combine)
+import Combine
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+extension Publishers {
+    public struct Anonymous<Output, Failure: Swift.Error>: Publisher {
+        private var closure: (AnySubscriber<Output, Failure>) -> Void
+
+        public init(closure: @escaping (AnySubscriber<Output, Failure>) -> Void) {
+            self.closure = closure
+        }
+
+        public func receive<S>(subscriber: S) where S : Subscriber, Anonymous.Failure == S.Failure, Anonymous.Output == S.Input {
+            let subscription = Subscriptions.Anonymous(subscriber: subscriber)
+            subscriber.receive(subscription: subscription)
+            subscription.start(closure)
+        }
+    }
+}
+import Photos
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+extension Subscriptions {
+    final class Anonymous<SubscriberType: Subscriber, Output, Failure>: Subscription where SubscriberType.Input == Output, Failure == SubscriberType.Failure {
+
+        private var subscriber: SubscriberType?
+
+        init(subscriber: SubscriberType) {
+            self.subscriber = subscriber
+        }
+
+        func start(_ closure: @escaping (AnySubscriber<Output, Failure>) -> Void) {
+            if let subscriber = subscriber {
+                closure(AnySubscriber(subscriber))
+            }
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            // Ignore demand for now
+        }
+
+        func cancel() {
+            self.subscriber = nil
+        }
+
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+extension AnyPublisher {
+    static func create(_ closure: @escaping (AnySubscriber<Output, Failure>) -> Void) -> AnyPublisher<Output, Failure> {
+        return Publishers.Anonymous<Output, Failure>(closure: closure)
+            .eraseToAnyPublisher()
+    }
+
+}
+
+#endif

--- a/Tests/ImagePipelineTests/ImagePipelinePublisherTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelinePublisherTests.swift
@@ -4,6 +4,8 @@
 
 import XCTest
 @testable import Nuke
+
+#if canImport(Combine)
 import Combine
 
 @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
@@ -55,3 +57,5 @@ class ImagePipelinePublisherTests: XCTestCase {
         XCTAssertEqual(image.nk_test_processorIDs, ["1"])
     }
 }
+
+#endif

--- a/Tests/ImagePipelineTests/ImagePipelinePublisherTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelinePublisherTests.swift
@@ -1,0 +1,57 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+import Combine
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+class ImagePipelinePublisherTests: XCTestCase {
+    var dataLoader: MockDataLoader!
+    var imageCache: MockImageCache!
+    var dataCache: MockDataCache!
+    var pipeline: ImagePipeline!
+
+    override func setUp() {
+        super.setUp()
+
+        dataLoader = MockDataLoader()
+        imageCache = MockImageCache()
+        dataCache = MockDataCache()
+        pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = imageCache
+            $0.dataCache = dataCache
+        }
+    }
+
+    func testLoadWithPublisher() throws {
+        // GIVEN
+        #warning("fix how error is populated")
+        let request = ImageRequest(id: "a", data: Just(Test.data).setFailureType(to: Swift.Error.self))
+
+        // WHEN
+        let record = expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // THEN
+        let image = try XCTUnwrap(record.image)
+        XCTAssertEqual(image.sizeInPixels, CGSize(width: 640, height: 480))
+    }
+
+    func testLoadWithPublisherAndApplyProcessor() throws {
+        // GIVEN
+        var request = ImageRequest(id: "a", data: Just(Test.data).setFailureType(to: Swift.Error.self))
+        request.processors = [MockImageProcessor(id: "1")]
+
+        // WHEN
+        let record = expect(pipeline).toLoadImage(with: request)
+        wait()
+
+        // THEN
+        let image = try XCTUnwrap(record.image)
+        XCTAssertEqual(image.sizeInPixels, CGSize(width: 640, height: 480))
+        XCTAssertEqual(image.nk_test_processorIDs, ["1"])
+    }
+}

--- a/Tests/ImageRequestTests.swift
+++ b/Tests/ImageRequestTests.swift
@@ -8,21 +8,6 @@ import XCTest
 class ImageRequestTests: XCTestCase {
     // MARK: - CoW
 
-    func testStructSemanticsArePreserved() {
-        // Given
-        let url1 =  URL(string: "http://test.com/1.png")!
-        let url2 = URL(string: "http://test.com/2.png")!
-        let request = ImageRequest(url: url1)
-
-        // When
-        var copy = request
-        copy.urlRequest = URLRequest(url: url2)
-
-        // Then
-        XCTAssertEqual(url2, copy.urlRequest.url)
-        XCTAssertEqual(url1, request.urlRequest.url)
-    }
-
     func testCopyOnWrite() {
         // Given
         var request = ImageRequest(url: URL(string: "http://test.com/1.png")!)
@@ -35,14 +20,15 @@ class ImageRequestTests: XCTestCase {
         // When
         var copy = request
         // Requst makes a copy at this point under the hood.
-        copy.urlRequest = URLRequest(url: URL(string: "http://test.com/2.png")!)
+        copy.priority = .low
 
         // Then
         XCTAssertEqual(copy.options.memoryCacheOptions.isReadAllowed, false)
         XCTAssertEqual(copy.options.userInfo["key"] as? String, "3")
         XCTAssertEqual(copy.options.filteredURL, "4")
         XCTAssertEqual((copy.processors.first as? MockImageProcessor)?.identifier, "4")
-        XCTAssertEqual(copy.priority, .high)
+        XCTAssertEqual(request.priority, .high) // Original request no updated
+        XCTAssertEqual(copy.priority, .low)
     }
 
     // MARK: - Misc


### PR DESCRIPTION
Example with the Photos framework:

```swift
let request = ImageRequest(
    id: asset.localIdentifier,
    data: PHAssetManager.imageDataPublisher(for: asset)
)
```

Example with Data:

```swift
let request = ImageRequest(
    id: "image-01",
    data: Just(Data())
)
```
