### PR TITLE
Fix #496: invalid URL strings clog the operation queue

### DIFF
--- a/Sources/Internal/Tasks/TaskFetchOriginalImageData.swift
+++ b/Sources/Internal/Tasks/TaskFetchOriginalImageData.swift
@@ -13,6 +13,11 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
     private lazy var data = Data()
 
     override func start() {
+        guard let urlRequest = request.urlRequest else {
+            self.send(error: .dataLoadingFailed(URLError(.badURL)))
+            return
+        }
+        
         if let rateLimiter = pipeline.rateLimiter {
             // Rate limiter is synchronized on pipeline's queue. Delayed work is
             // executed asynchronously also on the same queue.
@@ -20,15 +25,15 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
                 guard let self = self, !self.isDisposed else {
                     return false
                 }
-                self.loadData()
+                self.loadData(urlRequest: urlRequest)
                 return true
             }
         } else { // Start loading immediately.
-            loadData()
+            loadData(urlRequest: urlRequest)
         }
     }
 
-    private func loadData() {
+    private func loadData(urlRequest: URLRequest) {
         // Wrap data request in an operation to limit the maximum number of
         // concurrent data tasks.
         operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
@@ -36,23 +41,19 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
                 return finish()
             }
             self.async {
-                self.loadData(finish: finish)
+                self.loadData(urlRequest: urlRequest, finish: finish)
             }
         }
     }
 
     // This methods gets called inside data loading operation (Operation).
-    private func loadData(finish: @escaping () -> Void) {
+    private func loadData(urlRequest: URLRequest, finish: @escaping () -> Void) {
         guard !isDisposed else {
             return finish()
         }
         // Read and remove resumable data from cache (we're going to insert it
         // back in the cache if the request fails to complete again).
-        guard var urlRequest = request.urlRequest else {
-            self.send(error: .dataLoadingFailed(URLError(.badURL)))
-            return
-        }
-
+        var urlRequest = urlRequest
         if pipeline.configuration.isResumableDataEnabled,
            let resumableData = ResumableDataStorage.shared.removeResumableData(for: request, pipeline: pipeline) {
             // Update headers to add "Range" and "If-Range" headers

--- a/Tests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineTests.swift
@@ -515,7 +515,20 @@ class ImagePipelineTests: XCTestCase {
     }
 
     // MARK: Misc
+    
+    func testLoadWithInvalidURL() throws {
+        // GIVEN
+        pipeline = pipeline.reconfigured {
+            $0.dataLoader = DataLoader()
+        }
 
+        // WHEN
+        for _ in 0...100 {
+            expect(pipeline).toFailRequest( "http://example.com/invalid url")
+            wait()
+        }
+    }
+    
     #if !os(macOS)
     func testOverridingImageScale() throws {
         // GIVEN

--- a/Tests/XCTestCase+Nuke.swift
+++ b/Tests/XCTestCase+Nuke.swift
@@ -50,12 +50,12 @@ struct TestExpectationImagePipeline {
     }
 
     @discardableResult
-    func toFailRequest(_ request: ImageRequest, completion: @escaping ((Result<ImageResponse, ImagePipeline.Error>) -> Void)) -> ImageTask {
+    func toFailRequest(_ request: ImageRequestConvertible, completion: @escaping ((Result<ImageResponse, ImagePipeline.Error>) -> Void)) -> ImageTask {
         toFailRequest(request, progress: nil, completion: completion)
     }
 
     @discardableResult
-    func toFailRequest(_ request: ImageRequest,
+    func toFailRequest(_ request: ImageRequestConvertible,
                        progress: ((_ intermediateResponse: ImageResponse?, _ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void)? = nil,
                        completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) -> ImageTask {
         let expectation = test.expectation(description: "Image request failed \(request)")
@@ -67,7 +67,7 @@ struct TestExpectationImagePipeline {
         }
     }
 
-    func toFailRequest(_ request: ImageRequest, with expectedError: ImagePipeline.Error, file: StaticString = #file, line: UInt = #line) {
+    func toFailRequest(_ request: ImageRequestConvertible, with expectedError: ImagePipeline.Error, file: StaticString = #file, line: UInt = #line) {
         toFailRequest(request) { result in
             XCTAssertEqual(result.error, expectedError, file: file, line: line)
         }


### PR DESCRIPTION
When you call `loadImage(:)` or `loadData(:)` method and provide a URL `String` that is an invalid `URL`, it clogs the operation queue used for downloading data and the pipeline starts failing silently.