### PR TITLE
Default hashableIdentifier for ImageProcessing

### DIFF
--- a/Documentation/Migrations/Nuke 11 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 11 Migration Guide.md
@@ -47,3 +47,27 @@ public protocol ImageProcessing {
     func process(_ container: ImageContainer, context: ImageProcessingContext) throws -> ImageContainer
 }
 ```
+
+## ImageProcessing and Hashable
+
+If you are implementing custom image processors `ImageProcessing` that implement `hashableIdentifier` and return self, you can remove the `hashableIdentifier` implementation and use the one provided by default.
+
+```swift
+// Before (Nuke 10)
+extension ImageProcessors {
+    /// Scales an image to a specified size.
+    public struct Resize: ImageProcessing, Hashable {
+        private let size: CGSize
+        
+        var hashableIdentiifer: AnyHashable { self }
+    }
+}
+
+// After (Nuke 11)
+extension ImageProcessors {
+    /// Scales an image to a specified size.
+    public struct Resize: ImageProcessing, Hashable {
+        private let size: CGSize
+    }
+}
+```

--- a/Sources/Nuke/Processing/ImageProcessing.swift
+++ b/Sources/Nuke/Processing/ImageProcessing.swift
@@ -66,6 +66,10 @@ extension ImageProcessing {
     public var hashableIdentifier: AnyHashable { identifier }
 }
 
+extension ImageProcessing where Self: Hashable {
+    public var hashableIdentifier: AnyHashable { self }
+}
+
 /// Image processing context used when selecting which processor to use.
 public struct ImageProcessingContext: Sendable {
     public var request: ImageRequest

--- a/Sources/Nuke/Processing/ImageProcessors+Circle.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Circle.swift
@@ -25,8 +25,6 @@ extension ImageProcessors {
             return "com.github.kean/nuke/circle" + (suffix ?? "")
         }
 
-        public var hashableIdentifier: AnyHashable { self }
-
         public var description: String {
             "Circle(border: \(border?.description ?? "nil"))"
         }

--- a/Sources/Nuke/Processing/ImageProcessors+Composition.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Composition.swift
@@ -42,9 +42,6 @@ extension ImageProcessors {
             processors.map({ $0.identifier }).joined()
         }
 
-        /// An identifies that compares all the underlying processors for equality.
-        public var hashableIdentifier: AnyHashable { self }
-
         /// Creates a combined hash of all the given processors.
         public func hash(into hasher: inout Hasher) {
             for processor in processors {

--- a/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
@@ -37,9 +37,6 @@ extension ImageProcessors {
             "com.github.kean/nuke/gaussian_blur?radius=\(radius)"
         }
 
-        /// Returns hashable `self` that compares processors by their `radius`.`
-        public var hashableIdentifier: AnyHashable { self }
-
         public var description: String {
             "GaussianBlur(radius: \(radius))"
         }

--- a/Sources/Nuke/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Resize.swift
@@ -75,8 +75,6 @@ extension ImageProcessors {
             "com.github.kean/nuke/resize?s=\(size.cgSize),cm=\(contentMode),crop=\(crop),upscale=\(upscale)"
         }
 
-        public var hashableIdentifier: AnyHashable { self }
-
         public var description: String {
             "Resize(size: \(size.cgSize) pixels, contentMode: \(contentMode), crop: \(crop), upscale: \(upscale))"
         }

--- a/Sources/Nuke/Processing/ImageProcessors+RoundedCorners.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+RoundedCorners.swift
@@ -33,8 +33,6 @@ extension ImageProcessors {
             return "com.github.kean/nuke/rounded_corners?radius=\(radius)" + (suffix ?? "")
         }
 
-        public var hashableIdentifier: AnyHashable { self }
-
         public var description: String {
             "RoundedCorners(radius: \(radius) pixels, border: \(border?.description ?? "nil"))"
         }


### PR DESCRIPTION
`ImageProcessing` types that implement `Hashable` protocol now get default `hashableIdentifier` implementation