### PR TITLE
Update new APIs to not use ImageRequestConvertible

### DIFF
--- a/Documentation/Migrations/Nuke 11 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 11 Migration Guide.md
@@ -77,6 +77,8 @@ If you invalidate the pipeline, any new requests will immediately fail with `Ima
 
 ## ImageRequestConvertible
 
+`ImageRequestConvertible` was originally introduced in [Nuke 9.2](https://github.com/kean/Nuke/releases/tag/9.2.0) to reduce number of `loadImage(:)` APIs in code completion, but it's no longer an issue with the new async/await APIs.
+
 `ImageRequestConvertible` is soft-deprecated in Nuke 11. The other soft-deprecated APIs, such as a closure-based `ImagePipeline/loadImage(:)` will continue working with it. The new APIs, such as async/await `ImagePipeline/image(for:)` will work with `URL` and `ImageRequest` which is better for discoverability and performance.
 
 If you are using `ImageRequestConvertible` in your code, consider removing it now. But it won't be officially deprecated until the next major release.

--- a/Documentation/Migrations/Nuke 11 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 11 Migration Guide.md
@@ -75,3 +75,8 @@ extension ImageProcessors {
 
 If you invalidate the pipeline, any new requests will immediately fail with `ImagePipeline/Error/pipelineInvalidated` error.
 
+## ImageRequestConvertible
+
+`ImageRequestConvertible` is soft-deprecated in Nuke 11. The other soft-deprecated APIs, such as a closure-based `ImagePipeline/loadImage(:)` will continue working with it. The new APIs, such as async/await `ImagePipeline/image(for:)` will work with `URL` and `ImageRequest` which is better for discoverability and performance.
+
+If you are using `ImageRequestConvertible` in your code, consider removing it now. But it won't be officially deprecated until the next major release.

--- a/Documentation/Switch/switch-from-kingfisher.md
+++ b/Documentation/Switch/switch-from-kingfisher.md
@@ -57,7 +57,7 @@ struct ContentView: View {
     let url = URL(string: "https://example.com/image.jpeg")
 
     var body: some View {
-        LazyImage(source: url)
+        LazyImage(url: url)
     }
 }
 

--- a/Documentation/Switch/switch-from-sdwebimage.md
+++ b/Documentation/Switch/switch-from-sdwebimage.md
@@ -57,7 +57,7 @@ struct ContentView: View {
     let url = URL(string: "https://example.com/image.jpeg")
 
     var body: some View {
-        LazyImage(source: url)
+        LazyImage(url: url)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Despite the number of features, the framework is lean and compiles in under 2 se
 
 ## Documentation
 
-Nuke is easy to learn and use thanks to [**Nuke Docs**](https://kean.blog/nuke/guides/welcome). Make sure to also check out [**Nuke Demo**](https://github.com/kean/NukeDemo).
+Nuke is easy to learn and use thanks to [**Nuke Docs**](https://kean-docs.github.io/nuke/documentation/nuke/getting-started). Make sure to also check out [**Nuke Demo**](https://github.com/kean/NukeDemo).
 
 > Upgrading from the previous version? Use a [**Migration Guide**](https://github.com/kean/Nuke/tree/master/Documentation/Migrations). Switching from another framework? Use a [**Switching Guide**](https://github.com/kean/Nuke/tree/master/Documentation/Switch).
 
 <a href="https://kean-docs.github.io/nuke/documentation/nuke/getting-started">
-<img width="750" alt="nuke-docs" src="https://user-images.githubusercontent.com/1567433/175789824-d62f1599-1c7a-480f-a823-3db28fb12958.png">
+<img width="690" alt="Nuke Docs" src="https://user-images.githubusercontent.com/1567433/175790021-6bbc8643-3fbb-47ef-861f-3dde445a5b04.png">
 </a>
 
 <a name="h_plugins"></a>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Nuke is easy to learn and use thanks to [**Nuke Docs**](https://kean-docs.github
 > Upgrading from the previous version? Use a [**Migration Guide**](https://github.com/kean/Nuke/tree/master/Documentation/Migrations). Switching from another framework? Use a [**Switching Guide**](https://github.com/kean/Nuke/tree/master/Documentation/Switch).
 
 <a href="https://kean-docs.github.io/nuke/documentation/nuke/getting-started">
-<img width="690" alt="Nuke Docs" src="https://user-images.githubusercontent.com/1567433/175790021-6bbc8643-3fbb-47ef-861f-3dde445a5b04.png">
+<img width="690" alt="Nuke Docs" src="https://user-images.githubusercontent.com/1567433/175793167-b7e0c557-b887-444f-b18a-57d6f5ecf01a.png">
 </a>
 
 <a name="h_plugins"></a>

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Nuke is easy to learn and use thanks to [**Nuke Docs**](https://kean.blog/nuke/g
 
 > Upgrading from the previous version? Use a [**Migration Guide**](https://github.com/kean/Nuke/tree/master/Documentation/Migrations). Switching from another framework? Use a [**Switching Guide**](https://github.com/kean/Nuke/tree/master/Documentation/Switch).
 
-<a href="https://kean.blog/nuke/guides/welcome">
-<img src="https://user-images.githubusercontent.com/1567433/114312077-59259b80-9abf-11eb-93f9-29fb87eb025a.png">
+<a href="https://kean-docs.github.io/nuke/documentation/nuke/getting-started">
+<img width="750" alt="nuke-docs" src="https://user-images.githubusercontent.com/1567433/175789824-d62f1599-1c7a-480f-a823-3db28fb12958.png">
 </a>
 
 <a name="h_plugins"></a>

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -517,31 +517,3 @@ extension ImageRequest {
         }
     }
 }
-
-// MARK: - ImageRequestConvertible
-
-/// Represents a type that can be converted to an ``ImageRequest``.
-public protocol ImageRequestConvertible {
-    /// Returns a request.
-    func asImageRequest() -> ImageRequest
-}
-
-extension ImageRequest: ImageRequestConvertible {
-    public func asImageRequest() -> ImageRequest { self }
-}
-
-extension URL: ImageRequestConvertible {
-    public func asImageRequest() -> ImageRequest { ImageRequest(url: self) }
-}
-
-extension Optional: ImageRequestConvertible where Wrapped == URL {
-    public func asImageRequest() -> ImageRequest { ImageRequest(url: self) }
-}
-
-extension URLRequest: ImageRequestConvertible {
-    public func asImageRequest() -> ImageRequest { ImageRequest(urlRequest: self) }
-}
-
-extension String: ImageRequestConvertible {
-    public func asImageRequest() -> ImageRequest { ImageRequest(url: URL(string: self)) }
-}

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -19,9 +19,6 @@ import Combine
 /// )
 /// let response = try await pipeline.image(for: request)
 /// ```
-///
-/// Most APIs accept any types that conform to ``ImageRequestConvertible``. By
-/// default, it includes `URL`, `URLRequest`, and ``ImageRequest`` itself.
 public struct ImageRequest: CustomStringConvertible, Sendable {
 
     // MARK: Options

--- a/Sources/Nuke/Internal/Deprecated.swift
+++ b/Sources/Nuke/Internal/Deprecated.swift
@@ -101,18 +101,3 @@ extension ImageProcessing where Self == ImageProcessors.Anonymous {
         ImageProcessors.Anonymous(id: id, closure)
     }
 }
-
-extension ImagePipeline.Cache {
-    // Deprecated in Nuke 11.0
-    @available(*, deprecated, message: "Please use variants that accept URL or ImageRequest.")
-    public subscript(request: any ImageRequestConvertible) -> ImageContainer? {
-        get { self[request.asImageRequest()] }
-        nonmutating set { self[request.asImageRequest()] = newValue }
-    }
-
-    // Deprecated in Nuke 11.0
-    @available(*, deprecated, message: "Please use variants that accept URL or ImageRequest.")
-    public func cachedImage(for request: any ImageRequestConvertible, caches: Caches = [.all]) -> ImageContainer? {
-        cachedImage(for: request.asImageRequest(), caches: caches)
-    }
-}

--- a/Sources/Nuke/Internal/Deprecated.swift
+++ b/Sources/Nuke/Internal/Deprecated.swift
@@ -101,3 +101,33 @@ extension ImageProcessing where Self == ImageProcessors.Anonymous {
         ImageProcessors.Anonymous(id: id, closure)
     }
 }
+
+// MARK: - ImageRequestConvertible
+
+/// Represents a type that can be converted to an ``ImageRequest``.
+///
+/// - warning: Soft-deprecated in Nuke 11.0.
+public protocol ImageRequestConvertible {
+    /// Returns a request.
+    func asImageRequest() -> ImageRequest
+}
+
+extension ImageRequest: ImageRequestConvertible {
+    public func asImageRequest() -> ImageRequest { self }
+}
+
+extension URL: ImageRequestConvertible {
+    public func asImageRequest() -> ImageRequest { ImageRequest(url: self) }
+}
+
+extension Optional: ImageRequestConvertible where Wrapped == URL {
+    public func asImageRequest() -> ImageRequest { ImageRequest(url: self) }
+}
+
+extension URLRequest: ImageRequestConvertible {
+    public func asImageRequest() -> ImageRequest { ImageRequest(urlRequest: self) }
+}
+
+extension String: ImageRequestConvertible {
+    public func asImageRequest() -> ImageRequest { ImageRequest(url: URL(string: self)) }
+}

--- a/Sources/Nuke/Internal/Deprecated.swift
+++ b/Sources/Nuke/Internal/Deprecated.swift
@@ -101,3 +101,18 @@ extension ImageProcessing where Self == ImageProcessors.Anonymous {
         ImageProcessors.Anonymous(id: id, closure)
     }
 }
+
+extension ImagePipeline.Cache {
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "Please use variants that accept URL or ImageRequest.")
+    public subscript(request: any ImageRequestConvertible) -> ImageContainer? {
+        get { self[request.asImageRequest()] }
+        nonmutating set { self[request.asImageRequest()] = newValue }
+    }
+
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "Please use variants that accept URL or ImageRequest.")
+    public func cachedImage(for request: any ImageRequestConvertible, caches: Caches = [.all]) -> ImageContainer? {
+        cachedImage(for: request.asImageRequest(), caches: caches)
+    }
+}

--- a/Sources/Nuke/Nuke.docc/Essentials/getting-started.md
+++ b/Sources/Nuke/Nuke.docc/Essentials/getting-started.md
@@ -4,7 +4,7 @@ Learn about main Nuke features and APIs.
 
 ## Image Pipeline
 
-``ImagePipeline`` implements all steps needed to download an image and prepare it for display. You can start by using a shared pipeline and can configure a custom one later if needed. To load an image, use an async method ``ImagePipeline/image(for:delegate:)`` that returns ``ImageResponse`` containing an image.
+``ImagePipeline`` implements all steps needed to download an image and prepare it for display. You can start by using a shared pipeline and can configure a custom one later if needed. To load an image, use an async method ``ImagePipeline/image(for:delegate:)-2v6n0`` that returns ``ImageResponse`` containing an image.
 
 ```swift
 let response = try await ImagePipeline.shared.image(for: url)
@@ -52,8 +52,6 @@ let request = ImageRequest(
 )
 let response = try await pipeline.image(for: request)
 ```
-
-> Most APIs accept types that conform to ``ImageRequestConvertible``. By default, it includes `URL`, `URLRequest`, and ``ImageRequest`` itself.
 
 Set ``ImageRequest/processors`` to apply one of the built-in processors that can be found in ``ImageProcessors`` namespace or a custom one. See <doc:image-processing> for more on image processing.
 

--- a/Sources/Nuke/Nuke.docc/Essentials/getting-started.md
+++ b/Sources/Nuke/Nuke.docc/Essentials/getting-started.md
@@ -4,16 +4,14 @@ Learn about main Nuke features and APIs.
 
 ## Image Pipeline
 
-``ImagePipeline`` implements all steps needed to download an image and prepare it for display. You can start by using a shared pipeline and can configure a custom one later if needed. To load an image, use an async method ``ImagePipeline/image(for:delegate:)-2v6n0`` that returns ``ImageResponse`` containing an image.
+``ImagePipeline`` downloads, caches images, and prepares them for display. To load an image, use an async method ``ImagePipeline/image(for:delegate:)-2v6n0`` that returns ``ImageResponse`` with an image.
 
 ```swift
 let response = try await ImagePipeline.shared.image(for: url)
 let image = response.image
 ```
 
-When you call this method, the pipeline checks if the image exists in any of its cache layers. If there is no cache, the pipeline starts the download. When the data is loaded, it decodes the data, applies the processors, and prepares the image for display by decompressing it.
-
-> `ImagePipeline` also has completion-based and Combine APIs, but the documentation uses Async/Await in most of the examples.
+> ``ImagePipeline`` also has completion-based and Combine APIs, but the documentation uses Async/Await in most of the examples.
 
 You can monitor the request by passing ``ImageTaskDelegate``.
 

--- a/Sources/Nuke/Nuke.docc/Extensions/ImagePipeline-Extension.md
+++ b/Sources/Nuke/Nuke.docc/Extensions/ImagePipeline-Extension.md
@@ -17,7 +17,7 @@ You can customize ``ImagePipeline`` by initializing it with ``ImagePipeline/Conf
 
 ## Loading Images
 
-Use ``ImagePipeline/image(for:delegate:)`` that returns an ``ImageResponse`` containing an image in case of success.
+Use ``ImagePipeline/image(for:delegate:)-2v6n0`` that works with both `URL` and ``ImageRequest`` and returns an ``ImageResponse`` with an image in case of success.
 
 ```swift
 let response = try await ImagePipeline.shared.image(for: url)
@@ -79,14 +79,16 @@ func loadImage() async throws {
 
 ### Loading Images
 
-- ``image(for:delegate:)``
+- ``image(for:delegate:)-9mq8k``
+- ``image(for:delegate:)-2v6n0``
 - ``loadImage(with:completion:)``
 - ``loadImage(with:queue:progress:completion:)``
 - ``imagePublisher(with:)``
 
 ### Loading Data
 
-- ``data(for:)``
+- ``data(for:)-86rhw``
+- ``data(for:)-54h5g``
 - ``loadData(with:completion:)``
 - ``loadData(with:queue:progress:completion:)``
 

--- a/Sources/Nuke/Nuke.docc/Extensions/ImagePipeline-Extension.md
+++ b/Sources/Nuke/Nuke.docc/Extensions/ImagePipeline-Extension.md
@@ -83,7 +83,8 @@ func loadImage() async throws {
 - ``image(for:delegate:)-2v6n0``
 - ``loadImage(with:completion:)``
 - ``loadImage(with:queue:progress:completion:)``
-- ``imagePublisher(with:)``
+- ``imagePublisher(with:)-8j2bd``
+- ``imagePublisher(with:)-3pzm6``
 
 ### Loading Data
 

--- a/Sources/Nuke/Nuke.docc/Performance/Caching/accessing-caches.md
+++ b/Sources/Nuke/Nuke.docc/Performance/Caching/accessing-caches.md
@@ -42,11 +42,9 @@ You can access any caching layer directly, but the pipeline also offers a conven
 
 ### Subscript
 
-You can access memory cache with a subscript.
+You can access memory cache with a subscript that supports both `URL` and ``ImageRequest``.
 
 ```swift
-// It works with ImageRequestConvertible so it supports String, URL,
-// URLRequest, and ImageRequest
 let image = pipeline.cache[URL(string: "https://example.com/image.jpeg")!]
 pipeline.cache[ImageRequest(url: url)] = nil
 pipeline.cache["https://example.com/image.jpeg"] = ImageContainer(image: image)

--- a/Sources/Nuke/Nuke.docc/Performance/prefetching.md
+++ b/Sources/Nuke/Nuke.docc/Performance/prefetching.md
@@ -73,18 +73,11 @@ public final class ImagePrefetcher {
 }
 ```
 
-To start prefetching, call ``ImagePrefetcher/startPrefetching(with:)`` method. When you need the same image later to display it, simply use the ``ImagePipeline`` or view extensions to load the image. The pipeline will take care of coalescing the requests for new without starting any new downloads.
+To start prefetching, call ``ImagePrefetcher/startPrefetching(with:)-718dg`` method. When you need the same image later to display it, simply use the ``ImagePipeline`` or view extensions to load the image. The pipeline will take care of coalescing the requests for new without starting any new downloads:
 
-```swift
-public extension ImagePrefetcher {
-    func startPrefetching(with urls: [URL])
-    func startPrefetching(with requests: [any ImageRequestConvertible])
-
-    func stopPrefetching(with urls: [URL])
-    func stopPrefetching(with requests: [any ImageRequestConvertible])
-    func stopPrefetching()
-}
-```
+- ``ImagePrefetcher/startPrefetching(with:)-718dg``
+- ``ImagePrefetcher/stopPrefetching(with:)-8cdam``
+- ``ImagePrefetcher/stopPrefetching()``
 
 The prefetcher automatically cancels all of the outstanding tasks when deallocated. All ``ImagePrefetcher`` methods are thread-safe and are optimized to be used even from the main thread during scrolling.
 

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -403,7 +403,12 @@ public final class ImagePipeline: @unchecked Sendable {
     // MARK: - Loading Images (Combine)
 
     /// Returns a publisher which starts a new ``ImageTask`` when a subscriber is added.
-    public func imagePublisher(with request: any ImageRequestConvertible) -> AnyPublisher<ImageResponse, Error> {
+    public func imagePublisher(with url: URL) -> AnyPublisher<ImageResponse, Error> {
+        imagePublisher(with: ImageRequest(url: url))
+    }
+
+    /// Returns a publisher which starts a new ``ImageTask`` when a subscriber is added.
+    public func imagePublisher(with request: ImageRequest) -> AnyPublisher<ImageResponse, Error> {
         ImagePublisher(request: request.asImageRequest(), pipeline: self).eraseToAnyPublisher()
     }
 

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -118,7 +118,7 @@ public final class ImagePipeline: @unchecked Sendable {
     ///   is captured as a weak reference and is called on the main queue. You
     ///   can change the callback queue using ``Configuration-swift.struct/callbackQueue``.
     public func image(for url: URL, delegate: ImageTaskDelegate? = nil) async throws -> ImageResponse {
-        try await image(for: ImageRequest(url: url))
+        try await image(for: ImageRequest(url: url), delegate: delegate)
     }
 
     /// Returns an image for the given request.

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -110,6 +110,17 @@ public final class ImagePipeline: @unchecked Sendable {
 
     // MARK: - Loading Images (Async/Await)
 
+    /// Returns an image for the given URL.
+    ///
+    /// - parameters:
+    ///   - request: An image request.
+    ///   - delegate: A delegate for monitoring the request progress. The delegate
+    ///   is captured as a weak reference and is called on the main queue. You
+    ///   can change the callback queue using ``Configuration-swift.struct/callbackQueue``.
+    public func image(for url: URL, delegate: ImageTaskDelegate? = nil) async throws -> ImageResponse {
+        try await image(for: ImageRequest(url: url))
+    }
+
     /// Returns an image for the given request.
     ///
     /// - parameters:
@@ -117,7 +128,7 @@ public final class ImagePipeline: @unchecked Sendable {
     ///   - delegate: A delegate for monitoring the request progress. The delegate
     ///   is captured as a weak reference and is called on the main queue. You
     ///   can change the callback queue using ``Configuration-swift.struct/callbackQueue``.
-    public func image(for request: any ImageRequestConvertible, delegate: ImageTaskDelegate? = nil) async throws -> ImageResponse {
+    public func image(for request: ImageRequest, delegate: ImageTaskDelegate? = nil) async throws -> ImageResponse {
         let task = makeImageTask(request: request, queue: nil)
         task.delegate = delegate
 
@@ -142,11 +153,19 @@ public final class ImagePipeline: @unchecked Sendable {
 
     // MARK: - Loading Data (Async/Await)
 
+    /// Returns image data for the given URL.
+    ///
+    /// - parameter request: An image request.
+    @discardableResult
+    public func data(for url: URL) async throws -> (Data, URLResponse?) {
+        try await data(for: ImageRequest(url: url))
+    }
+
     /// Returns image data for the given request.
     ///
     /// - parameter request: An image request.
     @discardableResult
-    public func data(for request: any ImageRequestConvertible) async throws -> (Data, URLResponse?) {
+    public func data(for request: ImageRequest) async throws -> (Data, URLResponse?) {
         let task = makeImageTask(request: request, queue: nil, isDataTask: true)
         return try await withTaskCancellationHandler(handler: {
             task.cancel()

--- a/Sources/Nuke/Pipeline/ImagePipelineCache.swift
+++ b/Sources/Nuke/Pipeline/ImagePipelineCache.swift
@@ -19,13 +19,14 @@ extension ImagePipeline {
 extension ImagePipeline.Cache {
     // MARK: Subscript (Memory Cache)
 
-    /// Returns an image from the memory cache for the given request.
-    public subscript(request: any ImageRequestConvertible) -> ImageContainer? {
-        get { self[request.asImageRequest()] }
-        nonmutating set { self[request.asImageRequest()] = newValue }
+    /// Returns an image from the memory cache for the given URL.
+    public subscript(url: URL) -> ImageContainer? {
+        get { self[ImageRequest(url: url)] }
+        nonmutating set { self[ImageRequest(url: url)] = newValue }
     }
 
-    subscript(request: ImageRequest) -> ImageContainer? {
+    /// Returns an image from the memory cache for the given request.
+    public subscript(request: ImageRequest) -> ImageContainer? {
         get {
             cachedImageFromMemoryCache(for: request)
         }
@@ -48,7 +49,7 @@ extension ImagePipeline.Cache {
     ///   - request: The request. Make sure to remove the processors if you want
     ///   to retrieve an original image (if it's stored).
     ///   - caches: `[.all]`, by default.
-    public func cachedImage(for request: any ImageRequestConvertible, caches: Caches = [.all]) -> ImageContainer? {
+    public func cachedImage(for request: ImageRequest, caches: Caches = [.all]) -> ImageContainer? {
         let request = request.asImageRequest()
         if caches.contains(.memory) {
             if let image = cachedImageFromMemoryCache(for: request) {
@@ -78,7 +79,7 @@ extension ImagePipeline.Cache {
     ///   - request: The request. Make sure to remove the processors if you want
     ///   to retrieve an original image (if it's stored).
     ///   - caches: `[.all]`, by default.
-    public func storeCachedImage(_ image: ImageContainer, for request: any ImageRequestConvertible, caches: Caches = [.all]) {
+    public func storeCachedImage(_ image: ImageContainer, for request: ImageRequest, caches: Caches = [.all]) {
         let request = request.asImageRequest()
         if caches.contains(.memory) {
             storeCachedImageInMemoryCache(image, for: request)
@@ -91,7 +92,7 @@ extension ImagePipeline.Cache {
     }
 
     /// Removes the image from all caches.
-    public func removeCachedImage(for request: any ImageRequestConvertible, caches: Caches = [.all]) {
+    public func removeCachedImage(for request: ImageRequest, caches: Caches = [.all]) {
         let request = request.asImageRequest()
         if caches.contains(.memory) {
             removeCachedImageFromMemoryCache(for: request)
@@ -102,7 +103,7 @@ extension ImagePipeline.Cache {
     }
 
     /// Returns `true` if any of the caches contain the image.
-    public func containsCachedImage(for request: any ImageRequestConvertible, caches: Caches = [.all]) -> Bool {
+    public func containsCachedImage(for request: ImageRequest, caches: Caches = [.all]) -> Bool {
         let request = request.asImageRequest()
         if caches.contains(.memory) && cachedImageFromMemoryCache(for: request) != nil {
             return true
@@ -147,7 +148,7 @@ extension ImagePipeline.Cache {
     // MARK: Cached Data
 
     /// Returns cached data for the given request.
-    public func cachedData(for request: any ImageRequestConvertible) -> Data? {
+    public func cachedData(for request: ImageRequest) -> Data? {
         let request = request.asImageRequest()
         guard !request.options.contains(.disableDiskCacheReads) else {
             return nil
@@ -163,7 +164,7 @@ extension ImagePipeline.Cache {
     ///
     /// - note: Default ``DataCache`` stores data asynchronously, so it's safe
     /// to call this method even from the main thread.
-    public func storeCachedData(_ data: Data, for request: any ImageRequestConvertible) {
+    public func storeCachedData(_ data: Data, for request: ImageRequest) {
         let request = request.asImageRequest()
         guard let dataCache = dataCache(for: request),
               !request.options.contains(.disableDiskCacheWrites) else {
@@ -174,7 +175,7 @@ extension ImagePipeline.Cache {
     }
 
     /// Returns true if the data cache contains data for the given image
-    public func containsData(for request: any ImageRequestConvertible) -> Bool {
+    public func containsData(for request: ImageRequest) -> Bool {
         let request = request.asImageRequest()
         guard let dataCache = dataCache(for: request) else {
             return false
@@ -183,7 +184,7 @@ extension ImagePipeline.Cache {
     }
 
     /// Removes cached data for the given request.
-    public func removeCachedData(for request: any ImageRequestConvertible) {
+    public func removeCachedData(for request: ImageRequest) {
         let request = request.asImageRequest()
         guard let dataCache = dataCache(for: request) else {
             return
@@ -195,10 +196,6 @@ extension ImagePipeline.Cache {
     // MARK: Keys
 
     /// Returns image cache (memory cache) key for the given request.
-    public func makeImageCacheKey(for request: any ImageRequestConvertible) -> ImageCacheKey {
-        makeImageCacheKey(for: request.asImageRequest())
-    }
-
     func makeImageCacheKey(for request: ImageRequest) -> ImageCacheKey {
         if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
             return ImageCacheKey(key: customKey)
@@ -207,10 +204,6 @@ extension ImagePipeline.Cache {
     }
 
     /// Returns data cache (disk cache) key for the given request.
-    public func makeDataCacheKey(for request: any ImageRequestConvertible) -> String {
-        makeDataCacheKey(for: request.asImageRequest())
-    }
-
     func makeDataCacheKey(for request: ImageRequest) -> String {
         if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
             return customKey

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -84,6 +84,11 @@ public final class ImagePrefetcher: @unchecked Sendable {
         #endif
     }
 
+    /// Starts prefetching images for the given URL.
+    public func startPrefetching(with urls: [URL]) {
+        startPrefetching(with: urls.map { ImageRequest(url: $0) })
+    }
+
     /// Starts prefetching images for the given requests.
     ///
     /// When you need to display the same image later, use the ``ImagePipeline``
@@ -92,7 +97,7 @@ public final class ImagePrefetcher: @unchecked Sendable {
     ///
     /// The priority of the requests is set to the priority of the prefetcher
     /// (`.low` by default).
-    public func startPrefetching(with requests: [any ImageRequestConvertible]) {
+    public func startPrefetching(with requests: [ImageRequest]) {
         pipeline.queue.async {
             for request in requests {
                 var request = request.asImageRequest()
@@ -144,13 +149,19 @@ public final class ImagePrefetcher: @unchecked Sendable {
         }
     }
 
+    /// Stops prefetching images for the given URLs and cancels outstanding
+    /// requests.
+    public func stopPrefetching(with urls: [URL]) {
+        stopPrefetching(with: urls.map { ImageRequest(url: $0) })
+    }
+
     /// Stops prefetching images for the given requests and cancels outstanding
     /// requests.
     ///
     /// You don't need to balance the number of `start` and `stop` requests.
     /// If you have multiple screens with prefetching, create multiple instances
     /// of ``ImagePrefetcher``.
-    public func stopPrefetching(with requests: [any ImageRequestConvertible]) {
+    public func stopPrefetching(with requests: [ImageRequest]) {
         pipeline.queue.async {
             for request in requests {
                 self._stopPrefetching(with: request.asImageRequest())

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -85,6 +85,8 @@ public final class ImagePrefetcher: @unchecked Sendable {
     }
 
     /// Starts prefetching images for the given URL.
+    ///
+    /// See also ``startPrefetching(with:)-718dg`` that works with ``ImageRequest``.
     public func startPrefetching(with urls: [URL]) {
         startPrefetching(with: urls.map { ImageRequest(url: $0) })
     }
@@ -97,6 +99,8 @@ public final class ImagePrefetcher: @unchecked Sendable {
     ///
     /// The priority of the requests is set to the priority of the prefetcher
     /// (`.low` by default).
+    ///
+    /// See also ``startPrefetching(with:)-1jef2`` that works with `URL`.
     public func startPrefetching(with requests: [ImageRequest]) {
         pipeline.queue.async {
             for request in requests {
@@ -151,6 +155,8 @@ public final class ImagePrefetcher: @unchecked Sendable {
 
     /// Stops prefetching images for the given URLs and cancels outstanding
     /// requests.
+    ///
+    /// See also ``stopPrefetching(with:)-8cdam`` that works with ``ImageRequest``.
     public func stopPrefetching(with urls: [URL]) {
         stopPrefetching(with: urls.map { ImageRequest(url: $0) })
     }
@@ -161,6 +167,8 @@ public final class ImagePrefetcher: @unchecked Sendable {
     /// You don't need to balance the number of `start` and `stop` requests.
     /// If you have multiple screens with prefetching, create multiple instances
     /// of ``ImagePrefetcher``.
+    ///
+    /// See also ``stopPrefetching(with:)-2tcyq`` that works with `URL`.
     public func stopPrefetching(with requests: [ImageRequest]) {
         pipeline.queue.async {
             for request in requests {

--- a/Sources/NukeUI/FetchImage.swift
+++ b/Sources/NukeUI/FetchImage.swift
@@ -81,15 +81,20 @@ public final class FetchImage: ObservableObject, Identifiable {
     /// Initialiazes the image. To load an image, use one of the `load()` methods.
     public init() {}
 
-    // MARK: Load (ImageRequestConvertible)
+    // MARK: Loading Images
 
     /// Loads an image with the given request.
-    public func load(_ request: (any ImageRequestConvertible)?) {
+    public func load(_ url: URL?) {
+        load(url.map { ImageRequest(url: $0) })
+    }
+
+    /// Loads an image with the given request.
+    public func load(_ request: ImageRequest?) {
         assert(Thread.isMainThread, "Must be called from the main thread")
 
         reset()
 
-        guard var request = request?.asImageRequest() else {
+        guard var request = request else {
             handle(result: .failure(ImagePipeline.Error.imageRequestMissing))
             return
         }
@@ -139,6 +144,12 @@ public final class FetchImage: ObservableObject, Identifiable {
         )
         imageTask = task
         onStart?(task)
+    }
+
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "Please use load() methods that work either with URL or ImageRequest.")
+    public func load(_ request: (any ImageRequestConvertible)?) {
+        load(request?.asImageRequest())
     }
 
     private func handle(preview: ImageResponse) {

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -68,30 +68,65 @@ public struct LazyImage<Content: View>: View {
     /// Loads and displays an image using ``Image``.
     ///
     /// - Parameters:
-    ///   - source: The image source (`URL`, `URLRequest`, or `ImageRequest`)
-    ///   - resizingMode: `.aspectFill` by default.
-    public init(source: (any ImageRequestConvertible)?, resizingMode: ImageResizingMode = .aspectFill) where Content == Image {
-        self.request = source.map { HashableRequest(request: $0.asImageRequest()) }
+    ///   - url: The image URL.
+    ///   - resizingMode: The displayed image resizing mode.
+    public init(url: URL?, resizingMode: ImageResizingMode = .aspectFill) where Content == Image {
+        self.init(request: url.map { ImageRequest(url: $0) }, resizingMode: resizingMode)
+    }
+
+    /// Loads and displays an image using ``Image``.
+    ///
+    /// - Parameters:
+    ///   - request: The image request.
+    ///   - resizingMode: The displayed image resizing mode.
+    public init(request: ImageRequest?, resizingMode: ImageResizingMode = .aspectFill) where Content == Image {
+        self.request = request.map { HashableRequest(request: $0.asImageRequest()) }
         self.resizingMode = resizingMode
+    }
+
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "Please use init(request:) or init(url).")
+    public init(source: (any ImageRequestConvertible)?, resizingMode: ImageResizingMode = .aspectFill) where Content == Image {
+        self.init(request: source?.asImageRequest(), resizingMode: resizingMode)
     }
 #else
     /// Loads and displays an image using ``Image``.
     ///
     /// - Parameters:
-    ///   - source: The image source (`URL`, `URLRequest`, or `ImageRequest`)
+    ///   - url: The image URL.
+    public init(url: URL?) where Content == Image {
+        self.init(request: url.map { ImageRequest(url: $0) })
+    }
+
+    /// Loads and displays an image using ``Image``.
+    ///
+    /// - Parameters:
+    ///   - request: The image request.
+    public init(request: ImageRequest?) where Content == Image {
+        self.request = source.map { HashableRequest(request: $0) }
+    }
+
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "Please use init(request:) or init(url).")
     public init(source: (any ImageRequestConvertible)?) where Content == Image {
         self.request = source.map { HashableRequest(request: $0.asImageRequest()) }
     }
 #endif
+    /// Loads an images and displays custom content for each state.
+    ///
+    /// See also ``init(request:content:)``
+    public init(url: URL?, @ViewBuilder content: @escaping (LazyImageState) -> Content) {
+        self.init(request: url.map { ImageRequest(url: $0) }, content: content)
+    }
 
     /// Loads an images and displays custom content for each state.
     ///
     /// - Parameters:
-    ///   - source: The image source (`URL`, `URLRequest`, or `ImageRequest`)
+    ///   - request: The image request.
     ///   - content: The view to show for each of the image loading states.
     ///
     /// ```swift
-    /// LazyImage(source: $0) { state in
+    /// LazyImage(request: $0) { state in
     ///     if let image = state.image {
     ///         image // Displays the loaded image.
     ///     } else if state.error != nil {
@@ -101,6 +136,13 @@ public struct LazyImage<Content: View>: View {
     ///     }
     /// }
     /// ```
+    public init(request: ImageRequest?, @ViewBuilder content: @escaping (LazyImageState) -> Content) {
+        self.request = request.map { HashableRequest(request: $0) }
+        self.makeContent = content
+    }
+
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "Please use init(request:) or init(url).")
     public init(source: (any ImageRequestConvertible)?, @ViewBuilder content: @escaping (LazyImageState) -> Content) {
         self.request = source.map { HashableRequest(request: $0.asImageRequest()) }
         self.makeContent = content

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -103,7 +103,7 @@ public struct LazyImage<Content: View>: View {
     /// - Parameters:
     ///   - request: The image request.
     public init(request: ImageRequest?) where Content == Image {
-        self.request = source.map { HashableRequest(request: $0) }
+        self.request = request.map { HashableRequest(request: $0) }
     }
 
     // Deprecated in Nuke 11.0

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -204,13 +204,13 @@ public final class LazyImageView: _PlatformBaseView {
         transition = .fadeIn(duration: 0.33)
     }
 
-    /// Sets the given source and immediately starts the download.
+    /// Sets the given URL and immediately starts the download.
     public var url: URL? {
         get { request?.url }
         set { request = newValue.map { ImageRequest(url: $0) } }
     }
 
-    /// Sets the given source and immediately starts the download.
+    /// Sets the given request and immediately starts the download.
     public var request: ImageRequest? {
         didSet { load(request) }
     }

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -205,8 +205,21 @@ public final class LazyImageView: _PlatformBaseView {
     }
 
     /// Sets the given source and immediately starts the download.
+    public var url: URL? {
+        get { request?.url }
+        set { request = newValue.map { ImageRequest(url: $0) } }
+    }
+
+    /// Sets the given source and immediately starts the download.
+    public var request: ImageRequest? {
+        didSet { load(request) }
+    }
+    ///
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "Please `request` or `url` properties instead")
     public var source: (any ImageRequestConvertible)? {
-        didSet { load(source) }
+        get { request }
+        set { request = newValue?.asImageRequest() }
     }
 
     override public func updateConstraints() {
@@ -236,10 +249,10 @@ public final class LazyImageView: _PlatformBaseView {
         imageTask = nil
     }
 
-    // MARK: Load (ImageRequestConvertible)
+    // MARK: Loading Images
 
     /// Loads an image with the given request.
-    private func load(_ request: (any ImageRequestConvertible)?) {
+    private func load(_ request: ImageRequest?) {
         assert(Thread.isMainThread, "Must be called from the main thread")
 
         cancel()
@@ -250,7 +263,7 @@ public final class LazyImageView: _PlatformBaseView {
             isResetNeeded = true
         }
 
-        guard var request = request?.asImageRequest() else {
+        guard var request = request else {
             handle(result: .failure(ImagePipeline.Error.imageRequestMissing), isSync: true)
             return
         }

--- a/Sources/NukeUI/NukeUI.docc/Extensions/FetchImage-Extensions.md
+++ b/Sources/NukeUI/NukeUI.docc/Extensions/FetchImage-Extensions.md
@@ -58,9 +58,9 @@ struct ImageView: View {
 
 ### Loading Images
 
-- ``load(_:)-1vg63``
+- ``load(_:)-9my9q``
+- ``load(_:)-53ybw``
 - ``load(_:)-6pey2``
-- ``load(_:)-9f9hu``
 - ``cancel()``
 - ``reset()``
 
@@ -91,3 +91,7 @@ struct ImageView: View {
 - ``onSuccess``
 - ``onFailure``
 - ``onCompletion``
+
+### Deprecated
+
+- ``load(_:)-1vg63``

--- a/Sources/NukeUI/NukeUI.docc/Extensions/LazyImage-Extensions.md
+++ b/Sources/NukeUI/NukeUI.docc/Extensions/LazyImage-Extensions.md
@@ -7,7 +7,7 @@ The view is instantiated with a source where a source can be a `URL`, `URLReques
 ```swift
 struct ContainerView: View {
     var body: some View {
-        LazyImage(source: "https://example.com/image.jpeg")
+        LazyImage(url: URL(string: "https://example.com/image.jpeg"))
     }
 }
 ```
@@ -17,7 +17,7 @@ The view is called "lazy" because it loads the image from source only when it ap
 The view doesn't know the size of the image before it downloads it. Thus, you must specify the view size before loading the image. By default, the image will resize preserving the aspect ratio to fill the available space. You can change this behavior by passing a different resizing mode.
 
 ```swift
-LazyImage(source: "https://example.com/image.jpeg", resizingMode: .center)
+LazyImage(url: URL(string: "https://example.com/image.jpeg"), resizingMode: .center)
     .frame(height: 300)
 ```
 
@@ -30,7 +30,7 @@ Until the image loads, the view displays a standard placeholder that fills the a
 You can also specify a custom placeholder, a view to be displayed on failure, or even show a download progress.
 
 ```swift
-LazyImage(source: $0) { state in
+LazyImage(url: $0) { state in
     if let image = state.image {
         image // Displays the loaded image
     } else if state.error != nil {
@@ -44,14 +44,14 @@ LazyImage(source: $0) { state in
 When the image is loaded, it is displayed with a default animation. You can change it using a custom `animation` option.
 
 ```swift
-LazyImage(source: "https://example.com/image.jpeg")
+LazyImage(url: URL(string: "https://example.com/image.jpeg"))
     .animation(nil) // Disable all animations
 ```
 
 You can pass a complete `ImageRequest` as a source, but you can also configure the download via convenience modifiers.
 
 ```swift
-LazyImage(source: "https://example.com/image.jpeg")
+LazyImage(url: URL(string: "https://example.com/image.jpeg"))
     .processors([ImageProcessors.Resize(width: 44)])
     .priority(.high)
     .pipeline(customPipeline)
@@ -62,7 +62,7 @@ LazyImage(source: "https://example.com/image.jpeg")
 You can also monitor the status of the download.
 
 ```swift
-LazyImage(source: "https://example.com/image.jpeg")
+LazyImage(url: URL(string: "https://example.com/image.jpeg"))
     .onStart { print("Task started \($0)") }
     .onProgress { ... }
     .onSuccess { ... }
@@ -73,7 +73,7 @@ LazyImage(source: "https://example.com/image.jpeg")
 And if some API isn't exposed yet, you can always access the underlying `ImageView` instance.
 
 ```swift
-LazyImage(source: "https://example.com/image.jpeg")
+LazyImage(url: URL(string: "https://example.com/image.jpeg"))
     .onCreated { view in 
         view.videoGravity = .resizeAspect
     }

--- a/Sources/NukeUI/NukeUI.docc/Extensions/LazyImage-Extensions.md
+++ b/Sources/NukeUI/NukeUI.docc/Extensions/LazyImage-Extensions.md
@@ -83,8 +83,10 @@ LazyImage(source: "https://example.com/image.jpeg")
 
 ### Initializers
 
-- ``init(source:resizingMode:)``
-- ``init(source:content:)``
+- ``init(url:resizingMode:)``
+- ``init(request:resizingMode:)``
+- ``init(url:content:)``
+- ``init(request:content:)``
 
 ### Accessing Undelying Views
 
@@ -108,3 +110,8 @@ LazyImage(source: "https://example.com/image.jpeg")
 - ``onSuccess(_:)``
 - ``onFailure(_:)``
 - ``onCompletion(_:)``
+
+### Deprecated
+
+- ``init(source:resizingMode:)``
+- ``init(source:content:)``

--- a/Sources/NukeUI/NukeUI.docc/Extensions/LazyImageView-Extensions.md
+++ b/Sources/NukeUI/NukeUI.docc/Extensions/LazyImageView-Extensions.md
@@ -9,6 +9,8 @@
 
 ### Loading Images
 
+- ``url``
+- ``request``
 - ``source``
 - ``cancel()``
 - ``reset()``

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
@@ -231,17 +231,6 @@ class ImagePipelineCacheTests: XCTestCase {
         XCTAssertNil(cache.cachedData(for: Test.request))
     }
 
-    func testGetCachedImageWhenNoDecoder() {
-        // GIVEN
-        pipeline = pipeline.reconfigured {
-            $0.makeImageDecoder = { _ in nil }
-        }
-        cache.storeCachedData(Test.data, for: Test.url)
-
-        // THEN
-        XCTAssertNil(cache.cachedImage(for: Test.url, caches: [.disk]))
-    }
-
     // MARK: Store Cached Image
 
     func testStoreCachedImageMemoryCache() {
@@ -402,7 +391,6 @@ class ImagePipelineCacheTests: XCTestCase {
         // THEN
         XCTAssertNil(cache.cachedImage(for: request))
         XCTAssertNil(memoryCache[cache.makeImageCacheKey(for: request)])
-        XCTAssertNil(memoryCache[cache.makeImageCacheKey(for: Test.url)])
     }
 
     func testRemoveFromDiskCache() {
@@ -416,7 +404,6 @@ class ImagePipelineCacheTests: XCTestCase {
         // THEN
         XCTAssertNil(cache.cachedImage(for: request, caches: [.disk]))
         XCTAssertNil(diskCache.cachedData(for: cache.makeDataCacheKey(for: request)))
-        XCTAssertNil(diskCache.cachedData(for: cache.makeDataCacheKey(for: Test.url)))
     }
 
     func testRemoveFromAllCaches() {
@@ -473,7 +460,12 @@ class ImagePipelineCacheTests: XCTestCase {
 
     func testMakeSureAllAPIsAreAvailable() {
         cache[URL(string: "https://example.com/image.jpeg")!] = nil
-        cache[URLRequest(url: URL(string: "https://example.com/image.jpeg")!)] = nil
         cache[ImageRequest(url: URL(string: "https://example.com/image.jpeg")!)] = nil
+    }
+
+    // Deprecated in Nuke 11.0
+    @available(*, deprecated, message: "")
+    func testDeprecatedSubscript() {
+        cache[URLRequest(url: URL(string: "https://example.com/image.jpeg")!)] = nil
     }
 }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
@@ -462,10 +462,4 @@ class ImagePipelineCacheTests: XCTestCase {
         cache[URL(string: "https://example.com/image.jpeg")!] = nil
         cache[ImageRequest(url: URL(string: "https://example.com/image.jpeg")!)] = nil
     }
-
-    // Deprecated in Nuke 11.0
-    @available(*, deprecated, message: "")
-    func testDeprecatedSubscript() {
-        cache[URLRequest(url: URL(string: "https://example.com/image.jpeg")!)] = nil
-    }
 }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelinePublisherTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelinePublisherTests.swift
@@ -96,10 +96,6 @@ class ImagePipelinePublisherTests: XCTestCase {
         let _ = pipeline.imagePublisher(with: URL(string: "https://example.com/image.jpeg")!)
     }
 
-    func testInitWithURLRequest() {
-        let _ = pipeline.imagePublisher(with: URLRequest(url: URL(string: "https://example.com/image.jpeg")!))
-    }
-
     func testInitWithImageRequest() {
         let _ = pipeline.imagePublisher(with: ImageRequest(url: URL(string: "https://example.com/image.jpeg")))
     }

--- a/Tests/NukeTests/ImagePrefetcherTests.swift
+++ b/Tests/NukeTests/ImagePrefetcherTests.swift
@@ -66,8 +66,8 @@ final class ImagePrefetcherTests: XCTestCase {
         wait()
 
         // THEN image saved in both caches
-        XCTAssertNotNil(pipeline.cache[Test.url])
-        XCTAssertNotNil(pipeline.cache.cachedData(for: Test.url))
+        XCTAssertNotNil(pipeline.cache[Test.request])
+        XCTAssertNotNil(pipeline.cache.cachedData(for: Test.request))
     }
 
     func testStartPrefetchingWithTwoEquivalentURLs() {
@@ -137,8 +137,8 @@ final class ImagePrefetcherTests: XCTestCase {
         wait()
 
         // THEN image saved in both caches
-        XCTAssertNil(pipeline.cache[Test.url])
-        XCTAssertNotNil(pipeline.cache.cachedData(for: Test.url))
+        XCTAssertNil(pipeline.cache[Test.request])
+        XCTAssertNotNil(pipeline.cache.cachedData(for: Test.request))
     }
 
     // MARK: Pause


### PR DESCRIPTION
`ImageRequestConvertible` was originally introduced in [Nuke 9.2](https://github.com/kean/Nuke/releases/tag/9.2.0) to reduce number of versions of the `loadImage(:)` method in code completion, but it's no longer an issue with the new async/await APIs.

`ImageRequestConvertible` is soft-deprecated in Nuke 11. The other soft-deprecated APIs, such as a closure-based `ImagePipeline/loadImage(:)` will continue working with it. The new APIs, such as async/await `ImagePipeline/image(for:)` will work with `URL` and `ImageRequest` which is better for discoverability and performance.

If you are using `ImageRequestConvertible` in your code, consider removing it now. But it won't be officially deprecated until the next major release.
