### PR TITLE
Throwing Image Processing

### DIFF
--- a/Documentation/Migrations/Nuke 11 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 11 Migration Guide.md
@@ -26,7 +26,7 @@ sturct CustomImageProcessor: ImageProcessing {
 ```swift
 // After (Nuke 11)
 sturct CustomImageProcessor: ImageProcessing {
-    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+    func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
         container.map { $0.drawInCircle() }
     }
 }

--- a/Documentation/Migrations/Nuke 11 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 11 Migration Guide.md
@@ -16,7 +16,7 @@ If you have custom image processors that implement `ImageProcessing` protocol us
 
 ```swift
 // Before (Nuke 10)
-sturct CustomImageProcessor: ImageProcessing {
+struct CustomImageProcessor: ImageProcessing {
     func process(_ image: PlatformImage) -> PlatformImage? {
         image.drawInCircle()
     }
@@ -25,7 +25,7 @@ sturct CustomImageProcessor: ImageProcessing {
 
 ```swift
 // After (Nuke 11)
-sturct CustomImageProcessor: ImageProcessing {
+struct CustomImageProcessor: ImageProcessing {
     func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
         container.map { $0.drawInCircle() }
     }

--- a/Sources/Core/ImagePipeline.swift
+++ b/Sources/Core/ImagePipeline.swift
@@ -440,7 +440,7 @@ public final class ImagePipeline {
         }
     }
 
-    func makeTaskProcessImage(key: ImageProcessingKey, process: @escaping () -> ImageResponse?) -> AsyncTask<ImageResponse, Swift.Error>.Publisher {
+    func makeTaskProcessImage(key: ImageProcessingKey, process: @escaping () throws -> ImageResponse) -> AsyncTask<ImageResponse, Swift.Error>.Publisher {
         tasksProcessImage.publisherForKey(key) {
             OperationTask(self, configuration.imageProcessingQueue, process)
         }

--- a/Sources/Core/ImageResponse.swift
+++ b/Sources/Core/ImageResponse.swift
@@ -44,12 +44,9 @@ public struct ImageResponse {
         self.cacheType = cacheType
     }
 
-    func map(_ transformation: (ImageContainer) -> ImageContainer?) -> ImageResponse? {
-        return autoreleasepool {
-            guard let output = transformation(container) else {
-                return nil
-            }
-            return ImageResponse(container: output, urlResponse: urlResponse, cacheType: cacheType)
+    func map(_ transformation: (ImageContainer) throws -> ImageContainer) rethrows -> ImageResponse {
+        try autoreleasepool {
+            ImageResponse(container: try transformation(container), urlResponse: urlResponse, cacheType: cacheType)
         }
     }
 
@@ -116,11 +113,8 @@ public struct ImageContainer {
     }
 
     /// Modifies the wrapped image and keeps all of the rest of the metadata.
-    public func map(_ closure: (PlatformImage) -> PlatformImage?) -> ImageContainer? {
-        guard let image = closure(self.image) else {
-            return nil
-        }
-        return ImageContainer(image: image, type: type, isPreview: isPreview, data: data, userInfo: userInfo)
+    public func map(_ closure: (PlatformImage) throws -> PlatformImage) rethrows -> ImageContainer {
+        ImageContainer(image: try closure(image), type: type, isPreview: isPreview, data: data, userInfo: userInfo)
     }
 
     /// A key use in `userInfo`.

--- a/Sources/Core/Processing/ImageProcessing.swift
+++ b/Sources/Core/Processing/ImageProcessing.swift
@@ -26,7 +26,7 @@ public protocol ImageProcessing {
     /// basic `process(image:)` method.
     ///
     /// - note: Gets called a background queue managed by the pipeline.
-    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer?
+    func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer
 
     /// Returns a string that uniquely identifies the processor.
     ///

--- a/Sources/Core/Processing/ImageProcessors+Anonymous.swift
+++ b/Sources/Core/Processing/ImageProcessors+Anonymous.swift
@@ -8,15 +8,15 @@ extension ImageProcessors {
     /// Processed an image using a specified closure.
     public struct Anonymous: ImageProcessing, CustomStringConvertible {
         public let identifier: String
-        private let closure: (PlatformImage) -> PlatformImage?
+        private let closure: (PlatformImage) throws -> PlatformImage
 
-        public init(id: String, _ closure: @escaping (PlatformImage) -> PlatformImage?) {
+        public init(id: String, _ closure: @escaping (PlatformImage) throws -> PlatformImage) {
             self.identifier = id
             self.closure = closure
         }
 
-        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
-            container.map(closure)
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
+            try container.map(closure)
         }
 
         public var description: String {

--- a/Sources/Core/Processing/ImageProcessors+Circle.swift
+++ b/Sources/Core/Processing/ImageProcessors+Circle.swift
@@ -16,8 +16,8 @@ extension ImageProcessors {
             self.border = border
         }
 
-        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
-            container.map { $0.processed.byDrawingInCircle(border: border) }
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
+            try container.map { try $0.processed.byDrawingInCircle(border: border) }
         }
 
         public var identifier: String {

--- a/Sources/Core/Processing/ImageProcessors+Composition.swift
+++ b/Sources/Core/Processing/ImageProcessors+Composition.swift
@@ -18,10 +18,10 @@ extension ImageProcessors {
         /// Processes the given image by applying each processor in an order in
         /// which they were added. If one of the processors fails to produce
         /// an image the processing stops and `nil` is returned.
-        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
-            processors.reduce(container) { container, processor in
-                autoreleasepool {
-                    container.flatMap { processor.process($0, context: context) }
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
+            try processors.reduce(container) { container, processor in
+                try autoreleasepool {
+                    try processor.process(container, context: context)
                 }
             }
         }

--- a/Sources/Core/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Core/Processing/ImageProcessors+CoreImage.swift
@@ -59,7 +59,7 @@ extension ImageProcessors {
                 if let image = image.cgImage {
                     return CoreImage.CIImage(cgImage: image)
                 }
-                throw Error.failedToCreateInputCIImage(inputImage: image)
+                throw Error.inputImageIsEmpty(inputImage: image)
             }
             filter.setValue(try getCIImage(), forKey: kCIInputImageKey)
             guard let outputImage = filter.outputImage else {
@@ -77,7 +77,7 @@ extension ImageProcessors {
 
         public enum Error: Swift.Error, CustomStringConvertible {
             case failedToCreateFilter(name: String, parameters: [String: Any])
-            case failedToCreateInputCIImage(inputImage: PlatformImage)
+            case inputImageIsEmpty(inputImage: PlatformImage)
             case failedToApplyFilter(filter: CIFilter)
             case failedToCreateOutputCGImage(image: CIImage)
 
@@ -85,7 +85,7 @@ extension ImageProcessors {
                 switch self {
                 case let .failedToCreateFilter(name, parameters):
                     return "Failed to create filter named \(name) with parameters: \(parameters)"
-                case let .failedToCreateInputCIImage(inputImage):
+                case let .inputImageIsEmpty(inputImage):
                     return "Failed to create input CIImage for \(inputImage)"
                 case let .failedToApplyFilter(filter):
                     return "Failed to apply filter: \(filter.name)"

--- a/Sources/Core/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Core/Processing/ImageProcessors+CoreImage.swift
@@ -21,8 +21,8 @@ extension ImageProcessors {
     /// - [Core Image Programming Guide](https://developer.apple.com/library/ios/documentation/GraphicsImaging/Conceptual/CoreImaging/ci_intro/ci_intro.html)
     /// - [Core Image Filter Reference](https://developer.apple.com/library/prerelease/ios/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html)
     public struct CoreImageFilter: ImageProcessing, CustomStringConvertible {
-        private let name: String
-        private let parameters: [String: Any]
+        public let name: String
+        public let parameters: [String: Any]
         public let identifier: String
 
         /// - parameter identifier: Uniquely identifies the processor.
@@ -38,9 +38,11 @@ extension ImageProcessors {
             self.identifier = "com.github.kean/nuke/core_image?name=\(name))"
         }
 
-        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
-            let filter = CIFilter(name: name, parameters: parameters)
-            return container.map { CoreImageFilter.apply(filter: filter, to: $0) }
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
+            guard let filter = CIFilter(name: name, parameters: parameters) else {
+                throw Error.failedToCreateFilter(name: name, parameters: parameters)
+            }
+            return try container.map { try CoreImageFilter.apply(filter: filter, to: $0) }
         }
 
         // MARK: - Apply Filter
@@ -49,37 +51,48 @@ extension ImageProcessors {
         /// has `.priorityRequestLow` option set to `true`.
         public static var context = CIContext(options: [.priorityRequestLow: true])
 
-        public static func apply(filter: CIFilter?, to image: PlatformImage) -> PlatformImage? {
-            guard let filter = filter else {
-                return nil
-            }
-            return applyFilter(to: image) {
-                filter.setValue($0, forKey: kCIInputImageKey)
-                return filter.outputImage
-            }
-        }
-
-        static func applyFilter(to image: PlatformImage, context: CIContext = context, closure: (CoreImage.CIImage) -> CoreImage.CIImage?) -> PlatformImage? {
-            let ciImage: CoreImage.CIImage? = {
+        public static func apply(filter: CIFilter, to image: PlatformImage) throws -> PlatformImage {
+            func getCIImage() throws -> CoreImage.CIImage {
                 if let image = image.ciImage {
                     return image
                 }
                 if let image = image.cgImage {
                     return CoreImage.CIImage(cgImage: image)
                 }
-                return nil
-            }()
-            guard let inputImage = ciImage, let outputImage = closure(inputImage) else {
-                return nil
+                throw Error.failedToCreateInputCIImage(inputImage: image)
+            }
+            filter.setValue(try getCIImage(), forKey: kCIInputImageKey)
+            guard let outputImage = filter.outputImage else {
+                throw Error.failedToApplyFilter(filter: filter)
             }
             guard let imageRef = context.createCGImage(outputImage, from: outputImage.extent) else {
-                return nil
+                throw Error.failedToCreateOutputCGImage(image: outputImage)
             }
             return PlatformImage.make(cgImage: imageRef, source: image)
         }
 
         public var description: String {
             "CoreImageFilter(name: \(name), parameters: \(parameters))"
+        }
+
+        public enum Error: Swift.Error, CustomStringConvertible {
+            case failedToCreateFilter(name: String, parameters: [String: Any])
+            case failedToCreateInputCIImage(inputImage: PlatformImage)
+            case failedToApplyFilter(filter: CIFilter)
+            case failedToCreateOutputCGImage(image: CIImage)
+
+            public var description: String {
+                switch self {
+                case let .failedToCreateFilter(name, parameters):
+                    return "Failed to create filter named \(name) with parameters: \(parameters)"
+                case let .failedToCreateInputCIImage(inputImage):
+                    return "Failed to create input CIImage for \(inputImage)"
+                case let .failedToApplyFilter(filter):
+                    return "Failed to apply filter: \(filter.name)"
+                case let .failedToCreateOutputCGImage(image):
+                    return "Failed to create output image for extent: \(image.extent) from \(image)"
+                }
+            }
         }
     }
 }

--- a/Sources/Core/Processing/ImageProcessors+GaussianBlur.swift
+++ b/Sources/Core/Processing/ImageProcessors+GaussianBlur.swift
@@ -20,9 +20,11 @@ extension ImageProcessors {
         }
 
         /// Applies `CIGaussianBlur` filter to the image.
-        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
-            let filter = CIFilter(name: "CIGaussianBlur", parameters: ["inputRadius": radius])
-            return container.map { CoreImageFilter.apply(filter: filter, to: $0) }
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
+            guard let filter = CIFilter(name: "CIGaussianBlur", parameters: ["inputRadius": radius]) else {
+                throw ImageProcessors.CoreImageFilter.Error.failedToCreateFilter(name: "CIGaussianBlur", parameters: ["inputRadius": radius])
+            }
+            return try container.map { try CoreImageFilter.apply(filter: filter, to: $0) }
         }
 
         public var identifier: String {

--- a/Sources/Core/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Core/Processing/ImageProcessors+Resize.swift
@@ -64,11 +64,11 @@ extension ImageProcessors {
             self.init(size: CGSize(width: 9999, height: height), unit: unit, contentMode: .aspectFit, crop: false, upscale: upscale)
         }
 
-        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
             if crop && contentMode == .aspectFill {
-                return container.map { $0.processed.byResizingAndCropping(to: size.cgSize) }
+                return try container.map { try $0.processed.byResizingAndCropping(to: size.cgSize) }
             }
-            return container.map { $0.processed.byResizing(to: size.cgSize, contentMode: contentMode, upscale: upscale) }
+            return try container.map { try $0.processed.byResizing(to: size.cgSize, contentMode: contentMode, upscale: upscale) }
         }
 
         public var identifier: String {

--- a/Sources/Core/Processing/ImageProcessors+RoundedCorners.swift
+++ b/Sources/Core/Processing/ImageProcessors+RoundedCorners.swift
@@ -24,8 +24,8 @@ extension ImageProcessors {
             self.border = border
         }
 
-        public func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
-            container.map { $0.processed.byAddingRoundedCorners(radius: radius, border: border) }
+        public func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
+            try container.map { try $0.processed.byAddingRoundedCorners(radius: radius, border: border) }
         }
 
         public var identifier: String {

--- a/Sources/Core/Processing/ImageProcessors.swift
+++ b/Sources/Core/Processing/ImageProcessors.swift
@@ -105,7 +105,7 @@ extension ImageProcessing where Self == ImageProcessors.GaussianBlur {
 
 extension ImageProcessing where Self == ImageProcessors.Anonymous {
     /// Processed an image using a specified closure.
-    public static func process(id: String, _ closure: @escaping (PlatformImage) -> PlatformImage?) -> ImageProcessors.Anonymous {
+    public static func process(id: String, _ closure: @escaping (PlatformImage) throws -> PlatformImage) -> ImageProcessors.Anonymous {
         ImageProcessors.Anonymous(id: id, closure)
     }
 }

--- a/Sources/Core/Tasks/OperationTask.swift
+++ b/Sources/Core/Tasks/OperationTask.swift
@@ -8,9 +8,9 @@ import Foundation
 final class OperationTask<T>: AsyncTask<T, Swift.Error> {
     private let pipeline: ImagePipeline
     private let queue: OperationQueue
-    private let process: () -> T?
+    private let process: () throws -> T
 
-    init(_ pipeline: ImagePipeline, _ queue: OperationQueue, _ process: @escaping () -> T?) {
+    init(_ pipeline: ImagePipeline, _ queue: OperationQueue, _ process: @escaping () throws -> T) {
         self.pipeline = pipeline
         self.queue = queue
         self.process = process
@@ -19,13 +19,14 @@ final class OperationTask<T>: AsyncTask<T, Swift.Error> {
     override func start() {
         operation = queue.add { [weak self] in
             guard let self = self else { return }
-            let output = self.process()
+            let result = Result(catching: { try self.process() })
             self.pipeline.queue.async {
-                guard let output = output else {
-                    self.send(error: Error())
-                    return
+                switch result {
+                case .success(let value):
+                    self.send(value: value, isCompleted: true)
+                case .failure(let error):
+                    self.send(error: error)
                 }
-                self.send(value: output, isCompleted: true)
             }
         }
     }

--- a/Sources/Core/Tasks/TaskLoadImage.swift
+++ b/Sources/Core/Tasks/TaskLoadImage.swift
@@ -158,8 +158,8 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
         let key = ImageProcessingKey(image: response, processor: processor)
         dependency2 = pipeline.makeTaskProcessImage(key: key, process: { [request] in
             let context = ImageProcessingContext(request: request, response: response, isFinal: isCompleted)
-            return signpost(log, "ProcessImage", isCompleted ? "FinalImage" : "ProgressiveImage") {
-                response.map { processor.process($0, context: context) }
+            return try signpost(log, "ProcessImage", isCompleted ? "FinalImage" : "ProgressiveImage") {
+                try response.map { try processor.process($0, context: context) }
             }
         }).subscribe(priority: priority) { [weak self] event in
             guard let self = self else { return }

--- a/Sources/Internal/Log.swift
+++ b/Sources/Internal/Log.swift
@@ -29,12 +29,12 @@ func signpost<T>(_ log: OSLog, _ name: StaticString, _ work: () -> T) -> T {
     return result
 }
 
-func signpost<T>(_ log: OSLog, _ name: StaticString, _ message: @autoclosure () -> String, _ work: () -> T) -> T {
-    guard ImagePipeline.Configuration.isSignpostLoggingEnabled else { return work() }
+func signpost<T>(_ log: OSLog, _ name: StaticString, _ message: @autoclosure () -> String, _ work: () throws -> T) rethrows -> T {
+    guard ImagePipeline.Configuration.isSignpostLoggingEnabled else { return try work() }
 
     let signpostId = OSSignpostID(log: log)
     os_signpost(.begin, log: log, name: name, signpostID: signpostId, "%{public}s", message())
-    let result = work()
+    let result = try work()
     os_signpost(.end, log: log, name: name, signpostID: signpostId)
     return result
 }

--- a/Tests/ImageEncoderTests.swift
+++ b/Tests/ImageEncoderTests.swift
@@ -65,8 +65,7 @@ final class ImageEncoderTests: XCTestCase {
 
     func testEncodeCoreImageBackedImage() throws {
         // Given
-        let image = ImageProcessors.GaussianBlur()
-            .process(Test.image)!
+        let image = try ImageProcessors.GaussianBlur().process(Test.image)
         let encoder = ImageEncoders.Default()
 
         // When

--- a/Tests/ImageProcessorsTests/AnonymousTests.swift
+++ b/Tests/ImageProcessorsTests/AnonymousTests.swift
@@ -33,7 +33,7 @@ class ImageProcessorsAnonymousTests: XCTestCase {
         )
     }
 
-    func testAnonymousProcessorIsApplied() {
+    func testAnonymousProcessorIsApplied() throws {
         // Given
         let processor = ImageProcessors.Anonymous(id: "1") {
             $0.nk_test_processorIDs = ["1"]
@@ -41,9 +41,9 @@ class ImageProcessorsAnonymousTests: XCTestCase {
         }
 
         // When
-        let image = processor.process(Test.image)
+        let image = try processor.process(Test.image)
 
         // Then
-        XCTAssertEqual(image?.nk_test_processorIDs ?? [], ["1"])
+        XCTAssertEqual(image.nk_test_processorIDs ?? [], ["1"])
     }
 }

--- a/Tests/ImageProcessorsTests/CompositionTests.swift
+++ b/Tests/ImageProcessorsTests/CompositionTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class ImageProcessorsCompositionTest: XCTestCase {
 
-    func testAppliesAllProcessors() {
+    func testAppliesAllProcessors() throws {
         // GIVEN
         let processor = ImageProcessors.Composition([
             MockImageProcessor(id: "1"),
@@ -21,10 +21,10 @@ class ImageProcessorsCompositionTest: XCTestCase {
         )
 
         // WHEN
-        let image = processor.process(Test.image)
+        let image = try processor.process(Test.image)
 
         // THEN
-        XCTAssertEqual(image?.nk_test_processorIDs, ["1", "2"])
+        XCTAssertEqual(image.nk_test_processorIDs, ["1", "2"])
     }
 
     func testAppliesAllProcessorsWithContext() throws {
@@ -36,11 +36,10 @@ class ImageProcessorsCompositionTest: XCTestCase {
 
         // WHEN
         let context = ImageProcessingContext(request: Test.request, response: ImageResponse(container: Test.container), isFinal: true)
-        let output = processor.process(Test.container, context: context)
+        let output = try processor.process(Test.container, context: context)
 
         // THEN
-        let image = try XCTUnwrap(output?.image)
-        XCTAssertEqual(image.nk_test_processorIDs, ["1", "2"])
+        XCTAssertEqual(output.image.nk_test_processorIDs, ["1", "2"])
     }
 
     func testIdenfitiers() {

--- a/Tests/ImageProcessorsTests/CoreImageFilterTests.swift
+++ b/Tests/ImageProcessorsTests/CoreImageFilterTests.swift
@@ -48,7 +48,18 @@ class ImageProcessorsCoreImageFilterTests: XCTestCase {
         let processor = ImageProcessors.CoreImageFilter(name: "yo", parameters: ["inputIntensity": 0.5], identifier: "CISepiaTone-75")
 
         // THEN
-        XCTAssertNil(processor.process(input))
+        XCTAssertThrowsError(try processor.process(input)) { error in
+            guard let error = error as? ImageProcessors.CoreImageFilter.Error else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            switch error {
+            case let .failedToCreateFilter(name, parameters):
+                XCTAssertEqual(name, "yo")
+                XCTAssertNotNil(parameters["inputIntensity"])
+            default:
+                XCTFail("Unexpected error type: \(error)")
+            }
+        }
     }
 
     #if os(iOS) || os(tvOS)
@@ -71,7 +82,17 @@ class ImageProcessorsCoreImageFilterTests: XCTestCase {
         let processor = ImageProcessors.CoreImageFilter(name: "CISepiaTone", parameters: ["inputIntensity": 0.5], identifier: "CISepiaTone-75")
 
         // THEN
-        XCTAssertNil(processor.process(input))
+        XCTAssertThrowsError(try processor.process(input)) { error in
+            guard let error = error as? ImageProcessors.CoreImageFilter.Error else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            switch error {
+            case .inputImageIsEmpty:
+                break // Do nothing
+            default:
+                XCTFail("Unexpected error type: \(error)")
+            }
+        }
     }
 
     func testDescription() {

--- a/Tests/ImageProcessorsTests/GaussianBlurTests.swift
+++ b/Tests/ImageProcessorsTests/GaussianBlurTests.swift
@@ -12,41 +12,35 @@ import XCTest
 #if os(iOS) || os(tvOS) || os(macOS)
 
 class ImageProcessorsGaussianBlurTest: XCTestCase {
-    func testApplyBlur() {
+    func testApplyBlur() throws {
         // Given
         let image = Test.image
         let processor = ImageProcessors.GaussianBlur()
         XCTAssertFalse(processor.description.isEmpty) // Bumping that test coverage
 
         // When
-        let processed = processor.process(image)
-
-        // Then
-        XCTAssertNotNil(processed)
+        try processor.process(image)
     }
 
-    func testApplyBlurProducesImagesBackedByCoreGraphics() {
+    func testApplyBlurProducesImagesBackedByCoreGraphics() throws {
         // Given
         let image = Test.image
         let processor = ImageProcessors.GaussianBlur()
 
         // When
-        let processed = processor.process(image)
-
-        // Then
-        XCTAssertNotNil(processed?.cgImage)
+        try processor.process(image)
     }
 
-    func testApplyBlurProducesTransparentImages() {
+    func testApplyBlurProducesTransparentImages() throws {
         // Given
         let image = Test.image
         let processor = ImageProcessors.GaussianBlur()
 
         // When
-        let processed = processor.process(image)
+        let processed = try processor.process(image)
 
         // Then
-        XCTAssertEqual(processed?.cgImage?.isOpaque, false)
+        XCTAssertEqual(processed.cgImage?.isOpaque, false)
     }
 
     func testImagesWithSameRadiusHasSameIdentifiers() {

--- a/Tests/MockImageProcessor.swift
+++ b/Tests/MockImageProcessor.swift
@@ -29,7 +29,7 @@ class MockImageProcessor: ImageProcessing, CustomStringConvertible {
         self.identifier = id
     }
 
-    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+    func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
         container.map { image in
             var processorIDs: [String] = image.nk_test_processorIDs
 #if os(macOS)
@@ -54,7 +54,7 @@ class MockImageProcessor: ImageProcessing, CustomStringConvertible {
 // MARK: - MockFailingProcessor
 
 class MockFailingProcessor: ImageProcessing {
-    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+    func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
         nil
     }
 
@@ -68,7 +68,7 @@ class MockFailingProcessor: ImageProcessing {
 class MockEmptyImageProcessor: ImageProcessing {
     let identifier = "MockEmptyImageProcessor"
 
-    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+    func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
         container
     }
 
@@ -87,7 +87,7 @@ final class MockProcessorFactory {
     private final class Processor: MockImageProcessor {
         var factory: MockProcessorFactory!
 
-        override func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer? {
+        override func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
             factory.lock.lock()
             factory.numberOfProcessorsApplied += 1
             factory.lock.unlock()

--- a/Tests/MockImageProcessor.swift
+++ b/Tests/MockImageProcessor.swift
@@ -55,12 +55,16 @@ class MockImageProcessor: ImageProcessing, CustomStringConvertible {
 
 class MockFailingProcessor: ImageProcessing {
     func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer {
-        nil
+        throw MockError(description: "MockFailingProcessor failed")
     }
 
     var identifier: String {
         "MockFailingProcessor"
     }
+}
+
+struct MockError: Error {
+    let description: String
 }
 
 // MARK: - MockEmptyImageProcessor
@@ -91,7 +95,7 @@ final class MockProcessorFactory {
             factory.lock.lock()
             factory.numberOfProcessorsApplied += 1
             factory.lock.unlock()
-            return super.process(container, context: context)
+            return try super.process(container, context: context)
         }
     }
 

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -60,9 +60,9 @@ extension ImagePipeline {
 }
 
 extension ImageProcessing {
-    func process(_ image: PlatformImage) -> PlatformImage? {
+    func process(_ image: PlatformImage) throws -> PlatformImage {
         let context = ImageProcessingContext(request: Test.request, response: Test.response, isFinal: true)
-        return process(ImageContainer(image: image), context: context)?.image
+        return (try process(ImageContainer(image: image), context: context)).image
     }
 }
 


### PR DESCRIPTION
`ImageProcessing` protocol is now throwing:

```swift
public protocol ImageProcessing {
    // Before (Nuke 10)
    func process(_ container: ImageContainer, context: ImageProcessingContext) -> ImageContainer?

    // After (Nuke 11)
    func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer
}
```

With this change you can now capture and easily analyze processing errors.

There are a couple of other related changes to the public API:

- `CoreImageFilter.apply(filter:to:)` is now throwing an returns non-optional value.
- Make `CoreImageFilter` properties `name` and `parameters` public.
- Add `ImageDrawingError`
