### PR TITLE
Draft: Simplify ImageProcessing

### DIFF
--- a/Documentation/Migrations/Nuke 11 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 11 Migration Guide.md
@@ -9,3 +9,25 @@ This guide eases the transition of the existing apps that use Nuke 10.x to the l
 - iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0
 - Xcode 13.2
 - Swift 5.5.2
+
+## `ImageProcessing`
+
+If you have custom image processors that implement `ImageProcessing` protocol using the method:
+
+```swift
+// Before (Nuke 10)
+sturct CustomImageProcessor: ImageProcessing {
+    func process(_ image: PlatformImage) -> PlatformImage? {
+        image.drawInCircle()
+    }
+}
+```
+
+```swift
+// After (Nuke 11)
+sturct CustomImageProcessor: ImageProcessing {
+    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+        container.map { $0.drawInCircle() }
+    }
+}
+```

--- a/Sources/Core/Processing/ImageProcessing.swift
+++ b/Sources/Core/Processing/ImageProcessing.swift
@@ -22,11 +22,6 @@ import Foundation
 ///
 /// You must implement either one of those methods.
 public protocol ImageProcessing {
-    /// Returns a processed image. By default, returns `nil`.
-    ///
-    /// - note: Gets called a background queue managed by the pipeline.
-    func process(_ image: PlatformImage) -> PlatformImage?
-
     /// Optional method. Returns a processed image. By default, this calls the
     /// basic `process(image:)` method.
     ///
@@ -51,12 +46,6 @@ public protocol ImageProcessing {
 }
 
 public extension ImageProcessing {
-    /// The default implementation simply calls the basic
-    /// `process(_ image: PlatformImage) -> PlatformImage?` method.
-    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
-        container.map(process)
-    }
-
     /// The default impleemntation simply returns `var identifier: String`.
     var hashableIdentifier: AnyHashable { identifier }
 }

--- a/Sources/Core/Processing/ImageProcessors+Anonymous.swift
+++ b/Sources/Core/Processing/ImageProcessors+Anonymous.swift
@@ -15,8 +15,8 @@ extension ImageProcessors {
             self.closure = closure
         }
 
-        public func process(_ image: PlatformImage) -> PlatformImage? {
-            self.closure(image)
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+            container.map(closure)
         }
 
         public var description: String {

--- a/Sources/Core/Processing/ImageProcessors+Circle.swift
+++ b/Sources/Core/Processing/ImageProcessors+Circle.swift
@@ -16,8 +16,8 @@ extension ImageProcessors {
             self.border = border
         }
 
-        public func process(_ image: PlatformImage) -> PlatformImage? {
-            image.processed.byDrawingInCircle(border: border)
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+            container.map { $0.processed.byDrawingInCircle(border: border) }
         }
 
         public var identifier: String {

--- a/Sources/Core/Processing/ImageProcessors+Composition.swift
+++ b/Sources/Core/Processing/ImageProcessors+Composition.swift
@@ -15,14 +15,6 @@ extension ImageProcessors {
             self.processors = processors
         }
 
-        public func process(_ image: PlatformImage) -> PlatformImage? {
-            processors.reduce(image) { image, processor in
-                autoreleasepool {
-                    image.flatMap { processor.process($0) }
-                }
-            }
-        }
-
         /// Processes the given image by applying each processor in an order in
         /// which they were added. If one of the processors fails to produce
         /// an image the processing stops and `nil` is returned.

--- a/Sources/Core/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Core/Processing/ImageProcessors+CoreImage.swift
@@ -38,9 +38,9 @@ extension ImageProcessors {
             self.identifier = "com.github.kean/nuke/core_image?name=\(name))"
         }
 
-        public func process(_ image: PlatformImage) -> PlatformImage? {
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
             let filter = CIFilter(name: name, parameters: parameters)
-            return CoreImageFilter.apply(filter: filter, to: image)
+            return container.map { CoreImageFilter.apply(filter: filter, to: $0) }
         }
 
         // MARK: - Apply Filter

--- a/Sources/Core/Processing/ImageProcessors+GaussianBlur.swift
+++ b/Sources/Core/Processing/ImageProcessors+GaussianBlur.swift
@@ -20,9 +20,9 @@ extension ImageProcessors {
         }
 
         /// Applies `CIGaussianBlur` filter to the image.
-        public func process(_ image: PlatformImage) -> PlatformImage? {
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
             let filter = CIFilter(name: "CIGaussianBlur", parameters: ["inputRadius": radius])
-            return CoreImageFilter.apply(filter: filter, to: image)
+            return container.map { CoreImageFilter.apply(filter: filter, to: $0) }
         }
 
         public var identifier: String {

--- a/Sources/Core/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Core/Processing/ImageProcessors+Resize.swift
@@ -64,11 +64,11 @@ extension ImageProcessors {
             self.init(size: CGSize(width: 9999, height: height), unit: unit, contentMode: .aspectFit, crop: false, upscale: upscale)
         }
 
-        public func process(_ image: PlatformImage) -> PlatformImage? {
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
             if crop && contentMode == .aspectFill {
-                return image.processed.byResizingAndCropping(to: size.cgSize)
+                return container.map { $0.processed.byResizingAndCropping(to: size.cgSize) }
             }
-            return image.processed.byResizing(to: size.cgSize, contentMode: contentMode, upscale: upscale)
+            return container.map { $0.processed.byResizing(to: size.cgSize, contentMode: contentMode, upscale: upscale) }
         }
 
         public var identifier: String {

--- a/Sources/Core/Processing/ImageProcessors+RoundedCorners.swift
+++ b/Sources/Core/Processing/ImageProcessors+RoundedCorners.swift
@@ -24,8 +24,8 @@ extension ImageProcessors {
             self.border = border
         }
 
-        public func process(_ image: PlatformImage) -> PlatformImage? {
-            image.processed.byAddingRoundedCorners(radius: radius, border: border)
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+            container.map { $0.processed.byAddingRoundedCorners(radius: radius, border: border) }
         }
 
         public var identifier: String {

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -59,6 +59,13 @@ extension ImagePipeline {
     }
 }
 
+extension ImageProcessing {
+    func process(_ image: PlatformImage) -> PlatformImage? {
+        let context = ImageProcessingContext(request: Test.request, response: Test.response, isFinal: true)
+        return process(ImageContainer(image: image), context: context)?.image
+    }
+}
+
 #if !os(watchOS)
 extension ImageLoadingOptions {
     private static var stack = [ImageLoadingOptions]()


### PR DESCRIPTION
Simplify two-method `ImageProcessing` setup:

```swift 
public protocol ImageProcessing {
    // Remove
    func process(_ image: PlatformImage) -> PlatformImage?

    // This method is now required
    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer?

    // ...
}
```

The two-method setup was created to avoid breaking changes in an already packed [Nuke 9.0](https://github.com/kean/Nuke/releases/tag/9.0.0) release. But it ended-up being a bit overcomplicated. It's not obvious which method to implement without reading the documentation. And if you implement a more "advanced" method with `ImageContainer`, you have to also implement a "basic" one:

```swift
struct CustomProcessor: ImageProcessing {
    func process(_ image: PlatformImage) -> PlatformImage? {
        // What do you do here, especially if you use something from the container or context?
    }

    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
        container.map { $0.processed.byAddingRoundedCorners(radius: radius, border: border) }
    }

    //  ...
}
```

> I'm not sure this is worth a breaking change. Reducing an API surface is almost always good. There will have to be a breaking change regardless because I'm also adding `throw` conformance.