### PR TITLE
Sendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 - Rename async/await `loadImage(with:)` method to `image(for:)`, and `loadData(with:)` to `data(for:)`
+- Add `Sendable` conformance to some of the types
 
 ## Nuke 10.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nuke 10
 
+## Upcoming
+
+- Rename async/await `loadImage(with:)` method to `image(for:)`, and `loadData(with:)` to `data(for:)`
+
 ## Nuke 10.8.0
 
 *Apr 24, 2022*

--- a/Sources/Core/Caching/ImagePipelineCache.swift
+++ b/Sources/Core/Caching/ImagePipelineCache.swift
@@ -15,247 +15,253 @@ extension ImagePipeline {
     public struct Cache {
         let pipeline: ImagePipeline
         private var configuration: ImagePipeline.Configuration { pipeline.configuration }
-
-        // MARK: Subscript (Memory Cache)
-
-        /// Returns an image from the memory cache for the given request.
-        public subscript(request: ImageRequestConvertible) -> ImageContainer? {
-            get { self[request.asImageRequest()] }
-            nonmutating set { self[request.asImageRequest()] = newValue }
-        }
-
-        subscript(request: ImageRequest) -> ImageContainer? {
-            get {
-                cachedImageFromMemoryCache(for: request)
-            }
-            nonmutating set {
-                if let image = newValue {
-                    storeCachedImageInMemoryCache(image, for: request)
-                } else {
-                    removeCachedImageFromMemoryCache(for: request)
-                }
-            }
-        }
-
-        // MARK: Cached Images
-
-        /// Returns a cached image any of the caches.
-        ///
-        /// - note: Respects request options such as `cachePolicy`.
-        ///
-        /// - parameter request: The request. Make sure to remove the processors
-        /// if you want to retrieve an original image (if it's stored).
-        /// - parameter caches: `[.all]`, by default.
-        public func cachedImage(for request: ImageRequestConvertible, caches: Caches = [.all]) -> ImageContainer? {
-            let request = request.asImageRequest()
-            if caches.contains(.memory) {
-                if let image = cachedImageFromMemoryCache(for: request) {
-                    return image
-                }
-            }
-            if caches.contains(.disk) {
-                if let data = cachedData(for: request),
-                   let image = decodeImageData(data, for: request) {
-                    return image
-                }
-            }
-            return nil
-        }
-
-        /// Stores the image in all caches. To store image in the disk cache, it
-        /// will be encoded (see `ImageEncoding`)
-        ///
-        /// - note: Respects request cache options.
-        ///
-        /// - note: Default `DiskCache` stores data asynchronously, so it's safe
-        /// to call this method even from the main thread.
-        ///
-        /// - note: Image previews are not stored.
-        ///
-        /// - parameter request: The request. Make sure to remove the processors
-        /// if you want to retrieve an original image (if it's stored).
-        /// - parameter caches: `[.all]`, by default.
-        public func storeCachedImage(_ image: ImageContainer, for request: ImageRequestConvertible, caches: Caches = [.all]) {
-            let request = request.asImageRequest()
-            if caches.contains(.memory) {
-                storeCachedImageInMemoryCache(image, for: request)
-            }
-            if caches.contains(.disk) {
-                if let data = encodeImage(image, for: request) {
-                    storeCachedData(data, for: request)
-                }
-            }
-        }
-
-        /// Removes the image from all caches.
-        public func removeCachedImage(for request: ImageRequestConvertible, caches: Caches = [.all]) {
-            let request = request.asImageRequest()
-            if caches.contains(.memory) {
-                removeCachedImageFromMemoryCache(for: request)
-            }
-            if caches.contains(.disk) {
-                removeCachedData(for: request)
-            }
-        }
-
-        /// Returns `true` if any of the caches contain the image.
-        public func containsCachedImage(for request: ImageRequestConvertible, caches: Caches = [.all]) -> Bool {
-            let request = request.asImageRequest()
-            if caches.contains(.memory) && cachedImageFromMemoryCache(for: request) != nil {
-                return true
-            }
-            if caches.contains(.disk), let dataCache = dataCache(for: request) {
-                let key = makeDataCacheKey(for: request)
-                return dataCache.containsData(for: key)
-            }
-            return false
-        }
-
-        private func cachedImageFromMemoryCache(for request: ImageRequest) -> ImageContainer? {
-            guard !request.options.contains(.disableMemoryCacheReads) else {
-                return nil
-            }
-            let key = makeImageCacheKey(for: request)
-            if let imageCache = pipeline.imageCache {
-                return imageCache[key] // Fast path for a default cache (no protocol call)
-            }
-            return configuration.imageCache?[key]
-        }
-
-        private func storeCachedImageInMemoryCache(_ image: ImageContainer, for request: ImageRequest) {
-            guard !request.options.contains(.disableMemoryCacheWrites) else {
-                return
-            }
-            guard !image.isPreview || configuration.isStoringPreviewsInMemoryCache else {
-                return
-            }
-            let key = makeImageCacheKey(for: request)
-            configuration.imageCache?[key] = image
-        }
-
-        private func removeCachedImageFromMemoryCache(for request: ImageRequest) {
-            let key = makeImageCacheKey(for: request)
-            configuration.imageCache?[key] = nil
-        }
-
-        // MARK: Cached Data
-
-        /// Returns cached data for the given request.
-        public func cachedData(for request: ImageRequestConvertible) -> Data? {
-            let request = request.asImageRequest()
-            guard !request.options.contains(.disableDiskCacheReads) else {
-                return nil
-            }
-            guard let dataCache = dataCache(for: request) else {
-                return nil
-            }
-            let key = makeDataCacheKey(for: request)
-            return dataCache.cachedData(for: key)
-        }
-
-        /// Stores data for the given request.
-        ///
-        /// - note: Default `DiskCache` stores data asynchronously, so it's safe
-        /// to call this method even from the main thread.
-        public func storeCachedData(_ data: Data, for request: ImageRequestConvertible) {
-            let request = request.asImageRequest()
-            guard let dataCache = dataCache(for: request),
-                  !request.options.contains(.disableDiskCacheWrites) else {
-                return
-            }
-            let key = makeDataCacheKey(for: request)
-            dataCache.storeData(data, for: key)
-        }
-
-        /// Returns true if the data cache contains data for the given image
-        public func containsData(for request: ImageRequestConvertible) -> Bool {
-            let request = request.asImageRequest()
-            guard let dataCache = dataCache(for: request) else {
-                return false
-            }
-            return dataCache.containsData(for: makeDataCacheKey(for: request))
-        }
-
-        /// Removes cached data for the given request.
-        public func removeCachedData(for request: ImageRequestConvertible) {
-            let request = request.asImageRequest()
-            guard let dataCache = dataCache(for: request) else {
-                return
-            }
-            let key = makeDataCacheKey(for: request)
-            dataCache.removeData(for: key)
-        }
-
-        // MARK: Keys
-
-        /// Returns image cache (memory cache) key for the given request.
-        public func makeImageCacheKey(for request: ImageRequestConvertible) -> ImageCacheKey {
-            makeImageCacheKey(for: request.asImageRequest())
-        }
-
-        func makeImageCacheKey(for request: ImageRequest) -> ImageCacheKey {
-            if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
-                return ImageCacheKey(key: customKey)
-            }
-            return ImageCacheKey(request: request) // Use the default key
-        }
-
-        /// Returns data cache (disk cache) key for the given request.
-        public func makeDataCacheKey(for request: ImageRequestConvertible) -> String {
-            makeDataCacheKey(for: request.asImageRequest())
-        }
-
-        func makeDataCacheKey(for request: ImageRequest) -> String {
-            if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
-                return customKey
-            }
-            return request.makeDataCacheKey() // Use the default key
-        }
-
-        // MARK: Misc
-
-        /// Removes both images and data from all cache layes.
-        public func removeAll(caches: Caches = [.all]) {
-            if caches.contains(.memory) {
-                configuration.imageCache?.removeAll()
-            }
-            if caches.contains(.disk) {
-                configuration.dataCache?.removeAll()
-            }
-        }
-
-        // MARK: Private
-
-        private func decodeImageData(_ data: Data, for request: ImageRequest) -> ImageContainer? {
-            let context = ImageDecodingContext(request: request, data: data, isCompleted: true, urlResponse: nil)
-            guard let decoder = pipeline.delegate.imageDecoder(for: context, pipeline: pipeline) else {
-                return nil
-            }
-            return decoder.decode(data, urlResponse: nil, isCompleted: true, cacheType: .disk)?.container
-        }
-
-        private func encodeImage(_ image: ImageContainer, for request: ImageRequest) -> Data? {
-            let context = ImageEncodingContext(request: request, image: image.image, urlResponse: nil)
-            let encoder = pipeline.delegate.imageEncoder(for: context, pipeline: pipeline)
-            return encoder.encode(image, context: context)
-        }
-
-        private func dataCache(for request: ImageRequest) -> DataCaching? {
-            pipeline.delegate.dataCache(for: request, pipeline: pipeline)
-        }
-
-        // MARK: Options
-
-        /// Describes a set of cache layers to use.
-        public struct Caches: OptionSet {
-            public let rawValue: Int
-            public init(rawValue: Int) {
-                self.rawValue = rawValue
-            }
-
-            public static let memory = Caches(rawValue: 1 << 0)
-            public static let disk = Caches(rawValue: 1 << 1)
-            public static let all: Caches = [.memory, .disk]
-        }
     }
 }
+
+extension ImagePipeline.Cache {
+    // MARK: Subscript (Memory Cache)
+
+    /// Returns an image from the memory cache for the given request.
+    public subscript(request: ImageRequestConvertible) -> ImageContainer? {
+        get { self[request.asImageRequest()] }
+        nonmutating set { self[request.asImageRequest()] = newValue }
+    }
+
+    subscript(request: ImageRequest) -> ImageContainer? {
+        get {
+            cachedImageFromMemoryCache(for: request)
+        }
+        nonmutating set {
+            if let image = newValue {
+                storeCachedImageInMemoryCache(image, for: request)
+            } else {
+                removeCachedImageFromMemoryCache(for: request)
+            }
+        }
+    }
+
+    // MARK: Cached Images
+
+    /// Returns a cached image any of the caches.
+    ///
+    /// - note: Respects request options such as `cachePolicy`.
+    ///
+    /// - parameter request: The request. Make sure to remove the processors
+    /// if you want to retrieve an original image (if it's stored).
+    /// - parameter caches: `[.all]`, by default.
+    public func cachedImage(for request: ImageRequestConvertible, caches: Caches = [.all]) -> ImageContainer? {
+        let request = request.asImageRequest()
+        if caches.contains(.memory) {
+            if let image = cachedImageFromMemoryCache(for: request) {
+                return image
+            }
+        }
+        if caches.contains(.disk) {
+            if let data = cachedData(for: request),
+               let image = decodeImageData(data, for: request) {
+                return image
+            }
+        }
+        return nil
+    }
+
+    /// Stores the image in all caches. To store image in the disk cache, it
+    /// will be encoded (see `ImageEncoding`)
+    ///
+    /// - note: Respects request cache options.
+    ///
+    /// - note: Default `DiskCache` stores data asynchronously, so it's safe
+    /// to call this method even from the main thread.
+    ///
+    /// - note: Image previews are not stored.
+    ///
+    /// - parameter request: The request. Make sure to remove the processors
+    /// if you want to retrieve an original image (if it's stored).
+    /// - parameter caches: `[.all]`, by default.
+    public func storeCachedImage(_ image: ImageContainer, for request: ImageRequestConvertible, caches: Caches = [.all]) {
+        let request = request.asImageRequest()
+        if caches.contains(.memory) {
+            storeCachedImageInMemoryCache(image, for: request)
+        }
+        if caches.contains(.disk) {
+            if let data = encodeImage(image, for: request) {
+                storeCachedData(data, for: request)
+            }
+        }
+    }
+
+    /// Removes the image from all caches.
+    public func removeCachedImage(for request: ImageRequestConvertible, caches: Caches = [.all]) {
+        let request = request.asImageRequest()
+        if caches.contains(.memory) {
+            removeCachedImageFromMemoryCache(for: request)
+        }
+        if caches.contains(.disk) {
+            removeCachedData(for: request)
+        }
+    }
+
+    /// Returns `true` if any of the caches contain the image.
+    public func containsCachedImage(for request: ImageRequestConvertible, caches: Caches = [.all]) -> Bool {
+        let request = request.asImageRequest()
+        if caches.contains(.memory) && cachedImageFromMemoryCache(for: request) != nil {
+            return true
+        }
+        if caches.contains(.disk), let dataCache = dataCache(for: request) {
+            let key = makeDataCacheKey(for: request)
+            return dataCache.containsData(for: key)
+        }
+        return false
+    }
+
+    private func cachedImageFromMemoryCache(for request: ImageRequest) -> ImageContainer? {
+        guard !request.options.contains(.disableMemoryCacheReads) else {
+            return nil
+        }
+        let key = makeImageCacheKey(for: request)
+        if let imageCache = pipeline.imageCache {
+            return imageCache[key] // Fast path for a default cache (no protocol call)
+        }
+        return configuration.imageCache?[key]
+    }
+
+    private func storeCachedImageInMemoryCache(_ image: ImageContainer, for request: ImageRequest) {
+        guard !request.options.contains(.disableMemoryCacheWrites) else {
+            return
+        }
+        guard !image.isPreview || configuration.isStoringPreviewsInMemoryCache else {
+            return
+        }
+        let key = makeImageCacheKey(for: request)
+        configuration.imageCache?[key] = image
+    }
+
+    private func removeCachedImageFromMemoryCache(for request: ImageRequest) {
+        let key = makeImageCacheKey(for: request)
+        configuration.imageCache?[key] = nil
+    }
+
+    // MARK: Cached Data
+
+    /// Returns cached data for the given request.
+    public func cachedData(for request: ImageRequestConvertible) -> Data? {
+        let request = request.asImageRequest()
+        guard !request.options.contains(.disableDiskCacheReads) else {
+            return nil
+        }
+        guard let dataCache = dataCache(for: request) else {
+            return nil
+        }
+        let key = makeDataCacheKey(for: request)
+        return dataCache.cachedData(for: key)
+    }
+
+    /// Stores data for the given request.
+    ///
+    /// - note: Default `DiskCache` stores data asynchronously, so it's safe
+    /// to call this method even from the main thread.
+    public func storeCachedData(_ data: Data, for request: ImageRequestConvertible) {
+        let request = request.asImageRequest()
+        guard let dataCache = dataCache(for: request),
+              !request.options.contains(.disableDiskCacheWrites) else {
+            return
+        }
+        let key = makeDataCacheKey(for: request)
+        dataCache.storeData(data, for: key)
+    }
+
+    /// Returns true if the data cache contains data for the given image
+    public func containsData(for request: ImageRequestConvertible) -> Bool {
+        let request = request.asImageRequest()
+        guard let dataCache = dataCache(for: request) else {
+            return false
+        }
+        return dataCache.containsData(for: makeDataCacheKey(for: request))
+    }
+
+    /// Removes cached data for the given request.
+    public func removeCachedData(for request: ImageRequestConvertible) {
+        let request = request.asImageRequest()
+        guard let dataCache = dataCache(for: request) else {
+            return
+        }
+        let key = makeDataCacheKey(for: request)
+        dataCache.removeData(for: key)
+    }
+
+    // MARK: Keys
+
+    /// Returns image cache (memory cache) key for the given request.
+    public func makeImageCacheKey(for request: ImageRequestConvertible) -> ImageCacheKey {
+        makeImageCacheKey(for: request.asImageRequest())
+    }
+
+    func makeImageCacheKey(for request: ImageRequest) -> ImageCacheKey {
+        if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
+            return ImageCacheKey(key: customKey)
+        }
+        return ImageCacheKey(request: request) // Use the default key
+    }
+
+    /// Returns data cache (disk cache) key for the given request.
+    public func makeDataCacheKey(for request: ImageRequestConvertible) -> String {
+        makeDataCacheKey(for: request.asImageRequest())
+    }
+
+    func makeDataCacheKey(for request: ImageRequest) -> String {
+        if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
+            return customKey
+        }
+        return request.makeDataCacheKey() // Use the default key
+    }
+
+    // MARK: Misc
+
+    /// Removes both images and data from all cache layes.
+    public func removeAll(caches: Caches = [.all]) {
+        if caches.contains(.memory) {
+            configuration.imageCache?.removeAll()
+        }
+        if caches.contains(.disk) {
+            configuration.dataCache?.removeAll()
+        }
+    }
+
+    // MARK: Private
+
+    private func decodeImageData(_ data: Data, for request: ImageRequest) -> ImageContainer? {
+        let context = ImageDecodingContext(request: request, data: data, isCompleted: true, urlResponse: nil)
+        guard let decoder = pipeline.delegate.imageDecoder(for: context, pipeline: pipeline) else {
+            return nil
+        }
+        return decoder.decode(data, urlResponse: nil, isCompleted: true, cacheType: .disk)?.container
+    }
+
+    private func encodeImage(_ image: ImageContainer, for request: ImageRequest) -> Data? {
+        let context = ImageEncodingContext(request: request, image: image.image, urlResponse: nil)
+        let encoder = pipeline.delegate.imageEncoder(for: context, pipeline: pipeline)
+        return encoder.encode(image, context: context)
+    }
+
+    private func dataCache(for request: ImageRequest) -> DataCaching? {
+        pipeline.delegate.dataCache(for: request, pipeline: pipeline)
+    }
+
+    // MARK: Options
+
+    /// Describes a set of cache layers to use.
+    public struct Caches: OptionSet {
+        public let rawValue: Int
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        public static let memory = Caches(rawValue: 1 << 0)
+        public static let disk = Caches(rawValue: 1 << 1)
+        public static let all: Caches = [.memory, .disk]
+    }
+}
+
+#if swift(>=5.6)
+extension ImagePipeline.Cache.Caches: Sendable {}
+#endif

--- a/Sources/Core/Decoding/AssetType.swift
+++ b/Sources/Core/Decoding/AssetType.swift
@@ -88,3 +88,7 @@ public extension AssetType {
         return nil
     }
 }
+
+#if swift(>=5.6)
+extension AssetType: Sendable {}
+#endif

--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -164,13 +164,20 @@ public final class ImagePipeline {
     }
 
 #if swift(>=5.6)
+    // Deprecated in 10.9.0
+    @available(*, deprecated, message: "Renamed to image(for:)")
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
+    public func loadImage(with request: ImageRequestConvertible) async throws -> ImageResponse {
+        try await image(for: request)
+    }
+
     /// Loads an image for the given request.
     ///
     /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
     ///
     /// - parameter request: An image request.
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
-    public func loadImage(with request: ImageRequestConvertible) async throws -> ImageResponse {
+    public func image(for request: ImageRequestConvertible) async throws -> ImageResponse {
         let box = TaskBox()
         return try await withTaskCancellationHandler(handler: {
             box.task?.cancel()
@@ -269,13 +276,20 @@ public final class ImagePipeline {
     }
 
 #if swift(>=5.6)
+    // Deprecated in 10.9.0
+    @available(*, deprecated, message: "Renamed to data(for:)")
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
+    public func loadData(with request: ImageRequestConvertible) async throws -> (Data, URLResponse?) {
+        try await data(for: request)
+    }
+
     /// Loads an image for the given request.
     ///
     /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
     ///
     /// - parameter request: An image request.
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
-    public func loadData(with request: ImageRequestConvertible) async throws -> (Data, URLResponse?) {
+    public func data(for request: ImageRequestConvertible) async throws -> (Data, URLResponse?) {
         let box = TaskBox()
         return try await withTaskCancellationHandler(handler: {
             box.task?.cancel()

--- a/Sources/Core/ImageRequest.swift
+++ b/Sources/Core/ImageRequest.swift
@@ -469,3 +469,10 @@ extension String: ImageRequestConvertible {
         ImageRequest(url: URL(string: self))
     }
 }
+
+#if swift(>=5.6)
+extension ImageRequest.Priority: Sendable {}
+extension ImageRequest.Options: Sendable {}
+extension ImageRequest.UserInfoKey: Sendable {}
+extension ImageRequest.ThumbnailOptions: Sendable {}
+#endif

--- a/Sources/Core/ImageResponse.swift
+++ b/Sources/Core/ImageResponse.swift
@@ -142,3 +142,12 @@ public struct ImageContainer {
         public static let scanNumberKey: UserInfoKey = "com.github/kean/nuke/scan-number"
     }
 }
+
+#if swift(>=5.6)
+struct Test: Sendable {
+    var priority: ImageContainer.UserInfoKey
+}
+
+extension ImageResponse.CacheType: Sendable {}
+extension ImageContainer.UserInfoKey: Sendable {}
+#endif

--- a/Sources/Core/Processing/ImageProcessingOptions.swift
+++ b/Sources/Core/Processing/ImageProcessingOptions.swift
@@ -68,3 +68,8 @@ public enum ImageProcessingOptions {
         }
     }
 }
+
+#if swift(>=5.6)
+extension ImageProcessingOptions.Unit: Sendable {}
+extension ImageProcessingOptions.Border: @unchecked Sendable {}
+#endif

--- a/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -42,13 +42,13 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
         // WHEN
         @Sendable func loadImage() async throws -> ImageResponse {
             do {
-                return try await pipeline.loadImage(with: request)
+                return try await pipeline.image(for: request)
             } catch {
                 guard let error = (error as? ImagePipeline.Error),
                       (error.dataLoadingError as? URLError)?.networkUnavailableReason == .constrained else {
                     throw error
                 }
-                return try await pipeline.loadImage(with: lowQualityImageURL)
+                return try await pipeline.image(for: lowQualityImageURL)
             }
         }
 
@@ -62,7 +62,7 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
         dataLoader.queue.isSuspended = true
 
         let task = _Concurrency.Task {
-            try await pipeline.loadImage(with: Test.url)
+            try await pipeline.image(for: Test.url)
         }
         
         observer = NotificationCenter.default.addObserver(forName: MockDataLoader.DidStartTask, object: dataLoader, queue: OperationQueue()) { _ in
@@ -83,7 +83,7 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
         dataLoader.results[Test.url] = .success((Test.data, Test.urlResponse))
 
         // WHEN
-        let (data, response) = try await pipeline.loadData(with: Test.request)
+        let (data, response) = try await pipeline.data(for: Test.request)
 
         // THEN
         XCTAssertEqual(data.count, 22788)


### PR DESCRIPTION
I added `Sendable` for some primitive types. I'm not sure if it was needed, because compiler should be able to infer it.

Ideally, I'd like `ImageRequest` and `ImageResponse` to be `Sendable`, but they have the following properties, so I'm not sure they can be:

```swift
public var userInfo: [UserInfoKey: Any]
public var processors: [ImageProcessing]
```