### PR TITLE
Add associated Data to ImagePipeline.Error.decodingFailed

### DIFF
--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -354,7 +354,7 @@ public final class ImagePipeline {
         /// Data loader failed to load image data with a wrapped error.
         case dataLoadingFailed(Swift.Error)
         /// Decoder failed to produce a final image.
-        case decodingFailed
+        case decodingFailed(Data)
         /// Processor failed to produce a final image.
         case processingFailed(ImageProcessing)
 

--- a/Sources/Core/Tasks/TaskFetchDecodedImage.swift
+++ b/Sources/Core/Tasks/TaskFetchDecodedImage.swift
@@ -31,14 +31,14 @@ final class TaskFetchDecodedImage: ImagePipelineTask<ImageResponse> {
         // Sanity check
         guard !data.isEmpty else {
             if isCompleted {
-                send(error: .decodingFailed)
+                send(error: .decodingFailed(data))
             }
             return
         }
 
         guard let decoder = decoder(data: data, urlResponse: urlResponse, isCompleted: isCompleted) else {
             if isCompleted {
-                send(error: .decodingFailed)
+                send(error: .decodingFailed(data))
             } // Try again when more data is downloaded.
             return
         }
@@ -68,7 +68,7 @@ final class TaskFetchDecodedImage: ImagePipelineTask<ImageResponse> {
         if let response = response {
             send(value: response, isCompleted: isCompleted)
         } else if isCompleted {
-            send(error: .decodingFailed)
+            send(error: .decodingFailed(response?.container.data ?? Data()))
         }
     }
 

--- a/Tests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineTests.swift
@@ -492,7 +492,8 @@ class ImagePipelineTests: XCTestCase {
         }
 
         // When/Then
-        expect(pipeline).toFailRequest(Test.request, with: .decodingFailed)
+        let data = Test.data(name: "fixture", extension: "jpeg")
+        expect(pipeline).toFailRequest(Test.request, with: .decodingFailed(data))
         wait()
     }
 
@@ -526,7 +527,7 @@ class ImagePipelineTests: XCTestCase {
 
     func testErrorDescription() {
         XCTAssertFalse(ImagePipeline.Error.dataLoadingFailed(URLError(.unknown)).description.isEmpty) // Just padding here
-        XCTAssertFalse(ImagePipeline.Error.decodingFailed.description.isEmpty)
+        XCTAssertFalse(ImagePipeline.Error.decodingFailed(Data()).description.isEmpty)
 
         let processor = ImageProcessors.Resize(width: 100, unit: .pixels)
         let error = ImagePipeline.Error.processingFailed(processor)


### PR DESCRIPTION
Based on discussion at #544 