### PR TITLE
ImageTaskDelegate Concurrency Problem [Feedback Needed]

### DIFF
--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -109,6 +109,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     }
 }
 
+// TODO: rework this
 /// A protocol that defines methods that image pipeline instances call on their
 /// delegates to handle task-level events.
 public protocol ImageTaskDelegate: AnyObject {


### PR DESCRIPTION
## Problem

The new async/await [`image(for:delegate:)`](https://kean-docs.github.io/nuke/documentation/nuke/imagepipeline/image(for:delegate:)) method in unreleased [Nuke 11.0](https://github.com/kean/Nuke/pull/547) has the following signature:

```swift
func image(
    for request: any ImageRequestConvertible,
    delegate: ImageTaskDelegate? = nil
) async throws -> ImageResponse
```

[`ImageTaskDelegate`](https://kean-docs.github.io/nuke/documentation/nuke/imagetaskdelegate) sends task-level events: task created, progress updated, progressive preview produced, etc. The design is inspired by the [async/await API](https://developer.apple.com/documentation/foundation/urlsession/3767352-data) added to `URLSession` in iOS 15.

```swift
public protocol ImageTaskDelegate : AnyObject, Sendable {
    func imageTaskCreated(ImageTask)
    func imageTask(ImageTask, didReceivePreview: ImageResponse)
    func imageTask(ImageTask, didUpdateProgress: ImageTask.Progress)
    // And more...
```

The delegate is captured weakly and its methods are called on the main queue by default, but can be changed using [`callbackQueue`](https://kean-docs.github.io/nuke/documentation/nuke/imagepipeline/configuration-swift.struct/callbackqueue). The problem is that this design doesn't work well with structured concurrency.

**Example**

The delegate is most likely going to be used on the main queue most of the time, e.g. in custom views which are typically @MainActors.

```swift
@MainActor
private final class AsyncImageView: UIView, ImageTaskDelegate {
    private var imageTask: ImageTask?
    private let imageView = _ImageView()

    deinit {
        imageTask?.cancel()
    }

    func loadImage() async throws {
        imageView.image = try await pipeline.image(for: url, delegate: self).image
    }

    // This gets called immediately from `image(for:)` (important! invariant)
    func imageTaskCreated(_ task: ImageTask) {
        self.imageTask = task
    }

    func imageTask(_ task: ImageTask, didReceivePreview response: ImageResponse) {
        imageView.image = response.image // Display progressively decoded preview
    }
}
```

Unfortunately, this code produces the following warning:

<img width="719" alt="Screen Shot 2022-06-27 at 8 15 45 PM" src="https://user-images.githubusercontent.com/1567433/176060477-0372fad6-174e-4e26-899e-76afd4b47f21.png">

## Potential Solutions

### Option 1

Make [`ImageTaskDelegate`](https://kean-docs.github.io/nuke/documentation/nuke/imagetaskdelegate) `@MainActor`. It'll require a few changes to the pipeline, but it's feasible.

Cons:

- The user can no longer configure the callback queue
- [`ImagePipelineDelegate`](https://kean-docs.github.io/nuke/documentation/nuke/imagepipelinedelegate) currently inherits from [`ImageTaskDelegate`](https://kean-docs.github.io/nuke/documentation/nuke/imagetaskdelegate) to allow to monitor all tasks. It can't be `@MainActor`.

There is another problem with this approach. Unfortunately, it breaks the invariant that `imageTaskCreated` is called immediately on the caller's thread and that can lead to logic issues. The way to avoid it is by making [`image(for:delegate:)`](https://kean-docs.github.io/nuke/documentation/nuke/imagepipeline/image(for:delegate:)) itself `@MainActor`, but that's not possible because you should be able to use it from any thread.

![image](https://user-images.githubusercontent.com/1567433/176061282-093f66f9-ea8c-4613-89f0-bcaa40aeda83.png)

### Option 2

Use `nonisolated` when implementing `ImageTaskDelegate` methods. Unfortunately, it requires more code changes on the client side than just this:

![Screen Shot 2022-06-27 at 8 20 42 PM](https://user-images.githubusercontent.com/1567433/176060977-837acc4b-248d-4687-9233-dad90d8eeae8.png)

You can fix it by manually dispatching to the main actor, but it's bad.

```swift
nonisolated func imageTaskCreated(_ task: ImageTask) {
    Task { @MainActor in
        self.imageTask = task
    }
}
```

Unfortunately, it breaks the invariant that `imageTaskCreated` is called immediately on the caller's thread that can lead to logic issues. So this option is not feasible.

### Option 3

Wait until Swift introduced some sort of `@unchecked @MainActor` attribute to ignore these warnings – we know that the code is guaranteed to be called on the main queue.

### Option 4

Completely redesign this API. How?