### PR TITLE
Add async/await

### DIFF
--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -163,7 +163,7 @@ public final class ImagePipeline {
         return task
     }
     
-#if swift(>=5.5.2)
+#if swift(>=5.6)
     /// Loads an image for the given request.
     ///
     /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.

--- a/Sources/UI/FetchImage.swift
+++ b/Sources/UI/FetchImage.swift
@@ -192,6 +192,23 @@ public final class FetchImage: ObservableObject, Identifiable {
         })
     }
     
+#if swift(>=5.5.2)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
+    public func load(_ action: @escaping () async throws -> ImageResponse) {
+        reset()
+        isLoading = true
+        
+        let task = Task {
+            do {
+                self.handle(result: .success(try await action()))
+            } catch {
+                self.handle(result: .failure(error))
+            }
+        }
+        cancellable = AnyCancellable { task.cancel() }
+    }
+#endif
+    
     // MARK: Cancel
 
     /// Marks the request as being cancelled. Continues to display a downloaded

--- a/Sources/UI/FetchImage.swift
+++ b/Sources/UI/FetchImage.swift
@@ -192,7 +192,7 @@ public final class FetchImage: ObservableObject, Identifiable {
         })
     }
     
-#if swift(>=5.5.2)
+#if swift(>=5.6)
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
     public func load(_ action: @escaping () async throws -> ImageResponse) {
         reset()

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -20,6 +20,63 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
             $0.imageCache = nil
         }
     }
+    
+    // MARK: Common Use Cases
+
+    func testLowDataMode() async throws {
+        // GIVEN
+        let highQualityImageURL = URL(string: "https://example.com/high-quality-image.jpeg")!
+        let lowQualityImageURL = URL(string: "https://example.com/low-quality-image.jpeg")!
+
+        dataLoader.results[highQualityImageURL] = .failure(URLError(networkUnavailableReason: .constrained) as NSError)
+        dataLoader.results[lowQualityImageURL] = .success((Test.data, Test.urlResponse))
+                
+        // WHEN
+        let pipeline = self.pipeline!
+
+        // Create the default request to fetch the high quality image.
+        var urlRequest = URLRequest(url: highQualityImageURL)
+        urlRequest.allowsConstrainedNetworkAccess = false
+        let request = ImageRequest(urlRequest: urlRequest)
+
+        // WHEN
+        @Sendable func loadImage() async throws -> ImageResponse {
+            do {
+                return try await pipeline.loadImage(with: request)
+            } catch {
+                guard let error = (error as? ImagePipeline.Error),
+                      (error.dataLoadingError as? URLError)?.networkUnavailableReason == .constrained else {
+                    throw error
+                }
+                return try await pipeline.loadImage(with: lowQualityImageURL)
+            }
+        }
+
+        let response = try await loadImage()
+        XCTAssertNotNil(response.image)
+    }
+
+    private var observer: AnyObject?
+    
+    func testCancellation() async throws {
+        dataLoader.queue.isSuspended = true
+
+        let task = _Concurrency.Task {
+            try await pipeline.loadImage(with: Test.url)
+        }
+        
+        observer = NotificationCenter.default.addObserver(forName: MockDataLoader.DidStartTask, object: dataLoader, queue: OperationQueue()) { _ in
+            task.cancel()
+        }
+
+        var catchedError: Error?
+        do {
+            let _ = try await task.value
+        } catch {
+            catchedError = error
+        }
+        XCTAssertTrue(catchedError is CancellationError)
+    }
 }
 
 /// We have to mock it because there is no way to construct native `URLError`

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -5,7 +5,7 @@
 import XCTest
 @testable import Nuke
 
-#if swift(>=5.5.2)
+#if swift(>=5.6)
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
 class ImagePipelineAsyncAwaitTests: XCTestCase {
     var dataLoader: MockDataLoader!

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -77,6 +77,18 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
         }
         XCTAssertTrue(catchedError is CancellationError)
     }
+
+    func testLoadData() async throws {
+        // GIVEN
+        dataLoader.results[Test.url] = .success((Test.data, Test.urlResponse))
+
+        // WHEN
+        let (data, response) = try await pipeline.loadData(with: Test.request)
+
+        // THEN
+        XCTAssertEqual(data.count, 22788)
+        XCTAssertNotNil(response?.url, Test.url.absoluteString)
+    }
 }
 
 /// We have to mock it because there is no way to construct native `URLError`


### PR DESCRIPTION
This will be merged when it's clear what to do with https://github.com/kean/Nuke/issues/526

Add the following async/await APIs:

```swift
extension ImagePipeline {
    public func loadImage(with request: ImageRequestConvertible) async throws -> ImageResponse
    public func loadData(with request: ImageRequestConvertible) async throws -> (Data, URLResponse?)
}

extension FetchImage {
    public func load(_ action: @escaping () async throws -> ImageResponse)
}
```