### PR TITLE
Skip data loading queue

### DIFF
--- a/Sources/Core/ImageRequest.swift
+++ b/Sources/Core/ImageRequest.swift
@@ -266,6 +266,12 @@ public struct ImageRequest: CustomStringConvertible {
 
         /// Use existing cache data and fail if no cached data is available.
         public static let returnCacheDataDontLoad = Options(rawValue: 1 << 4)
+
+        /// Perform data loading immediatelly, ignoring `dataLoadingQueue`.
+        ///
+        /// - warning: If there is an outstanding task for loading the same
+        /// resource but without this option, a new task will be created.
+        public static let skipDataLoadingQueue = Options(rawValue: 1 << 5)
     }
 
     /// Thumbnail options.

--- a/Sources/Core/ImageRequest.swift
+++ b/Sources/Core/ImageRequest.swift
@@ -267,7 +267,7 @@ public struct ImageRequest: CustomStringConvertible {
         /// Use existing cache data and fail if no cached data is available.
         public static let returnCacheDataDontLoad = Options(rawValue: 1 << 4)
 
-        /// Perform data loading immediatelly, ignoring `dataLoadingQueue`.
+        /// Perform data loading immediately, ignoring `dataLoadingQueue`.
         ///
         /// - warning: If there is an outstanding task for loading the same
         /// resource but without this option, a new task will be created.

--- a/Sources/Core/Pipeline/ImagePipelineConfiguration.swift
+++ b/Sources/Core/Pipeline/ImagePipelineConfiguration.swift
@@ -141,14 +141,14 @@ extension ImagePipeline {
         /// and cancelled at a high rate (e.g. scrolling through a collection view).
         public var isRateLimiterEnabled = true
 
-        /// `false` by default. If `true` the pipeline will try to produce a new
+        /// `true` by default. If `true` the pipeline will try to produce a new
         /// image each time it receives a new portion of data from data loader.
         /// The decoder used by the image loading session determines whether
         /// to produce a partial image or not. The default image decoder
         /// (`ImageDecoder`) supports progressive JPEG decoding.
         public var isProgressiveDecodingEnabled = true
 
-        /// `false` by default. If `true`, the pipeline will store all of the
+        /// `true` by default. If `true`, the pipeline will store all of the
         /// progressively generated previews in the memory cache. All of the
         /// previews have `isPreview` flag set to `true`.
         public var isStoringPreviewsInMemoryCache = true
@@ -158,6 +158,10 @@ extension ImagePipeline {
         /// resume where it left off. Supports both validators (`ETag`,
         /// `Last-Modified`). Resumable downloads are enabled by default.
         public var isResumableDataEnabled = true
+
+        /// `false` by default. Set it to false to perform all data loading
+        /// operations immediatelly, ignoring `dataLoadingQueue`.
+        public var isDataLoadingQueueSkipped = false
 
         // MARK: - Options (Shared)
 

--- a/Sources/Core/Pipeline/ImagePipelineConfiguration.swift
+++ b/Sources/Core/Pipeline/ImagePipelineConfiguration.swift
@@ -160,7 +160,7 @@ extension ImagePipeline {
         public var isResumableDataEnabled = true
 
         /// `false` by default. Set it to false to perform all data loading
-        /// operations immediatelly, ignoring `dataLoadingQueue`.
+        /// operations immediately, ignoring `dataLoadingQueue`.
         public var isDataLoadingQueueSkipped = false
 
         // MARK: - Options (Shared)

--- a/Sources/Core/Tasks/TaskFetchOriginalImageData.swift
+++ b/Sources/Core/Tasks/TaskFetchOriginalImageData.swift
@@ -34,14 +34,18 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
     }
 
     private func loadData(urlRequest: URLRequest) {
-        // Wrap data request in an operation to limit the maximum number of
-        // concurrent data tasks.
-        operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
-            guard let self = self else {
-                return finish()
-            }
-            self.async {
-                self.loadData(urlRequest: urlRequest, finish: finish)
+        if pipeline.configuration.isDataLoadingQueueSkipped {
+            loadData(urlRequest: urlRequest, finish: { /* do nothing */ })
+        } else {
+            // Wrap data request in an operation to limit the maximum number of
+            // concurrent data tasks.
+            operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
+                guard let self = self else {
+                    return finish()
+                }
+                self.async {
+                    self.loadData(urlRequest: urlRequest, finish: finish)
+                }
             }
         }
     }

--- a/Sources/Core/Tasks/TaskFetchOriginalImageData.swift
+++ b/Sources/Core/Tasks/TaskFetchOriginalImageData.swift
@@ -34,7 +34,7 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
     }
 
     private func loadData(urlRequest: URLRequest) {
-        if pipeline.configuration.isDataLoadingQueueSkipped {
+        if pipeline.configuration.isDataLoadingQueueSkipped || request.options.contains(.skipDataLoadingQueue) {
             loadData(urlRequest: urlRequest, finish: { /* do nothing */ })
         } else {
             // Wrap data request in an operation to limit the maximum number of

--- a/Sources/Core/Tasks/TaskFetchWithPublisher.swift
+++ b/Sources/Core/Tasks/TaskFetchWithPublisher.swift
@@ -10,14 +10,18 @@ final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
     private lazy var data = Data()
 
     override func start() {
-        // Wrap data request in an operation to limit the maximum number of
-        // concurrent data tasks.
-        operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
-            guard let self = self else {
-                return finish()
-            }
-            self.async {
-                self.loadData(finish: finish)
+        if pipeline.configuration.isDataLoadingQueueSkipped {
+            loadData(finish: { /* do nothing */ })
+        } else {
+            // Wrap data request in an operation to limit the maximum number of
+            // concurrent data tasks.
+            operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
+                guard let self = self else {
+                    return finish()
+                }
+                self.async {
+                    self.loadData(finish: finish)
+                }
             }
         }
     }

--- a/Sources/Core/Tasks/TaskFetchWithPublisher.swift
+++ b/Sources/Core/Tasks/TaskFetchWithPublisher.swift
@@ -10,7 +10,7 @@ final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
     private lazy var data = Data()
 
     override func start() {
-        if pipeline.configuration.isDataLoadingQueueSkipped {
+        if pipeline.configuration.isDataLoadingQueueSkipped || request.options.contains(.skipDataLoadingQueue) {
             loadData(finish: { /* do nothing */ })
         } else {
             // Wrap data request in an operation to limit the maximum number of

--- a/Sources/Internal/Log.swift
+++ b/Sources/Internal/Log.swift
@@ -19,11 +19,16 @@ func signpost(_ log: OSLog, _ object: AnyObject, _ name: StaticString, _ type: O
     os_signpost(type, log: log, name: name, signpostID: signpostId, "%{public}s", message())
 }
 
-func signpost<T>(_ log: OSLog, _ name: StaticString, _ message: @autoclosure () -> String? = nil, _ work: () throws -> T) rethrows -> T {
+func signpost<T>(_ log: OSLog, _ name: StaticString, _ work: () throws -> T) rethrows -> T {
+    try signpost(log, name, "", work)
+}
+
+func signpost<T>(_ log: OSLog, _ name: StaticString, _ message: @autoclosure () -> String, _ work: () throws -> T) rethrows -> T {
     guard ImagePipeline.Configuration.isSignpostLoggingEnabled else { return try work() }
 
     let signpostId = OSSignpostID(log: log)
-    if let message = message() {
+    let message = message()
+    if !message.isEmpty {
         os_signpost(.begin, log: log, name: name, signpostID: signpostId, "%{public}s", message)
     } else {
         os_signpost(.begin, log: log, name: name, signpostID: signpostId)

--- a/Sources/Internal/Log.swift
+++ b/Sources/Internal/Log.swift
@@ -19,22 +19,15 @@ func signpost(_ log: OSLog, _ object: AnyObject, _ name: StaticString, _ type: O
     os_signpost(type, log: log, name: name, signpostID: signpostId, "%{public}s", message())
 }
 
-func signpost<T>(_ log: OSLog, _ name: StaticString, _ work: () throws -> T) rethrows -> T {
+func signpost<T>(_ log: OSLog, _ name: StaticString, _ message: @autoclosure () -> String? = nil, _ work: () throws -> T) rethrows -> T {
     guard ImagePipeline.Configuration.isSignpostLoggingEnabled else { return try work() }
 
     let signpostId = OSSignpostID(log: log)
-    os_signpost(.begin, log: log, name: name, signpostID: signpostId)
-    let result = try work()
-    os_signpost(.end, log: log, name: name, signpostID: signpostId)
-    return result
-}
-
-// TODO: Do we need this version?
-func signpost<T>(_ log: OSLog, _ name: StaticString, _ message: @autoclosure () -> String, _ work: () throws -> T) rethrows -> T {
-    guard ImagePipeline.Configuration.isSignpostLoggingEnabled else { return try work() }
-
-    let signpostId = OSSignpostID(log: log)
-    os_signpost(.begin, log: log, name: name, signpostID: signpostId, "%{public}s", message())
+    if let message = message() {
+        os_signpost(.begin, log: log, name: name, signpostID: signpostId, "%{public}s", message)
+    } else {
+        os_signpost(.begin, log: log, name: name, signpostID: signpostId)
+    }
     let result = try work()
     os_signpost(.end, log: log, name: name, signpostID: signpostId)
     return result

--- a/Tests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineTests.swift
@@ -579,7 +579,7 @@ class ImagePipelineTests: XCTestCase {
         XCTAssertNil(error.dataLoadingError)
     }
 
-    // MARK: Configuration
+    // MARK: Skip Data Loading Queue Option
 
     func testSkipDataLoadingQueueWithURL() throws {
         // Given
@@ -607,6 +607,34 @@ class ImagePipelineTests: XCTestCase {
         queue.isSuspended = true
 
         let request = ImageRequest(id: "a", data: Just(Test.data))
+
+        // Then image is still loaded
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+    }
+
+    func testSkipDataLoadingQueuePerRequestWithURL() throws {
+        // Given
+        let queue = pipeline.configuration.dataLoadingQueue
+        queue.isSuspended = true
+
+        let request = ImageRequest(url: Test.url, options: [
+            .skipDataLoadingQueue
+        ])
+
+        // Then image is still loaded
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+    }
+
+    func testSkipDataLoadingQueuePerRequestWithPublisher() throws {
+        // Given
+        let queue = pipeline.configuration.dataLoadingQueue
+        queue.isSuspended = true
+
+        let request = ImageRequest(id: "a", data: Just(Test.data), options: [
+            .skipDataLoadingQueue
+        ])
 
         // Then image is still loaded
         expect(pipeline).toLoadImage(with: request)

--- a/Tests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelineTests.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2022 Alexander Grebenyuk (github.com/kean).
 
 import XCTest
+import Combine
 @testable import Nuke
 
 class ImagePipelineTests: XCTestCase {
@@ -578,8 +579,42 @@ class ImagePipelineTests: XCTestCase {
         XCTAssertNil(error.dataLoadingError)
     }
 
+    // MARK: Configuration
+
+    func testSkipDataLoadingQueueWithURL() throws {
+        // Given
+        pipeline = pipeline.reconfigured {
+            $0.isDataLoadingQueueSkipped = true
+        }
+
+        let queue = pipeline.configuration.dataLoadingQueue
+        queue.isSuspended = true
+
+        let request = ImageRequest(url: Test.url)
+
+        // Then image is still loaded
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+    }
+
+    func testSkipDataLoadingQueueWithPublisher() throws {
+        // Given
+        pipeline = pipeline.reconfigured {
+            $0.isDataLoadingQueueSkipped = true
+        }
+
+        let queue = pipeline.configuration.dataLoadingQueue
+        queue.isSuspended = true
+
+        let request = ImageRequest(id: "a", data: Just(Test.data))
+
+        // Then image is still loaded
+        expect(pipeline).toLoadImage(with: request)
+        wait()
+    }
+
     // MARK: Misc
-    
+
     func testLoadWithInvalidURL() throws {
         // GIVEN
         pipeline = pipeline.reconfigured {


### PR DESCRIPTION
Add the following option to ignore data loading queue:

```swift
// For entire pipeline
extension ImagePipeline.Configuration {
        /// `false` by default. Set it to false to perform all data loading
        /// operations immediatelly, ignoring `dataLoadingQueue`.
        public var isDataLoadingQueueSkipped = false
}

// For individual requests
extension ImageRequest.Options {
        /// Perform data loading immediatelly, ignoring `dataLoadingQueue`.
        ///
        /// - warning: If there is an outstanding task for loading the same
        /// resource but without this option, a new task will be created.
        public static let skipDataLoadingQueue = Options(rawValue: 1 << 5)
}
```

Use-case:

- Using a data loader or data publisher that limits concurrent tasks in a different way or doesn't require it
- Elevating the priority of critical tasks by ignoring all outstanding operations in `dataLoadingQueue`. Alternative: using a dedicated pipeline for critical requests.