### PR TITLE
ImageTaskDelegate

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		0C95FD542571B278008D4FC2 /* baseline.webp in Resources */ = {isa = PBXBuildFile; fileRef = 0C95FD532571B278008D4FC2 /* baseline.webp */; };
 		0C973E141D9FDB9F00C00AD9 /* Nuke.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0C9174901BAE99EE004A7905 /* Nuke.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0C9B6E7620B9F3E2001924B8 /* ImagePipelineCoalescingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9B6E7520B9F3E2001924B8 /* ImagePipelineCoalescingTests.swift */; };
+		0CA3BA63285C11EA0079A444 /* ImagePipelineTaskDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA3BA62285C11EA0079A444 /* ImagePipelineTaskDelegateTests.swift */; };
 		0CA4EC9626E67C7000BAC8E5 /* AVDataAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4EC9426E67C7000BAC8E5 /* AVDataAsset.swift */; };
 		0CA4EC9926E67CEC00BAC8E5 /* ImageDecoders+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4EC9826E67CEC00BAC8E5 /* ImageDecoders+Default.swift */; };
 		0CA4EC9B26E67D3000BAC8E5 /* ImageDecoders+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4EC9A26E67D3000BAC8E5 /* ImageDecoders+Empty.swift */; };
@@ -484,6 +485,7 @@
 		0C95FD532571B278008D4FC2 /* baseline.webp */ = {isa = PBXFileReference; lastKnownFileType = file; path = baseline.webp; sourceTree = "<group>"; };
 		0C97DD9E284C00EA00F55FDA /* Nuke 11 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Nuke 11 Migration Guide.md"; sourceTree = "<group>"; };
 		0C9B6E7520B9F3E2001924B8 /* ImagePipelineCoalescingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineCoalescingTests.swift; sourceTree = "<group>"; };
+		0CA3BA62285C11EA0079A444 /* ImagePipelineTaskDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineTaskDelegateTests.swift; sourceTree = "<group>"; };
 		0CA4EC9426E67C7000BAC8E5 /* AVDataAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDataAsset.swift; sourceTree = "<group>"; };
 		0CA4EC9826E67CEC00BAC8E5 /* ImageDecoders+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageDecoders+Default.swift"; sourceTree = "<group>"; };
 		0CA4EC9A26E67D3000BAC8E5 /* ImageDecoders+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageDecoders+Empty.swift"; sourceTree = "<group>"; };
@@ -928,6 +930,7 @@
 				0C6B5BE0257010D300D763F2 /* ImagePipelineFormatsTests.swift */,
 				0CD37C9925BA36D5006C2C36 /* ImagePipelineLoadDataTests.swift */,
 				0C53C8AE263C7B1700E62D03 /* ImagePipelineDelegateTests.swift */,
+				0CA3BA62285C11EA0079A444 /* ImagePipelineTaskDelegateTests.swift */,
 				0CE6202426543EC700AAB8C3 /* ImagePipelinePublisherTests.swift */,
 				0C5D5A9C2724773A0056B95B /* ImagePipelineAsyncAwaitTests.swift */,
 				0C78A2A8263F560A0051E0FF /* ImagePipelineCacheTests.swift */,
@@ -1755,6 +1758,7 @@
 				0CF58FF726DAAC3800D2650D /* ImageDownsampleTests.swift in Sources */,
 				0C211E502856328500F48AA6 /* DataLoaderTests.swift in Sources */,
 				0C91B0EC2438E287007F9100 /* ResizeTests.swift in Sources */,
+				0CA3BA63285C11EA0079A444 /* ImagePipelineTaskDelegateTests.swift in Sources */,
 				0C6D0A8C20E57C810037B68F /* ImagePipelineDataCacheTests.swift in Sources */,
 				0C68F609208A1F40007DC696 /* ImageDecoderRegistryTests.swift in Sources */,
 				0CE6202526543EC700AAB8C3 /* ImagePipelinePublisherTests.swift in Sources */,

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		0C973E141D9FDB9F00C00AD9 /* Nuke.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0C9174901BAE99EE004A7905 /* Nuke.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0C9B6E7620B9F3E2001924B8 /* ImagePipelineCoalescingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9B6E7520B9F3E2001924B8 /* ImagePipelineCoalescingTests.swift */; };
 		0CA3BA63285C11EA0079A444 /* ImagePipelineTaskDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA3BA62285C11EA0079A444 /* ImagePipelineTaskDelegateTests.swift */; };
+		0CA3BA64285C15A90079A444 /* MockProgressiveDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCBB533217D0B980026F552 /* MockProgressiveDataLoader.swift */; };
 		0CA4EC9626E67C7000BAC8E5 /* AVDataAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4EC9426E67C7000BAC8E5 /* AVDataAsset.swift */; };
 		0CA4EC9926E67CEC00BAC8E5 /* ImageDecoders+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4EC9826E67CEC00BAC8E5 /* ImageDecoders+Default.swift */; };
 		0CA4EC9B26E67D3000BAC8E5 /* ImageDecoders+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA4EC9A26E67D3000BAC8E5 /* ImageDecoders+Empty.swift */; };
@@ -1598,6 +1599,7 @@
 			files = (
 				0C2CD7C725B7C0280017018F /* XCTestCaseExtensions.swift in Sources */,
 				0C2CD7BA25B7C0100017018F /* MockDataLoader.swift in Sources */,
+				0CA3BA64285C15A90079A444 /* MockProgressiveDataLoader.swift in Sources */,
 				0C2CD7C825B7C0280017018F /* NukeExtensions.swift in Sources */,
 				0C2CD7C625B7C0280017018F /* XCTestCase+Nuke.swift in Sources */,
 				0C2CD7C025B7C0200017018F /* Helpers.swift in Sources */,

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -107,7 +107,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
 
 /// A protocol that defines methods that image pipeline instances call on their
 /// delegates to handle task-level events.
-public protocol ImageTaskDelegate: AnyObject {
+public protocol ImageTaskDelegate: AnyObject, Sendable {
     /// Gets called when the task is started. The caller can save the instance
     /// of the class to update the task later.
     func imageTaskWillStart(_ task: ImageTask)

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -108,9 +108,11 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
 /// A protocol that defines methods that image pipeline instances call on their
 /// delegates to handle task-level events.
 public protocol ImageTaskDelegate: AnyObject, Sendable {
+    func imageTaskCreated(_ task: ImageTask)
+
     /// Gets called when the task is started. The caller can save the instance
     /// of the class to update the task later.
-    func imageTaskWillStart(_ task: ImageTask)
+    func imageTaskStarted(_ task: ImageTask)
 
     /// Gets called when the progress is updated.
     func imageTask(_ task: ImageTask, didUpdateProgress progress: (completed: Int64, total: Int64))
@@ -124,23 +126,27 @@ public protocol ImageTaskDelegate: AnyObject, Sendable {
 }
 
 extension ImageTaskDelegate {
-    func imageTaskWillStart(_ task: ImageTask) {
+    public func imageTaskCreated(_ task: ImageTask) {
+
+    }
+
+    public func imageTaskStarted(_ task: ImageTask) {
         // Do nothing
     }
 
-    func imageTask(_ task: ImageTask, didUpdateProgress progress: (completed: Int64, total: Int64)) {
+    public func imageTask(_ task: ImageTask, didUpdateProgress progress: (completed: Int64, total: Int64)) {
         // Do nothing
     }
 
-    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse) {
+    public func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse) {
         // Do nothing
     }
 
-    func imageTaskDidCancel(_ task: ImageTask) {
+    public func imageTaskDidCancel(_ task: ImageTask) {
         // Do nothing
     }
 
-    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
+    public func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
         // Do nothing
     }
 }

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -17,8 +17,6 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// The original request.
     public let request: ImageRequest
 
-    let isDataTask: Bool
-
     /// Updates the priority of the task, even if it is already running.
     public func setPriority(_ priority: ImageRequest.Priority) {
         pipeline?.imageTaskUpdatePriorityCalled(self, priority: priority)
@@ -55,11 +53,10 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         #endif
     }
 
-    init(taskId: Int64, request: ImageRequest, isDataTask: Bool, pipeline: ImagePipeline) {
+    init(taskId: Int64, request: ImageRequest, pipeline: ImagePipeline) {
         self.taskId = taskId
         self.request = request
         self._priority = request.priority
-        self.isDataTask = isDataTask
         self.pipeline = pipeline
 
         self._isCancelled = UnsafeMutablePointer<Int32>.allocate(capacity: 1)

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -121,8 +121,6 @@ public protocol ImageTaskDelegate: AnyObject {
     func imageTaskDidCancel(_ task: ImageTask)
 
     func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>)
-
-    func dataTask(_ task: ImageTask, didCompleteWithResult result: Result<(data: Data, response: URLResponse?), ImagePipeline.Error>)
 }
 
 extension ImageTaskDelegate {
@@ -143,10 +141,6 @@ extension ImageTaskDelegate {
     }
 
     func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
-        // Do nothing
-    }
-
-    func dataTask(_ task: ImageTask, didCompleteWithResult result: Result<(data: Data, response: URLResponse?), ImagePipeline.Error>) {
         // Do nothing
     }
 }

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -108,6 +108,7 @@ public final class ImagePipeline: @unchecked Sendable {
 
     /// Loads an image for the given request.
     public func image(for request: any ImageRequestConvertible, delegate: ImageTaskDelegate? = nil) async throws -> ImageResponse {
+        #warning("Move delegate to startImageTask")
         let task = makeImageTask(request: request.asImageRequest())
         delegate?.imageTaskCreated(task)
 

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -406,9 +406,6 @@ public final class ImagePipeline: @unchecked Sendable {
         queue.async {
             task._priority = priority
             guard let subscription = self.tasks[task] else { return }
-            if !task.isDataTask {
-                self.send(.priorityUpdated(priority: priority), task)
-            }
             subscription.setPriority(priority.taskPriority)
         }
     }

--- a/Sources/Nuke/Pipeline/ImagePipelineDelegate.swift
+++ b/Sources/Nuke/Pipeline/ImagePipelineDelegate.swift
@@ -8,7 +8,7 @@ import Foundation
 ///
 /// - warning: The delegate methods are performed on the pipeline queue in the
 /// background.
-public protocol ImagePipelineDelegate: ImageTaskDelegate, Sendable { // swiftlint:disable:this class_delegate_protocol
+public protocol ImagePipelineDelegate: ImageTaskDelegate {
     // MARK: Configuration
 
     /// Returns data loader for the given request.

--- a/Sources/Nuke/Pipeline/ImagePipelineDelegate.swift
+++ b/Sources/Nuke/Pipeline/ImagePipelineDelegate.swift
@@ -105,7 +105,6 @@ extension ImagePipelineDelegate {
 public enum ImageTaskEvent {
     case started
     case cancelled
-    case priorityUpdated(priority: ImageRequest.Priority)
     case intermediateResponseReceived(response: ImageResponse)
     case progressUpdated(completedUnitCount: Int64, totalUnitCount: Int64)
     case completed(result: Result<ImageResponse, ImagePipeline.Error>)

--- a/Sources/Nuke/Pipeline/ImagePipelineDelegate.swift
+++ b/Sources/Nuke/Pipeline/ImagePipelineDelegate.swift
@@ -8,7 +8,7 @@ import Foundation
 ///
 /// - warning: The delegate methods are performed on the pipeline queue in the
 /// background.
-public protocol ImagePipelineDelegate: Sendable { // swiftlint:disable:this class_delegate_protocol
+public protocol ImagePipelineDelegate: ImageTaskDelegate, Sendable { // swiftlint:disable:this class_delegate_protocol
     // MARK: Configuration
 
     /// Returns data loader for the given request.
@@ -54,11 +54,6 @@ public protocol ImagePipelineDelegate: Sendable { // swiftlint:disable:this clas
     func shouldDecompress(response: ImageResponse, for request: ImageRequest, pipeline: ImagePipeline) -> Bool
 
     func decompress(response: ImageResponse, request: ImageRequest, pipeline: ImagePipeline) -> ImageResponse
-
-    // MARK: Monitoring
-
-    /// Delivers the events produced by the image tasks started via `loadImage` method.
-    func pipeline(_ pipeline: ImagePipeline, imageTask: ImageTask, didReceiveEvent event: ImageTaskEvent)
 }
 
 extension ImagePipelineDelegate {
@@ -95,36 +90,6 @@ extension ImagePipelineDelegate {
         response.container.image = ImageDecompression.decompress(image: response.image)
         return response
     }
-
-    public func pipeline(_ pipeline: ImagePipeline, imageTask: ImageTask, didReceiveEvent event: ImageTaskEvent) {
-        // Do nothing
-    }
 }
 
-/// An image task event sent by the pipeline.
-public enum ImageTaskEvent {
-    case started
-    case cancelled
-    case intermediateResponseReceived(response: ImageResponse)
-    case progressUpdated(completedUnitCount: Int64, totalUnitCount: Int64)
-    case completed(result: Result<ImageResponse, ImagePipeline.Error>)
-}
-
-extension ImageTaskEvent {
-    init(_ event: AsyncTask<ImageResponse, ImagePipeline.Error>.Event) {
-        switch event {
-        case let .error(error):
-            self = .completed(result: .failure(error))
-        case let .value(response, isCompleted):
-            if isCompleted {
-                self = .completed(result: .success(response))
-            } else {
-                self = .intermediateResponseReceived(response: response)
-            }
-        case let .progress(progress):
-            self = .progressUpdated(completedUnitCount: progress.completed, totalUnitCount: progress.total)
-        }
-    }
-}
-
-struct ImagePipelineDefaultDelegate: ImagePipelineDelegate {}
+final class ImagePipelineDefaultDelegate: ImagePipelineDelegate {}

--- a/Tests/ImagePipelineObserver.swift
+++ b/Tests/ImagePipelineObserver.swift
@@ -10,8 +10,6 @@ final class ImagePipelineObserver: ImagePipelineDelegate, @unchecked Sendable {
     var cancelledTaskCount = 0
     var completedTaskCount = 0
 
-    var events = [ImageTaskEvent]()
-
     static let didStartTask = Notification.Name("com.github.kean.Nuke.Tests.ImagePipelineObserver.DidStartTask")
     static let didCancelTask = Notification.Name("com.github.kean.Nuke.Tests.ImagePipelineObserver.DidCancelTask")
     static let didCompleteTask = Notification.Name("com.github.kean.Nuke.Tests.ImagePipelineObserver.DidFinishTask")
@@ -19,20 +17,51 @@ final class ImagePipelineObserver: ImagePipelineDelegate, @unchecked Sendable {
     static let taskKey = "taskKey"
     static let resultKey = "resultKey"
 
-    func pipeline(_ pipeline: ImagePipeline, imageTask: ImageTask, didReceiveEvent event: ImageTaskEvent) {
-        switch event {
-        case .started:
-            startedTaskCount += 1
-            NotificationCenter.default.post(name: ImagePipelineObserver.didStartTask, object: self, userInfo: [ImagePipelineObserver.taskKey: imageTask])
-        case .cancelled:
-            cancelledTaskCount += 1
-            NotificationCenter.default.post(name: ImagePipelineObserver.didCancelTask, object: self, userInfo: [ImagePipelineObserver.taskKey: imageTask])
-        case .completed(let result):
-            completedTaskCount += 1
-            NotificationCenter.default.post(name: ImagePipelineObserver.didCompleteTask, object: self, userInfo: [ImagePipelineObserver.taskKey: imageTask, ImagePipelineObserver.resultKey: result])
-        default:
-            break
+    var events = [ImageTaskEvent]()
+
+    func imageTaskWillStart(_ task: ImageTask) {
+        startedTaskCount += 1
+        NotificationCenter.default.post(name: ImagePipelineObserver.didStartTask, object: self, userInfo: [ImagePipelineObserver.taskKey: task])
+        events.append(.started)
+    }
+
+    func imageTaskDidCancel(_ task: ImageTask) {
+        cancelledTaskCount += 1
+        NotificationCenter.default.post(name: ImagePipelineObserver.didCancelTask, object: self, userInfo: [ImagePipelineObserver.taskKey: task])
+        events.append(.cancelled)
+    }
+
+    func imageTask(_ task: ImageTask, didUpdateProgress progress: (completed: Int64, total: Int64)) {
+        events.append(.progressUpdated(completedUnitCount: progress.completed, totalUnitCount: progress.total))
+    }
+
+    func imageTask(_ task: ImageTask, didProduceProgressiveResponse response: ImageResponse) {
+        events.append(.intermediateResponseReceived(response: response))
+    }
+
+    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
+        completedTaskCount += 1
+        NotificationCenter.default.post(name: ImagePipelineObserver.didCompleteTask, object: self, userInfo: [ImagePipelineObserver.taskKey: task, ImagePipelineObserver.resultKey: result])
+        events.append(.completed(result: result))
+    }
+}
+
+enum ImageTaskEvent: Equatable {
+    case started
+    case cancelled
+    case intermediateResponseReceived(response: ImageResponse)
+    case progressUpdated(completedUnitCount: Int64, totalUnitCount: Int64)
+    case completed(result: Result<ImageResponse, ImagePipeline.Error>)
+
+    static func == (lhs: ImageTaskEvent, rhs: ImageTaskEvent) -> Bool {
+        switch (lhs, rhs) {
+        case (.started, .started): return true
+        case (.cancelled, .cancelled): return true
+        case let (.intermediateResponseReceived(lhs), .intermediateResponseReceived(rhs)): return lhs == rhs
+        case let (.progressUpdated(lhsTotal, lhsCompleted), .progressUpdated(rhsTotal, rhsCompleted)):
+            return (lhsTotal, lhsCompleted) == (rhsTotal, rhsCompleted)
+        case let (.completed(lhs), .completed(rhs)): return lhs == rhs
+        default: return false
         }
-        events.append(event)
     }
 }

--- a/Tests/ImagePipelineObserver.swift
+++ b/Tests/ImagePipelineObserver.swift
@@ -38,9 +38,10 @@ final class ImagePipelineObserver: ImagePipelineDelegate, @unchecked Sendable {
     }
 
     func imageTaskDidCancel(_ task: ImageTask) {
+        append(.cancelled)
+
         cancelledTaskCount += 1
         NotificationCenter.default.post(name: ImagePipelineObserver.didCancelTask, object: self, userInfo: [ImagePipelineObserver.taskKey: task])
-        append(.cancelled)
     }
 
     func imageTask(_ task: ImageTask, didUpdateProgress progress: (completed: Int64, total: Int64)) {
@@ -52,9 +53,10 @@ final class ImagePipelineObserver: ImagePipelineDelegate, @unchecked Sendable {
     }
 
     func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
+        append(.completed(result: result))
+
         completedTaskCount += 1
         NotificationCenter.default.post(name: ImagePipelineObserver.didCompleteTask, object: self, userInfo: [ImagePipelineObserver.taskKey: task, ImagePipelineObserver.resultKey: result])
-        append(.completed(result: result))
     }
 }
 

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -26,7 +26,6 @@ extension ImageTaskEvent: Equatable {
         switch (lhs, rhs) {
         case (.started, .started): return true
         case (.cancelled, .cancelled): return true
-        case let (.priorityUpdated(lhs), .priorityUpdated(rhs)): return lhs == rhs
         case let (.intermediateResponseReceived(lhs), .intermediateResponseReceived(rhs)): return lhs == rhs
         case let (.progressUpdated(lhsTotal, lhsCompleted), .progressUpdated(rhsTotal, rhsCompleted)):
             return (lhsTotal, lhsCompleted) == (rhsTotal, rhsCompleted)

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -21,20 +21,6 @@ extension ImagePipeline.Error: Equatable {
     }
 }
 
-extension ImageTaskEvent: Equatable {
-    public static func == (lhs: ImageTaskEvent, rhs: ImageTaskEvent) -> Bool {
-        switch (lhs, rhs) {
-        case (.started, .started): return true
-        case (.cancelled, .cancelled): return true
-        case let (.intermediateResponseReceived(lhs), .intermediateResponseReceived(rhs)): return lhs == rhs
-        case let (.progressUpdated(lhsTotal, lhsCompleted), .progressUpdated(rhsTotal, rhsCompleted)):
-            return (lhsTotal, lhsCompleted) == (rhsTotal, rhsCompleted)
-        case let (.completed(lhs), .completed(rhs)): return lhs == rhs
-        default: return false
-        }
-    }
-}
-
 extension ImageResponse: Equatable {
     public static func == (lhs: ImageResponse, rhs: ImageResponse) -> Bool {
         return lhs.image === rhs.image

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -76,7 +76,7 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
 
     func testImageTaskReturnedImmediately() async throws {
         // GIVEN
-        taskDelegate.onWillStart = { [unowned self] in imageTask = $0 }
+        taskDelegate.onTaskCreated = { [unowned self] in imageTask = $0 }
 
         // WHEN
         _ = try await pipeline.image(for: Test.request, delegate: taskDelegate)
@@ -88,7 +88,7 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
     func testImageTaskDelegateDidCancelIsCalled() async throws {
         // GIVEN
         dataLoader.queue.isSuspended = true
-        taskDelegate.onWillStart = { [unowned self] in imageTask = $0 }
+        taskDelegate.onTaskCreated = { [unowned self] in imageTask = $0 }
 
         observer = NotificationCenter.default.addObserver(forName: MockDataLoader.DidStartTask, object: dataLoader, queue: OperationQueue()) { [unowned self] _ in
             imageTask?.cancel()
@@ -189,7 +189,7 @@ class ImagePipelineAsyncAwaitTests: XCTestCase {
 
         let observer = expect(queue).toEnqueueOperationsWithCount(1)
 
-        taskDelegate.onWillStart = { [unowned self] in imageTask = $0 }
+        taskDelegate.onTaskCreated = { [unowned self] in imageTask = $0 }
 
         Task.detached { [unowned self] in
             try await self.pipeline.image(for: request, delegate: taskDelegate)
@@ -298,10 +298,16 @@ private struct Progress: Equatable {
 }
 
 private final class AnonymousImateTaskDelegate: ImageTaskDelegate, @unchecked Sendable {
-    var onWillStart: ((ImageTask) -> Void)?
+    var onTaskCreated: ((ImageTask) -> Void)?
 
-    func imageTaskWillStart(_ task: ImageTask) {
-        onWillStart?(task)
+    func imageTaskCreated(_ task: ImageTask) {
+        onTaskCreated?(task)
+    }
+
+    var onTaskStarted: ((ImageTask) -> Void)?
+
+    func imageTaskStarted(_ task: ImageTask) {
+
     }
 
     var onProgress: ((_ completed: Int64, _ total: Int64) -> Void)?

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -297,7 +297,7 @@ private struct Progress: Equatable {
     let completed, total: Int64
 }
 
-private final class AnonymousImateTaskDelegate: ImageTaskDelegate {
+private final class AnonymousImateTaskDelegate: ImageTaskDelegate, @unchecked Sendable {
     var onWillStart: ((ImageTask) -> Void)?
 
     func imageTaskWillStart(_ task: ImageTask) {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
@@ -67,60 +67,6 @@ class ImagePipelineDelegateTests: XCTestCase {
         XCTAssertEqual(dataLoader.createdTaskCount, 1)
     }
 
-    // MARK: Monitoring
-
-    func testStartAndCompletedEvents() throws {
-        var result: Result<ImageResponse, ImagePipeline.Error>?
-        expect(pipeline).toLoadImage(with: Test.request) { result = $0 }
-        wait()
-
-        // Then
-        XCTAssertEqual(delegate.events, [
-            ImageTaskEvent.started,
-            .progressUpdated(completedUnitCount: 22789, totalUnitCount: 22789),
-            .completed(result: try XCTUnwrap(result))
-        ])
-    }
-
-    func testProgressUpdateEvents() throws {
-        let request = ImageRequest(url: Test.url)
-        dataLoader.results[Test.url] = .success(
-            (Data(count: 20), URLResponse(url: Test.url, mimeType: "jpeg", expectedContentLength: 20, textEncodingName: nil))
-        )
-
-        var result: Result<ImageResponse, ImagePipeline.Error>?
-        expect(pipeline).toFailRequest(request) { result = $0 }
-        wait()
-
-        // Then
-        XCTAssertEqual(delegate.events, [
-            ImageTaskEvent.started,
-            .progressUpdated(completedUnitCount: 10, totalUnitCount: 20),
-            .progressUpdated(completedUnitCount: 20, totalUnitCount: 20),
-            .completed(result: try XCTUnwrap(result))
-        ])
-    }
-
-    func testCancellationEvents() {
-        dataLoader.queue.isSuspended = true
-
-        expectNotification(MockDataLoader.DidStartTask, object: dataLoader)
-        let task = pipeline.loadImage(with: Test.request) { _ in
-            XCTFail()
-        }
-        wait() // Wait till operation is created
-
-        expectNotification(MockDataLoader.DidCancelTask, object: dataLoader)
-        task.cancel()
-        wait()
-
-        // Then
-        XCTAssertEqual(delegate.events, [
-            ImageTaskEvent.started,
-            .cancelled
-        ])
-    }
-
     func testDataIsStoredInCache() {
         // WHEN
         expect(pipeline).toLoadImage(with: Test.request)
@@ -153,10 +99,5 @@ private final class MockImagePipelineDelegate: ImagePipelineDelegate, @unchecked
     func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline, completion: @escaping (Data?) -> Void) {
         completion(isCacheEnabled ? data : nil)
     }
-
-    var events = [ImageTaskEvent]()
-
-    func pipeline(_ pipeline: ImagePipeline, imageTask: ImageTask, didReceiveEvent event: ImageTaskEvent) {
-        events.append(event)
-    }
 }
+

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
@@ -101,33 +101,6 @@ class ImagePipelineDelegateTests: XCTestCase {
         ])
     }
 
-    func testUpdatePriorityEvents() {
-        // Given
-        let queue = pipeline.configuration.dataLoadingQueue
-        queue.isSuspended = true
-
-        let request = Test.request
-        XCTAssertEqual(request.priority, .normal)
-
-        let operationQueueObserver = self.expect(queue).toEnqueueOperationsWithCount(1)
-
-        let task = pipeline.loadImage(with: request) { _ in }
-        wait() // Wait till the operation is created.
-
-        guard let operation = operationQueueObserver.operations.first else {
-            return XCTFail("Failed to find operation")
-        }
-        expect(operation).toUpdatePriority()
-        task.setPriority(.high)
-        wait()
-
-        // Then
-        XCTAssertEqual(delegate.events, [
-            ImageTaskEvent.started,
-            .priorityUpdated(priority: .high)
-        ])
-    }
-
     func testCancellationEvents() {
         dataLoader.queue.isSuspended = true
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
@@ -29,7 +29,8 @@ class ImagePipelineTaskDelegateTests: XCTestCase {
         
         // Then
         XCTAssertEqual(delegate.events, [
-            ImageTaskEvent.started,
+            ImageTaskEvent.created,
+            .started,
             .progressUpdated(completedUnitCount: 22789, totalUnitCount: 22789),
             .completed(result: try XCTUnwrap(result))
         ])
@@ -47,7 +48,8 @@ class ImagePipelineTaskDelegateTests: XCTestCase {
         
         // Then
         XCTAssertEqual(delegate.events, [
-            ImageTaskEvent.started,
+            ImageTaskEvent.created,
+            .started,
             .progressUpdated(completedUnitCount: 10, totalUnitCount: 20),
             .progressUpdated(completedUnitCount: 20, totalUnitCount: 20),
             .completed(result: try XCTUnwrap(result))
@@ -69,7 +71,8 @@ class ImagePipelineTaskDelegateTests: XCTestCase {
         
         // Then
         XCTAssertEqual(delegate.events, [
-            ImageTaskEvent.started,
+            ImageTaskEvent.created,
+            .started,
             .cancelled
         ])
     }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
@@ -1,0 +1,76 @@
+//// The MIT License (MIT)
+//
+// Copyright (c) 2015-2022 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Nuke
+
+class ImagePipelineTaskDelegateTests: XCTestCase {
+    private var dataLoader: MockDataLoader!
+    private var pipeline: ImagePipeline!
+    private var delegate: ImagePipelineObserver!
+    
+    override func setUp() {
+        super.setUp()
+        
+        dataLoader = MockDataLoader()
+        delegate = ImagePipelineObserver()
+        
+        pipeline = ImagePipeline(delegate: delegate) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+    }
+    
+    func testStartAndCompletedEvents() throws {
+        var result: Result<ImageResponse, ImagePipeline.Error>?
+        expect(pipeline).toLoadImage(with: Test.request) { result = $0 }
+        wait()
+        
+        // Then
+        XCTAssertEqual(delegate.events, [
+            ImageTaskEvent.started,
+            .progressUpdated(completedUnitCount: 22789, totalUnitCount: 22789),
+            .completed(result: try XCTUnwrap(result))
+        ])
+    }
+    
+    func testProgressUpdateEvents() throws {
+        let request = ImageRequest(url: Test.url)
+        dataLoader.results[Test.url] = .success(
+            (Data(count: 20), URLResponse(url: Test.url, mimeType: "jpeg", expectedContentLength: 20, textEncodingName: nil))
+        )
+        
+        var result: Result<ImageResponse, ImagePipeline.Error>?
+        expect(pipeline).toFailRequest(request) { result = $0 }
+        wait()
+        
+        // Then
+        XCTAssertEqual(delegate.events, [
+            ImageTaskEvent.started,
+            .progressUpdated(completedUnitCount: 10, totalUnitCount: 20),
+            .progressUpdated(completedUnitCount: 20, totalUnitCount: 20),
+            .completed(result: try XCTUnwrap(result))
+        ])
+    }
+    
+    func testCancellationEvents() {
+        dataLoader.queue.isSuspended = true
+        
+        expectNotification(MockDataLoader.DidStartTask, object: dataLoader)
+        let task = pipeline.loadImage(with: Test.request) { _ in
+            XCTFail()
+        }
+        wait() // Wait till operation is created
+        
+        expectNotification(MockDataLoader.DidCancelTask, object: dataLoader)
+        task.cancel()
+        wait()
+        
+        // Then
+        XCTAssertEqual(delegate.events, [
+            ImageTaskEvent.started,
+            .cancelled
+        ])
+    }
+}

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
@@ -65,7 +65,7 @@ class ImagePipelineTaskDelegateTests: XCTestCase {
         }
         wait() // Wait till operation is created
         
-        expectNotification(MockDataLoader.DidCancelTask, object: dataLoader)
+        expectNotification(ImagePipelineObserver.didCancelTask, object: delegate)
         task.cancel()
         wait()
         


### PR DESCRIPTION
There are currently two mechanisms for receiving image tasks events: `ImagePipelineDelegate` with a top-level `ImageTaskEvent` and the new `ImageTaskDelegate` added for Async/Await. The goal is to consolidate these two mechanisms, similar to how `URLSessionDelegate` work.