### PR TITLE
Progressive Decoding with AsyncThrowingStream

### DIFF
--- a/Sources/Nuke/Core/ImageTask.swift
+++ b/Sources/Nuke/Core/ImageTask.swift
@@ -105,7 +105,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
 }
 
 public final class AsyncImageTask: @unchecked Sendable {
-    weak var task: ImageTask?
+    var task: ImageTask?
 
     public func setPriority(_ priority: ImageRequest.Priority) {
         task?.setPriority(priority)

--- a/Sources/Nuke/Core/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Core/Pipeline/ImagePipeline.swift
@@ -189,7 +189,7 @@ public final class ImagePipeline: @unchecked Sendable {
     @discardableResult
     public func image(
         for request: any ImageRequestConvertible,
-        progress: ((_ response: ImageResponse?, _ completed: Int64, _ total: Int64) -> Void)? = nil,
+        progress: ((_ completed: Int64, _ total: Int64) -> Void)? = nil,
         task: AsyncImageTask = AsyncImageTask()
     ) async throws -> ImageResponse {
         return try await withTaskCancellationHandler(handler: {
@@ -200,7 +200,9 @@ public final class ImagePipeline: @unchecked Sendable {
                 // completion) are called exactly once. `onCancel` is a new addition
                 // just for Async/Await. Ideally, the completion should be called on
                 // cancellation instead, but that ship has sailed. Maybe in Nuke 11.
-                task.task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: progress, onCancel: {
+                task.task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: {
+                    if $0 == nil { progress?($1, $2) }
+                }, onCancel: {
                     continuation.resume(throwing: CancellationError())
                 }, completion: {
                     continuation.resume(with: $0)

--- a/Sources/Nuke/Core/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Core/Pipeline/ImagePipeline.swift
@@ -164,9 +164,12 @@ public final class ImagePipeline: @unchecked Sendable {
         task: AsyncImageTask = AsyncImageTask()
     ) -> AsyncThrowingStream<ImageResponse, Swift.Error> {
         AsyncThrowingStream { continuation in
-            let task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: { response, _, _ in
-                guard let response = response else { return }
-                continuation.yield(response)
+            let task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: { response, completed, total in
+                if let response = response {
+                    continuation.yield(response)
+                } else {
+                    progress?(completed, total)
+                }
             }, completion: {
                 switch $0 {
                 case .success(let response):

--- a/Sources/Nuke/Core/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Core/Pipeline/ImagePipeline.swift
@@ -103,7 +103,95 @@ public final class ImagePipeline: @unchecked Sendable {
         }
     }
 
-    // MARK: - Loading Images
+    // MARK: - Loading Images (Async/Await)
+
+    /// Loads an image for the given request.
+    ///
+    /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
+    ///
+    /// - parameter request: An image request.
+    ///
+    @discardableResult
+    public func image(
+        for request: any ImageRequestConvertible,
+        progress: ((_ completed: Int64, _ total: Int64) -> Void)? = nil,
+        task: AsyncImageTask = AsyncImageTask()
+    ) async throws -> ImageResponse {
+        return try await withTaskCancellationHandler(handler: {
+            task.task?.cancel()
+        }, operation: {
+            try await withUnsafeThrowingContinuation { continuation in
+                // The pipeline guarantees that the callbacks (either onCancel or
+                // completion) are called exactly once. `onCancel` is a new addition
+                // just for Async/Await. Ideally, the completion should be called on
+                // cancellation instead, but that ship has sailed. Maybe in Nuke 11.
+                task.task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: {
+                    if $0 == nil { progress?($1, $2) }
+                }, onCancel: {
+                    continuation.resume(throwing: CancellationError())
+                }, completion: {
+                    continuation.resume(with: $0)
+                })
+            }
+        })
+    }
+
+    /// Loads an image for the given request, producing progressive images as
+    /// more data becomes available.
+    public func images(
+        for request: any ImageRequestConvertible,
+        progress: ((_ completed: Int64, _ total: Int64) -> Void)? = nil,
+        task: AsyncImageTask = AsyncImageTask()
+    ) -> AsyncThrowingStream<ImageResponse, Swift.Error> {
+        AsyncThrowingStream { continuation in
+            let task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: { response, completed, total in
+                if let response = response {
+                    continuation.yield(response)
+                } else {
+                    progress?(completed, total)
+                }
+            }, completion: {
+                switch $0 {
+                case .success(let response):
+                    continuation.yield(response)
+                    continuation.finish()
+                case .failure(let error):
+                    continuation.finish(throwing: error)
+                }
+            })
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Loads an image for the given request.
+    ///
+    /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
+    ///
+    /// - parameter request: An image request.
+    @discardableResult
+    public func data(
+        for request: any ImageRequestConvertible,
+        progress: (@Sendable (_ completed: Int64, _ total: Int64) -> Void)? = nil,
+        task: AsyncImageTask = AsyncImageTask()
+    ) async throws -> (Data, URLResponse?) {
+        return try await withTaskCancellationHandler(handler: {
+            task.task?.cancel()
+        }, operation: {
+            try await withUnsafeThrowingContinuation { continuation in
+                // The pipeline guarantees that the callbacks (either onCancel or
+                // completion) are called exactly once. `onCancel` is a new addition
+                // just for Async/Await. Ideally, the completion should be called on
+                // cancellation instead, but that ship has sailed. Maybe in Nuke 11.
+                task.task = loadData(with: request.asImageRequest(), isConfined: false, queue: nil, progress: progress, onCancel: {
+                    continuation.resume(throwing: CancellationError())
+                }, completion: {
+                    continuation.resume(with: $0)
+                })
+            }
+        })
+    }
+
+    // MARK: - Loading Images (Closures)
 
     /// Loads an image for the given request.
     @discardableResult public func loadImage(
@@ -154,64 +242,6 @@ public final class ImagePipeline: @unchecked Sendable {
             }
         }
         return task
-    }
-
-    /// Loads an image for the given request, producing progressive images as
-    /// more data becomes available.
-    public func images(
-        for request: any ImageRequestConvertible,
-        progress: ((_ completed: Int64, _ total: Int64) -> Void)? = nil,
-        task: AsyncImageTask = AsyncImageTask()
-    ) -> AsyncThrowingStream<ImageResponse, Swift.Error> {
-        AsyncThrowingStream { continuation in
-            let task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: { response, completed, total in
-                if let response = response {
-                    continuation.yield(response)
-                } else {
-                    progress?(completed, total)
-                }
-            }, completion: {
-                switch $0 {
-                case .success(let response):
-                    continuation.yield(response)
-                    continuation.finish()
-                case .failure(let error):
-                    continuation.finish(throwing: error)
-                }
-            })
-            continuation.onTermination = { _ in task.cancel() }
-        }
-    }
-
-    /// Loads an image for the given request.
-    ///
-    /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
-    ///
-    /// - parameter request: An image request.
-    ///
-    @discardableResult
-    public func image(
-        for request: any ImageRequestConvertible,
-        progress: ((_ completed: Int64, _ total: Int64) -> Void)? = nil,
-        task: AsyncImageTask = AsyncImageTask()
-    ) async throws -> ImageResponse {
-        return try await withTaskCancellationHandler(handler: {
-            task.task?.cancel()
-        }, operation: {
-            try await withUnsafeThrowingContinuation { continuation in
-                // The pipeline guarantees that the callbacks (either onCancel or
-                // completion) are called exactly once. `onCancel` is a new addition
-                // just for Async/Await. Ideally, the completion should be called on
-                // cancellation instead, but that ship has sailed. Maybe in Nuke 11.
-                task.task = loadImage(with: request.asImageRequest(), isConfined: false, queue: nil, progress: {
-                    if $0 == nil { progress?($1, $2) }
-                }, onCancel: {
-                    continuation.resume(throwing: CancellationError())
-                }, completion: {
-                    continuation.resume(with: $0)
-                })
-            }
-        })
     }
 
     private func startImageTask(
@@ -286,34 +316,6 @@ public final class ImagePipeline: @unchecked Sendable {
         completion: @escaping (Result<(data: Data, response: URLResponse?), Error>) -> Void
     ) -> ImageTask {
         loadData(with: request.asImageRequest(), isConfined: false, queue: queue, progress: progress, completion: completion)
-    }
-
-    /// Loads an image for the given request.
-    ///
-    /// See [Nuke Docs](https://kean.blog/nuke/guides/image-pipeline) to learn more.
-    ///
-    /// - parameter request: An image request.
-    @discardableResult
-    public func data(
-        for request: any ImageRequestConvertible,
-        progress: (@Sendable (_ completed: Int64, _ total: Int64) -> Void)? = nil,
-        task: AsyncImageTask = AsyncImageTask()
-    ) async throws -> (Data, URLResponse?) {
-        return try await withTaskCancellationHandler(handler: {
-            task.task?.cancel()
-        }, operation: {
-            try await withUnsafeThrowingContinuation { continuation in
-                // The pipeline guarantees that the callbacks (either onCancel or
-                // completion) are called exactly once. `onCancel` is a new addition
-                // just for Async/Await. Ideally, the completion should be called on
-                // cancellation instead, but that ship has sailed. Maybe in Nuke 11.
-                task.task = loadData(with: request.asImageRequest(), isConfined: false, queue: nil, progress: progress, onCancel: {
-                    continuation.resume(throwing: CancellationError())
-                }, completion: {
-                    continuation.resume(with: $0)
-                })
-            }
-        })
     }
 
     func loadData(

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -100,7 +100,7 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
         // WHEN
         do {
             try await pipeline.image(for: Test.request, progress: {
-                self.recordedProgress.append(Progress(completed: $1, total: $2))
+                self.recordedProgress.append(Progress(completed: $0, total: $1))
             })
         } catch {
             // Do nothing

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -371,8 +371,8 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         let task = Task {
             var responses: [ImageResponse] = []
             do {
-                for try await resposne in pipeline.images(for: Test.request) {
-                    responses.append(resposne)
+                for try await response in pipeline.images(for: Test.request) {
+                    responses.append(response)
                     box.onCancel?()
                 }
             } catch {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -349,6 +349,40 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         wait()
     }
     #endif
+
+    // MARK: - Async/Await
+
+    func testProgressiveDecodingAsyncAwait() async throws {
+        var responses: [ImageResponse] = []
+        for try await response in pipeline.images(for: Test.request) {
+            responses.append(response)
+            dataLoader.resume()
+        }
+        XCTAssertEqual(responses.count, 3)
+    }
+
+    func testCancellationDuringDecodingAsyncAwait() async {
+        class Box {
+            var onCancel: (() -> Void)?
+        }
+
+        let box = Box()
+
+        let task = Task {
+            var responses: [ImageResponse] = []
+            do {
+                for try await resposne in pipeline.images(for: Test.request) {
+                    responses.append(resposne)
+                    box.onCancel?()
+                }
+            } catch {
+                XCTFail() // Stream terminates without throwing an error
+            }
+            XCTAssertEqual(responses.count, 1)
+        }
+        box.onCancel = task.cancel
+        await task.value
+    }
 }
 
 private extension XCTestCase {


### PR DESCRIPTION
Represent progressive decoding using async sequence:

```swift
for try await response in pipeline.images(for: Test.request) {
    print("Got new response: \(response)")
}
```

Update `progress` closure to only be called when download progress is updated, not when a new preview is returned.