### PR TITLE
Add: default parameter nil to nuke_display(image:data:)

### DIFF
--- a/Sources/UI/ImageViewExtensions.swift
+++ b/Sources/UI/ImageViewExtensions.swift
@@ -52,7 +52,7 @@ public typealias ImageDisplayingView = UIView & Nuke_ImageDisplaying
 
 extension UIImageView: Nuke_ImageDisplaying {
     /// Displays an image.
-    open func nuke_display(image: UIImage?, data: Data?) {
+    open func nuke_display(image: UIImage?, data: Data? = nil) {
         self.image = image
     }
 }
@@ -64,7 +64,7 @@ public typealias ImageDisplayingView = NSObject & Nuke_ImageDisplaying
 
 extension NSImageView: Nuke_ImageDisplaying {
     /// Displays an image.
-    open func nuke_display(image: NSImage?, data: Data?) {
+    open func nuke_display(image: NSImage?, data: Data? = nil) {
         self.image = image
     }
 }
@@ -76,7 +76,7 @@ public typealias ImageDisplayingView = WKInterfaceObject & Nuke_ImageDisplaying
 
 extension WKInterfaceImage: Nuke_ImageDisplaying {
     /// Displays an image.
-    open func nuke_display(image: UIImage?, data: Data?) {
+    open func nuke_display(image: UIImage?, data: Data? = nil) {
         self.setImage(image)
     }
 }


### PR DESCRIPTION
Thank you for the nice update to version10!!

I wanna suggest one change. nuke_display(image:data) which is a protocol method of Nuke_ImageDisplaying is defined as extension method of UIImageView, NSImageView and WKInterfaceImage. But, the data parameter is never used although this can be the destructive change at updating to version10.
So, if there are not some hesitations for this point, it is better to have default parameter nil, I think.