### PR TITLE
Enable custom disk cache for data publishers

### DIFF
--- a/Sources/Core/Tasks/TaskFetchDecodedImage.swift
+++ b/Sources/Core/Tasks/TaskFetchDecodedImage.swift
@@ -28,15 +28,6 @@ final class TaskFetchDecodedImage: ImagePipelineTask<ImageResponse> {
             operation?.cancel() // Cancel any potential pending progressive decoding tasks
         }
 
-        // Sanity check
-        guard !data.isEmpty else {
-            // TODO: TaskLoadData does it. No need to check this twice.
-            if isCompleted {
-                send(error: .dataIsEmpty)
-            }
-            return
-        }
-
         let context = ImageDecodingContext(request: request, data: data, isCompleted: isCompleted, urlResponse: urlResponse)
         guard let decoder = getDecoder(for: context) else {
             if isCompleted {

--- a/Sources/Core/Tasks/TaskFetchWithPublisher.swift
+++ b/Sources/Core/Tasks/TaskFetchWithPublisher.swift
@@ -57,7 +57,7 @@ final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
         switch result {
         case .finished:
             guard !data.isEmpty else {
-                send(error: .dataLoadingFailed(URLError(.resourceUnavailable, userInfo: [:])))
+                send(error: .dataIsEmpty)
                 return
             }
             storeDataInCacheIfNeeded(data)

--- a/Tests/ImagePipelineTests/ImagePipelinePublisherTests.swift
+++ b/Tests/ImagePipelineTests/ImagePipelinePublisherTests.swift
@@ -77,6 +77,19 @@ class ImagePipelinePublisherTests: XCTestCase {
         wait()
     }
 
+    func testDataIsStoredInDataCache() {
+        // GIVEN
+        let request = ImageRequest(id: "a", data: Just(Test.data))
+
+        // WHEN
+        expect(pipeline).toLoadImage(with: request)
+
+        // THEN
+        wait { _ in
+            XCTAssertFalse(self.dataCache.store.isEmpty)
+        }
+    }
+
     // MARK: ImageRequestConvertible
 
     func testInitWithString() {


### PR DESCRIPTION
Enable disk cache (`DataCaching`) for data publishers:

```swift
let request = ImageRequest(id: "a", data: Just(Test.data))
```

There are a few options to disable it:

- Create a pipeline with no disk cache (default behavior)
- Implement `ImagePipelineDelegate` method `dataCache(for:pipeline:)` or `willCache(data:image:for:pipeline:)` and disable cache on per-request basis
- Pass `.disableDiskCacheWrites` option to requests backed by data publishers