### PR TITLE
Async/Await

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		0C505B6C2286F3AD006D5399 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C505B6B2286F3AD006D5399 /* Task.swift */; };
 		0C53C8AF263C7B1700E62D03 /* ImagePipelineDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C53C8AE263C7B1700E62D03 /* ImagePipelineDelegateTests.swift */; };
 		0C53C8B1263C968200E62D03 /* ImagePipelineDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C53C8B0263C968200E62D03 /* ImagePipelineDelegate.swift */; };
+		0C5D5A9D2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5D5A9C2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift */; };
 		0C64F73B24383043001983C6 /* ImageEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C64F73A24383043001983C6 /* ImageEncoderTests.swift */; };
 		0C64F73D2438371A001983C6 /* img_751.heic in Resources */ = {isa = PBXBuildFile; fileRef = 0C64F73C243836B5001983C6 /* img_751.heic */; };
 		0C64F73F243838BF001983C6 /* swift.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C64F73E243838BF001983C6 /* swift.png */; };
@@ -263,6 +264,7 @@
 		0C53C8AE263C7B1700E62D03 /* ImagePipelineDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDelegateTests.swift; sourceTree = "<group>"; };
 		0C53C8B0263C968200E62D03 /* ImagePipelineDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDelegate.swift; sourceTree = "<group>"; };
 		0C54E64126616E9D00ED1049 /* Nuke 10 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 10 Migration Guide.md"; sourceTree = "<group>"; };
+		0C5D5A9C2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineAsyncAwaitTests.swift; sourceTree = "<group>"; };
 		0C5D81871D46A385000ECCB6 /* ThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafetyTests.swift; sourceTree = "<group>"; };
 		0C64F73A24383043001983C6 /* ImageEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageEncoderTests.swift; sourceTree = "<group>"; };
 		0C64F73C243836B5001983C6 /* img_751.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = img_751.heic; sourceTree = "<group>"; };
@@ -647,6 +649,7 @@
 				0CD37C9925BA36D5006C2C36 /* ImagePipelineLoadDataTests.swift */,
 				0C53C8AE263C7B1700E62D03 /* ImagePipelineDelegateTests.swift */,
 				0CE6202426543EC700AAB8C3 /* ImagePipelinePublisherTests.swift */,
+				0C5D5A9C2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift */,
 			);
 			path = ImagePipelineTests;
 			sourceTree = "<group>";
@@ -1230,6 +1233,7 @@
 				0CE334DB2724563D0017BB8D /* ImageProcessorsProtocolExtensionsTests.swift in Sources */,
 				0C7C06981BCA888800089D7F /* Helpers.swift in Sources */,
 				0C4AF1EB1FE85539002F86CB /* LinkedListTest.swift in Sources */,
+				0C5D5A9D2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift in Sources */,
 				0CB2EFD62110F52C00F7C63F /* RateLimiterTests.swift in Sources */,
 				0C7C06971BCA888800089D7F /* MockDataLoader.swift in Sources */,
 				0CC6272125BDF7EA00466F04 /* ImageRequestConvertibleTests.swift in Sources */,

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -63,7 +63,7 @@
 		0C4F8FFF22E4B8F60070ECFD /* fixture.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C70D97B2089042400A49DAC /* fixture.png */; };
 		0C4F900022E4B8F60070ECFD /* cat.gif in Resources */ = {isa = PBXBuildFile; fileRef = 0C8DC722209B842600084AA6 /* cat.gif */; };
 		0C4F900322E4C4FB0070ECFD /* Nuke.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C9174901BAE99EE004A7905 /* Nuke.framework */; };
-		0C505B6C2286F3AD006D5399 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C505B6B2286F3AD006D5399 /* Task.swift */; };
+		0C505B6C2286F3AD006D5399 /* AsyncTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C505B6B2286F3AD006D5399 /* AsyncTask.swift */; };
 		0C53C8AF263C7B1700E62D03 /* ImagePipelineDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C53C8AE263C7B1700E62D03 /* ImagePipelineDelegateTests.swift */; };
 		0C53C8B1263C968200E62D03 /* ImagePipelineDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C53C8B0263C968200E62D03 /* ImagePipelineDelegate.swift */; };
 		0C5D5A9D2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5D5A9C2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift */; };
@@ -88,7 +88,7 @@
 		0C75279F1D473AEF00EC6222 /* MockImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068A1BCA888800089D7F /* MockImageProcessor.swift */; };
 		0C78A2A7263F4E680051E0FF /* ImagePipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C78A2A6263F4E680051E0FF /* ImagePipelineCache.swift */; };
 		0C78A2A9263F560A0051E0FF /* ImagePipelineCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C78A2A8263F560A0051E0FF /* ImagePipelineCacheTests.swift */; };
-		0C78BD4626575000002FBC6F /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C505B6B2286F3AD006D5399 /* Task.swift */; };
+		0C78BD4626575000002FBC6F /* AsyncTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C505B6B2286F3AD006D5399 /* AsyncTask.swift */; };
 		0C7C067C1BCA882A00089D7F /* Nuke.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C9174901BAE99EE004A7905 /* Nuke.framework */; };
 		0C7C06971BCA888800089D7F /* MockDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068C1BCA888800089D7F /* MockDataLoader.swift */; };
 		0C7C06981BCA888800089D7F /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C068D1BCA888800089D7F /* Helpers.swift */; };
@@ -260,7 +260,7 @@
 		0C4B34312572E9AC000FDDBA /* generate_docs.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = generate_docs.sh; path = Scripts/generate_docs.sh; sourceTree = "<group>"; };
 		0C4B6A341E36630E00E86B21 /* Nuke 5 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 5 Migration Guide.md"; sourceTree = "<group>"; };
 		0C4F8FDF22E4B6ED0070ECFD /* Nuke Thread Safety Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Nuke Thread Safety Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0C505B6B2286F3AD006D5399 /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
+		0C505B6B2286F3AD006D5399 /* AsyncTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTask.swift; sourceTree = "<group>"; };
 		0C53C8AE263C7B1700E62D03 /* ImagePipelineDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDelegateTests.swift; sourceTree = "<group>"; };
 		0C53C8B0263C968200E62D03 /* ImagePipelineDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineDelegate.swift; sourceTree = "<group>"; };
 		0C54E64126616E9D00ED1049 /* Nuke 10 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 10 Migration Guide.md"; sourceTree = "<group>"; };
@@ -758,7 +758,7 @@
 		0CB402D325B6568800F5A241 /* Tasks */ = {
 			isa = PBXGroup;
 			children = (
-				0C505B6B2286F3AD006D5399 /* Task.swift */,
+				0C505B6B2286F3AD006D5399 /* AsyncTask.swift */,
 				0C2CD6EA25B67FB30017018F /* ImagePipelineTask.swift */,
 				0CB4030025B6639200F5A241 /* TaskLoadImage.swift */,
 				0C2A368A26437BF100F1D000 /* TaskLoadData.swift */,
@@ -1283,7 +1283,7 @@
 				0C3261F51FEBC232009276AC /* MockDataLoader.swift in Sources */,
 				0CC627A525C100FA00466F04 /* ImageProcessingPerformanceTests.swift in Sources */,
 				0C8D7BF51D9DC07E00D12EB7 /* DataCachePeformanceTests.swift in Sources */,
-				0C78BD4626575000002FBC6F /* Task.swift in Sources */,
+				0C78BD4626575000002FBC6F /* AsyncTask.swift in Sources */,
 				0CC6279025C100BC00466F04 /* ImageViewPerformanceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1299,7 +1299,7 @@
 				0C0FD5FC1CA47FE1002A78FB /* ImageCache.swift in Sources */,
 				0C0FD5EC1CA47FE1002A78FB /* ImagePipeline.swift in Sources */,
 				0C0FD5E01CA47FE1002A78FB /* DataLoader.swift in Sources */,
-				0C505B6C2286F3AD006D5399 /* Task.swift in Sources */,
+				0C505B6C2286F3AD006D5399 /* AsyncTask.swift in Sources */,
 				0CC36A2C25B8BC6300811018 /* LinkedList.swift in Sources */,
 				0C179C7B2283597F008AB488 /* ImageEncoding.swift in Sources */,
 				0CB4030125B6639200F5A241 /* TaskLoadImage.swift in Sources */,

--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -155,7 +155,7 @@ public final class ImagePipeline {
             box.task?.cancel()
         }, operation: {
             try await withUnsafeThrowingContinuation { continuation in
-                box.task = self.loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: nil, onCancel: {
+                box.task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: nil, onCancel: {
                     continuation.resume(throwing: CancellationError())
                 }, completion: {
                     continuation.resume(with: $0)

--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -138,6 +138,22 @@ public final class ImagePipeline {
     ) -> ImageTask {
         loadImage(with: request.asImageRequest(), isConfined: false, queue: queue, progress: progress, completion: completion)
     }
+    
+#if swift(>=5.5)
+    /// Loads an image for the given request.
+    ///
+    /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
+    ///
+    /// - parameter request: An image request.
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    public func loadImage(with request: ImageRequestConvertible) async throws -> ImageResponse {
+        try await withUnsafeThrowingContinuation { continuation in
+            self.loadImage(with: request, queue: nil, progress: nil) {
+                continuation.resume(with: $0)
+            }
+        }
+    }
+#endif
 
     func loadImage(
         with request: ImageRequest,

--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -403,31 +403,31 @@ public final class ImagePipeline {
     // and `loadData()` with the same request, only on `TaskFetchOriginalImageData`
     // is created. The work is split between tasks to minimize any duplicated work.
 
-    func makeTaskLoadImage(for request: ImageRequest) -> Task<ImageResponse, Error>.Publisher {
+    func makeTaskLoadImage(for request: ImageRequest) -> AsyncTask<ImageResponse, Error>.Publisher {
         tasksLoadImage.publisherForKey(request.makeImageLoadKey()) {
             TaskLoadImage(self, request)
         }
     }
 
-    func makeTaskLoadData(for request: ImageRequest) -> Task<(Data, URLResponse?), Error>.Publisher {
+    func makeTaskLoadData(for request: ImageRequest) -> AsyncTask<(Data, URLResponse?), Error>.Publisher {
         tasksLoadData.publisherForKey(request.makeImageLoadKey()) {
             TaskLoadData(self, request)
         }
     }
 
-    func makeTaskProcessImage(key: ImageProcessingKey, process: @escaping () -> ImageResponse?) -> Task<ImageResponse, Swift.Error>.Publisher {
+    func makeTaskProcessImage(key: ImageProcessingKey, process: @escaping () -> ImageResponse?) -> AsyncTask<ImageResponse, Swift.Error>.Publisher {
         tasksProcessImage.publisherForKey(key) {
             OperationTask(self, configuration.imageProcessingQueue, process)
         }
     }
 
-    func makeTaskFetchDecodedImage(for request: ImageRequest) -> Task<ImageResponse, Error>.Publisher {
+    func makeTaskFetchDecodedImage(for request: ImageRequest) -> AsyncTask<ImageResponse, Error>.Publisher {
         tasksFetchDecodedImage.publisherForKey(request.makeDecodedImageLoadKey()) {
             TaskFetchDecodedImage(self, request)
         }
     }
 
-    func makeTaskFetchOriginalImageData(for request: ImageRequest) -> Task<(Data, URLResponse?), Error>.Publisher {
+    func makeTaskFetchOriginalImageData(for request: ImageRequest) -> AsyncTask<(Data, URLResponse?), Error>.Publisher {
         tasksFetchOriginalImageData.publisherForKey(request.makeDataLoadKey()) {
             request.publisher == nil ?
                 TaskFetchOriginalImageData(self, request) :

--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -139,13 +139,13 @@ public final class ImagePipeline {
         loadImage(with: request.asImageRequest(), isConfined: false, queue: queue, progress: progress, completion: completion)
     }
     
-#if swift(>=5.5)
+#if swift(>=5.5.2)
     /// Loads an image for the given request.
     ///
     /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
     ///
     /// - parameter request: An image request.
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
     public func loadImage(with request: ImageRequestConvertible) async throws -> ImageResponse {
         final class TaskBox {
             var task: ImageTask?

--- a/Sources/Core/ImagePipelineDelegate.swift
+++ b/Sources/Core/ImagePipelineDelegate.swift
@@ -96,7 +96,7 @@ public enum ImageTaskEvent {
 }
 
 extension ImageTaskEvent {
-    init(_ event: Task<ImageResponse, ImagePipeline.Error>.Event) {
+    init(_ event: AsyncTask<ImageResponse, ImagePipeline.Error>.Event) {
         switch event {
         case let .error(error):
             self = .completed(result: .failure(error))

--- a/Sources/Core/ImageTask.swift
+++ b/Sources/Core/ImageTask.swift
@@ -48,6 +48,8 @@ public final class ImageTask: Hashable, CustomStringConvertible {
     var isCancelled: Bool { _isCancelled.pointee == 1 }
     private let _isCancelled: UnsafeMutablePointer<Int32>
 
+    var onCancel: (() -> Void)?
+    
     deinit {
         self._isCancelled.deallocate()
         #if TRACK_ALLOCATIONS

--- a/Sources/Core/Tasks/ImagePipelineTask.swift
+++ b/Sources/Core/Tasks/ImagePipelineTask.swift
@@ -6,7 +6,7 @@ import Foundation
 
 // Each task holds a strong reference to the pipeline. This is by design. The
 // user does not need to hold a strong reference to the pipeline.
-class ImagePipelineTask<Value>: Task<Value, ImagePipeline.Error> {
+class ImagePipelineTask<Value>: AsyncTask<Value, ImagePipeline.Error> {
     let pipeline: ImagePipeline
     // A canonical request representing the unit work performed by the task.
     let request: ImageRequest

--- a/Sources/Core/Tasks/OperationTask.swift
+++ b/Sources/Core/Tasks/OperationTask.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// A one-shot task for performing a single () -> T function.
-final class OperationTask<T>: Task<T, Swift.Error> {
+final class OperationTask<T>: AsyncTask<T, Swift.Error> {
     private let pipeline: ImagePipeline
     private let queue: OperationQueue
     private let process: () -> T?

--- a/Sources/UI/FetchImage.swift
+++ b/Sources/UI/FetchImage.swift
@@ -196,7 +196,8 @@ public final class FetchImage: ObservableObject, Identifiable {
     public func load(_ action: @escaping () async throws -> ImageResponse) {
         reset()
         isLoading = true
-        let task = _Concurrency.Task {
+        
+        let task = Task {
             do {
                 self.handle(result: .success(try await action()))
             } catch {

--- a/Sources/UI/FetchImage.swift
+++ b/Sources/UI/FetchImage.swift
@@ -192,7 +192,8 @@ public final class FetchImage: ObservableObject, Identifiable {
         })
     }
     
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+#if swift(>=5.5.2)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
     public func load(_ action: @escaping () async throws -> ImageResponse) {
         reset()
         isLoading = true
@@ -206,7 +207,8 @@ public final class FetchImage: ObservableObject, Identifiable {
         }
         cancellable = AnyCancellable { task.cancel() }
     }
-
+#endif
+    
     // MARK: Cancel
 
     /// Marks the request as being cancelled. Continues to display a downloaded

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -1,0 +1,109 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+
+#if swift(>=5.5)
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+class ImagePipelineAsyncAwaitTests: XCTestCase {
+    var dataLoader: MockDataLoader!
+    var pipeline: ImagePipeline!
+
+    override func setUp() {
+        super.setUp()
+
+        dataLoader = MockDataLoader()
+        pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+    }
+
+    // MARK: Common Use Cases
+
+    func testLowDataMode() async throws {
+        // GIVEN
+        let highQualityImageURL = URL(string: "https://example.com/high-quality-image.jpeg")!
+        let lowQualityImageURL = URL(string: "https://example.com/low-quality-image.jpeg")!
+
+        dataLoader.results[highQualityImageURL] = .failure(URLError(networkUnavailableReason: .constrained) as NSError)
+        dataLoader.results[lowQualityImageURL] = .success((Test.data, Test.urlResponse))
+
+        // WHEN
+        let pipeline = self.pipeline!
+
+        // Create the default request to fetch the high quality image.
+        var urlRequest = URLRequest(url: highQualityImageURL)
+        urlRequest.allowsConstrainedNetworkAccess = false
+        let request = ImageRequest(urlRequest: urlRequest)
+
+        // WHEN
+        func loadImage() async throws -> ImageResponse {
+            do {
+                return try await pipeline.loadImage(with: request)
+            } catch {
+                guard (error as? URLError)?.networkUnavailableReason == .constrained else {
+                    throw error
+                }
+                return try await pipeline.loadImage(with: lowQualityImageURL)
+            }
+        }
+        
+        let response = try await loadImage()
+        XCTAssertNotNil(response.image)
+    }
+
+//    // MARK: Basics
+//
+//    func testSyncCacheLookup() {
+//        // GIVEN
+//        let cache = MockImageCache()
+//        cache[Test.request] = ImageContainer(image: Test.image)
+//        pipeline = pipeline.reconfigured {
+//            $0.imageCache = cache
+//        }
+//
+//        // WHEN
+//        var image: PlatformImage?
+//        cancellable = pipeline.imagePublisher(with: Test.url).sink(receiveCompletion: { result in
+//            switch result {
+//            case .finished:
+//                break // Expected result
+//            case .failure:
+//                XCTFail()
+//            }
+//        }, receiveValue: {
+//            image = $0.image
+//        })
+//
+//        // THEN image returned synchronously
+//        XCTAssertNotNil(image)
+//    }
+//
+//    func testCancellation() {
+//        dataLoader.queue.isSuspended = true
+//
+//        expectNotification(MockDataLoader.DidStartTask, object: dataLoader)
+//        let cancellable = pipeline.imagePublisher(with: Test.url).sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+//        wait() // Wait till operation is created
+//
+//        expectNotification(MockDataLoader.DidCancelTask, object: dataLoader)
+//        cancellable.cancel()
+//        wait()
+//    }
+}
+
+/// We have to mock it because there is no way to construct native `URLError`
+/// with a `networkUnavailableReason`.
+private struct URLError: Swift.Error {
+    var networkUnavailableReason: NetworkUnavailableReason?
+
+    enum NetworkUnavailableReason {
+        case cellular
+        case expensive
+        case constrained
+    }
+}
+#endif

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -51,43 +51,11 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
                 return try await pipeline.loadImage(with: lowQualityImageURL)
             }
         }
-        
-        let task = _Concurrency.Task<ImageResponse, Error> {
-            try await loadImage()
-        }
 
-        let response = try await task.value
+        let response = try await loadImage()
         XCTAssertNotNil(response.image)
     }
 
-//    // MARK: Basics
-//
-//    func testSyncCacheLookup() {
-//        // GIVEN
-//        let cache = MockImageCache()
-//        cache[Test.request] = ImageContainer(image: Test.image)
-//        pipeline = pipeline.reconfigured {
-//            $0.imageCache = cache
-//        }
-//
-//        // WHEN
-//        var image: PlatformImage?
-//        cancellable = pipeline.imagePublisher(with: Test.url).sink(receiveCompletion: { result in
-//            switch result {
-//            case .finished:
-//                break // Expected result
-//            case .failure:
-//                XCTFail()
-//            }
-//        }, receiveValue: {
-//            image = $0.image
-//        })
-//
-//        // THEN image returned synchronously
-//        XCTAssertNotNil(image)
-//    }
-
-//
     private var observer: AnyObject?
     
     func testCancellation() async throws {

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -90,7 +90,7 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
 //
     private var observer: AnyObject?
     
-    func _testCancellation() async throws {
+    func testCancellation() async throws {
         dataLoader.queue.isSuspended = true
 
         let task = _Concurrency.Task {
@@ -101,11 +101,13 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
             task.cancel()
         }
 
+        var catchedError: Error?
         do {
             let _ = try await task.value
         } catch {
-            print(error)
+            catchedError = error
         }
+        XCTAssertTrue(catchedError is CancellationError)
     }
 }
 

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -5,8 +5,8 @@
 import XCTest
 @testable import Nuke
 
-#if swift(>=5.5)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+#if swift(>=5.5.2)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
 class ImagePipelineAsyncAwaitTests: XCTestCase {
     var dataLoader: MockDataLoader!
     var pipeline: ImagePipeline!

--- a/Tests/PerformanceTests/TaskPerformanceTests.swift
+++ b/Tests/PerformanceTests/TaskPerformanceTests.swift
@@ -5,7 +5,7 @@
 import XCTest
 import Nuke
 
-// `Task.swift` is added directly to this target.
+// `AsyncTask.swift` is added directly to this target.
 class TaskPerformanceTests: XCTestCase {
     func testSubscribe() {
         measure {

--- a/Tests/PerformanceTests/TaskPerformanceTests.swift
+++ b/Tests/PerformanceTests/TaskPerformanceTests.swift
@@ -57,7 +57,7 @@ private struct MyError: Equatable {
     let raw: String
 }
 
-private final class SimpleTask: Task<Int, MyError> {
+private final class SimpleTask: AsyncTask<Int, MyError> {
     override func start() {
         send(progress: TaskProgress(completed: 1, total: 2))
         send(value: 1)
@@ -66,7 +66,7 @@ private final class SimpleTask: Task<Int, MyError> {
     }
 }
 
-private final class EmptyTask: Task<Int, MyError> {
+private final class EmptyTask: AsyncTask<Int, MyError> {
     override func start() {
     }
 }

--- a/Tests/TaskTests.swift
+++ b/Tests/TaskTests.swift
@@ -55,7 +55,7 @@ class TaskTests: XCTestCase {
 
         weak var weakFoo: Foo?
 
-        let task: Task<Int, Error> = autoreleasepool { // Just in case
+        let task: AsyncTask<Int, Error> = autoreleasepool { // Just in case
             let foo = Foo()
             weakFoo = foo
             return SimpleTask<Int, Error>(starter: { _ in
@@ -84,7 +84,7 @@ class TaskTests: XCTestCase {
         })
 
         // When
-        var recordedEvents = [Task<Int, MyError>.Event]()
+        var recordedEvents = [AsyncTask<Int, MyError>.Event]()
         _ = task.subscribe { event in
             recordedEvents.append(event)
         }
@@ -100,7 +100,7 @@ class TaskTests: XCTestCase {
 
     func testBothSubscriptionsReceiveEvents() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
 
         // When there are two subscriptions
         var eventCount = 0
@@ -133,7 +133,7 @@ class TaskTests: XCTestCase {
 
     func testCantSubscribeToAlreadySucceededTask() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         let _ = task.subscribe { _ in }
 
         // When
@@ -145,7 +145,7 @@ class TaskTests: XCTestCase {
 
     func testCantSubscribeToAlreadyFailedTasks() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         let _ = task.subscribe { _ in }
 
         // When
@@ -176,8 +176,8 @@ class TaskTests: XCTestCase {
 
     func testWhenSubscriptionIsRemovedNoEventsAreSent() {
         // Given
-        let task = Task<Int, MyError>()
-        var recordedEvents = [Task<Int, MyError>.Event]()
+        let task = AsyncTask<Int, MyError>()
+        var recordedEvents = [AsyncTask<Int, MyError>.Event]()
         let subscription = task.subscribe { recordedEvents.append($0) }
 
         // When
@@ -190,7 +190,7 @@ class TaskTests: XCTestCase {
 
     func testWhenSubscriptionIsRemovedTaskBecomesDisposed() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         let subscription = task.subscribe { _ in }
 
         // When
@@ -202,7 +202,7 @@ class TaskTests: XCTestCase {
 
     func testWhenSubscriptionIsRemovedOnCancelIsCalled() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         let subscription = task.subscribe { _ in }
 
         var onCancelledIsCalled = false
@@ -292,7 +292,7 @@ class TaskTests: XCTestCase {
 
     func testWhenTaskChangesOperationPriorityUpdated() { // Or sets operation later
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         let subscription = task.subscribe { _ in }
 
         // When
@@ -382,7 +382,7 @@ class TaskTests: XCTestCase {
 
     func testExecutingTaskIsntDisposed() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         var isDisposeCalled = false
         task.onDisposed = { isDisposeCalled = true }
         let _ = task.subscribe { _ in }
@@ -412,7 +412,7 @@ class TaskTests: XCTestCase {
 
     func testThatTaskIsDisposedWhenCompletedWithSuccess() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         var isDisposeCalled = false
         task.onDisposed = { isDisposeCalled = true }
         let _ = task.subscribe { _ in }
@@ -427,7 +427,7 @@ class TaskTests: XCTestCase {
 
     func testThatTaskIsDisposedWhenCompletedWithFailure() {
         // Given
-        let task = Task<Int, MyError>()
+        let task = AsyncTask<Int, MyError>()
         var isDisposeCalled = false
         task.onDisposed = { isDisposeCalled = true }
         let _ = task.subscribe { _ in }
@@ -447,7 +447,7 @@ private struct MyError: Equatable {
     let raw: String
 }
 
-private final class SimpleTask<T, E>: Task<T, E> {
+private final class SimpleTask<T, E>: AsyncTask<T, E> {
     private var starter: ((SimpleTask) -> Void)?
 
     /// Initializes the task with the `starter`.
@@ -464,7 +464,7 @@ private final class SimpleTask<T, E>: Task<T, E> {
     }
 }
 
-extension Task {
+extension AsyncTask {
     func subscribe(priority: TaskPriority = .normal, _ observer: @escaping (Event) -> Void) -> TaskSubscription? {
         publisher.subscribe(priority: priority, observer)
     }


### PR DESCRIPTION
### 1. Add `ImagePipeline` `loadImage` async method

```swift
do {
    return try await pipeline.loadImage(with: request)
} catch {
    guard let error = (error as? ImagePipeline.Error),
          (error.dataLoadingError as? URLError)?.networkUnavailableReason == .constrained else {
        throw error
    }
    return try await pipeline.loadImage(with: lowQualityImageURL)
}
```

### 2. `FetchImage` now supports async responses

```swift
struct ImageView: View {
    let url: URL

    @StateObject private var image = FetchImage()

    var body: some View {
        ZStack {
            Rectangle().fill(Color.gray)
            image.view?
                .resizable()
                .aspectRatio(contentMode: .fill)
                .clipped()
        }
        .onAppear { loadImage(url) }
        .onChange(of: url) { loadImage($0) }
        .onDisappear(perform: image.reset)
    }

    private func loadImage(url: URL) {
         image.load {
               try await ImagePipeline.shared.loadImage(with: url) // Or could be any async task you want
         }
    }
}
```
