### PR TITLE
Add DataLoader delegate for easy Pulse integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ Nuke is easy to learn and use thanks to documentation generated using DocC: [**N
 <img width="690" alt="Nuke Docs" src="https://user-images.githubusercontent.com/1567433/175793167-b7e0c557-b887-444f-b18a-57d6f5ecf01a.png">
 </a>
 
-<a name="h_plugins"></a>
+## Integrations
+
+Nuke provides an easy way to integrate [Pulse](https://github.com/kean/Pulse), a network logging framework which is optimized for working with images.
+
+```swift
+(ImagePipeline.shared.configuration.dataLoader as? DataLoader)?.delegate = URLSessionProxyDelegate()
+```
+
 ## Extensions
 
 The image pipeline is easy to customize and extend. Check out the following first-class extensions and packages built by the community.
@@ -48,7 +55,6 @@ The image pipeline is easy to customize and extend. Check out the following firs
 |[**Gifu Plugin**](https://github.com/kean/Nuke-Gifu-Plugin)|Use [Gifu](https://github.com/kaishin/Gifu) to load and display animated GIFs|
 |[**RxNuke**](https://github.com/kean/RxNuke)|[RxSwift](https://github.com/ReactiveX/RxSwift) extensions for Nuke with examples|
 
-<a name="h_requirements"></a>
 ## Minimum Requirements
 
 | Nuke       | Date         | Swift       | Xcode      | Platforms                                     |

--- a/Sources/Nuke/Internal/Deprecated.swift
+++ b/Sources/Nuke/Internal/Deprecated.swift
@@ -122,3 +122,37 @@ extension URLRequest: ImageRequestConvertible {
 extension String: ImageRequestConvertible {
     public func asImageRequest() -> ImageRequest { ImageRequest(url: URL(string: self)) }
 }
+
+// Deprecated in Nuke 11.1
+@available(*, deprecated, message: "Please use `DataLoader/delegate` instead")
+public protocol DataLoaderObserving {
+    func dataLoader(_ loader: DataLoader, urlSession: URLSession, dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent)
+
+    /// Sent when complete statistics information has been collected for the task.
+    func dataLoader(_ loader: DataLoader, urlSession: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics)
+}
+
+@available(*, deprecated, message: "Please use `DataLoader/delegate` instead")
+extension DataLoaderObserving {
+    public func dataLoader(_ loader: DataLoader, urlSession: URLSession, dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent) {
+        // Do nothing
+    }
+
+    public func dataLoader(_ loader: DataLoader, urlSession: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        // Do nothing
+    }
+}
+
+/// Deprecated in Nuke 11.1
+public enum DataTaskEvent {
+    case resumed
+    case receivedResponse(response: URLResponse)
+    case receivedData(data: Data)
+    case completed(error: Error?)
+}
+
+// Deprecated in Nuke 11.1
+protocol _DataLoaderObserving: AnyObject {
+    func dataTask(_ dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent)
+    func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics)
+}

--- a/Sources/Nuke/Loading/DataLoader.swift
+++ b/Sources/Nuke/Loading/DataLoader.swift
@@ -11,6 +11,17 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
 
     public var observer: (any DataLoaderObserving)?
 
+    /// The delegate that gets called for the callbacks handled by the data loader.
+    /// You can use it for observing the events sent by the data loader, but it
+    /// won't affect the requests in any way. For example, you can use it to
+    /// log network requests using [Pulse](https://github.com/kean/Pulse) which
+    /// is optimized to work with images.
+    ///
+    /// - note: The delegate retained.
+    public var delegate: URLSessionDelegate? {
+        didSet { impl.delegate = delegate }
+    }
+
     deinit {
         session.invalidateAndCancel()
 
@@ -20,8 +31,12 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
     }
 
     /// Initializes ``DataLoader`` with the given configuration.
-    /// - parameter configuration: `URLSessionConfiguration.default` with
-    /// `URLCache` with 0 MB memory capacity and 150 MB disk capacity.
+    ///
+    /// - parameters:
+    ///   - configuration: `URLSessionConfiguration.default` with `URLCache` with
+    ///   0 MB memory capacity and 150 MB disk capacity by default.
+    ///   - validate: Validates the response. By default, check if the status
+    ///   code is in the acceptable range (`200..<300`).
     public init(configuration: URLSessionConfiguration = DataLoader.defaultConfiguration,
                 validate: @escaping (URLResponse) -> Swift.Error? = DataLoader.validate) {
         let queue = OperationQueue()
@@ -69,7 +84,7 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
     /// Shared url cached used by a default ``DataLoader``. The cache is
     /// initialized with 0 MB memory capacity and 150 MB disk capacity.
     public static let sharedUrlCache: URLCache = {
-        let diskCapacity = 150 * 1024 * 1024 // 150 MB
+        let diskCapacity = 150 * 1048576 // 150 MB
         #if targetEnvironment(macCatalyst)
         return URLCache(memoryCapacity: 0, diskCapacity: diskCapacity, directory: URL(fileURLWithPath: cachePath))
         #else
@@ -113,6 +128,7 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
 private final class _DataLoader: NSObject, URLSessionDataDelegate {
     var validate: (URLResponse) -> Swift.Error? = DataLoader.validate
     private var handlers = [URLSessionTask: _Handler]()
+    var delegate: URLSessionDelegate?
     weak var observer: (any _DataLoaderObserving)?
 
     /// Loads data with the given request.
@@ -133,10 +149,21 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
 
     // MARK: URLSessionDelegate
 
+#if swift(>=5.7)
+    func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+            (delegate as? URLSessionTaskDelegate)?.urlSession?(session, didCreateTask: task)
+        } else {
+            // Doesn't exist on earlier versions
+        }
+    }
+#endif
+
     func urlSession(_ session: URLSession,
                     dataTask: URLSessionDataTask,
                     didReceive response: URLResponse,
                     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        (delegate as? URLSessionDataDelegate)?.urlSession?(session, dataTask: dataTask, didReceive: response, completionHandler: { _ in })
         send(dataTask, .receivedResponse(response: response))
 
         guard let handler = handlers[dataTask] else {
@@ -152,6 +179,8 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        (delegate as? URLSessionTaskDelegate)?.urlSession?(session, task: task, didCompleteWithError: error)
+
         assert(task is URLSessionDataTask)
         if let dataTask = task as? URLSessionDataTask {
             send(dataTask, .completed(error: error))
@@ -165,12 +194,14 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        (delegate as? URLSessionTaskDelegate)?.urlSession?(session, task: task, didFinishCollecting: metrics)
         observer?.task(task, didFinishCollecting: metrics)
     }
 
     // MARK: URLSessionDataDelegate
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        (delegate as? URLSessionDataDelegate)?.urlSession?(session, dataTask: dataTask, didReceive: data)
         send(dataTask, .receivedData(data: data))
 
         guard let handler = handlers[dataTask], let response = dataTask.response else {

--- a/Sources/Nuke/Loading/DataLoader.swift
+++ b/Sources/Nuke/Loading/DataLoader.swift
@@ -14,9 +14,14 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
 
     /// The delegate that gets called for the callbacks handled by the data loader.
     /// You can use it for observing the events sent by the data loader, but it
-    /// won't affect the requests in any way. For example, you can use it to
-    /// log network requests using [Pulse](https://github.com/kean/Pulse) which
-    /// is optimized to work with images.
+    /// won't affect the requests in any way.
+    ///
+    /// For example, you can use it to log network requests using [Pulse](https://github.com/kean/Pulse)
+    /// which is optimized to work with images.
+    ///
+    /// ```swift
+    /// (ImagePipeline.shared.configuration.dataLoader as? DataLoader)?.delegate = URLSessionProxyDelegate()
+    /// ```
     ///
     /// - note: The delegate retained.
     public var delegate: URLSessionDelegate? {

--- a/Sources/Nuke/Loading/DataLoader.swift
+++ b/Sources/Nuke/Loading/DataLoader.swift
@@ -9,6 +9,7 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
     public let session: URLSession
     private let impl = _DataLoader()
 
+    @available(*, deprecated, message: "Please use `DataLoader/delegate` instead")
     public var observer: (any DataLoaderObserving)?
 
     /// The delegate that gets called for the callbacks handled by the data loader.
@@ -113,10 +114,12 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
 
     // MARK: _DataLoaderObserving
 
+    @available(*, deprecated, message: "Please use `DataLoader/delegate` instead")
     func dataTask(_ dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent) {
         observer?.dataLoader(self, urlSession: session, dataTask: dataTask, didReceiveEvent: event)
     }
 
+    @available(*, deprecated, message: "Please use `DataLoader/delegate` instead")
     func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
         observer?.dataLoader(self, urlSession: session, task: task, didFinishCollecting: metrics)
     }
@@ -226,38 +229,4 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate {
             self.completion = completion
         }
     }
-}
-
-// MARK: - DataLoaderObserving
-
-/// An event send by the data loader.
-public enum DataTaskEvent {
-    case resumed
-    case receivedResponse(response: URLResponse)
-    case receivedData(data: Data)
-    case completed(error: Error?)
-}
-
-/// Allows you to tap into internal events of the data loader. Events are
-/// delivered on the internal serial operation queue.
-public protocol DataLoaderObserving {
-    func dataLoader(_ loader: DataLoader, urlSession: URLSession, dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent)
-
-    /// Sent when complete statistics information has been collected for the task.
-    func dataLoader(_ loader: DataLoader, urlSession: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics)
-}
-
-extension DataLoaderObserving {
-    public func dataLoader(_ loader: DataLoader, urlSession: URLSession, dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent) {
-        // Do nothing
-    }
-
-    public func dataLoader(_ loader: DataLoader, urlSession: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        // Do nothing
-    }
-}
-
-protocol _DataLoaderObserving: AnyObject {
-    func dataTask(_ dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent)
-    func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics)
 }

--- a/Sources/Nuke/Loading/DataLoader.swift
+++ b/Sources/Nuke/Loading/DataLoader.swift
@@ -13,8 +13,7 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
     public var observer: (any DataLoaderObserving)?
 
     /// The delegate that gets called for the callbacks handled by the data loader.
-    /// You can use it for observing the events sent by the data loader, but it
-    /// won't affect the requests in any way.
+    /// You can use it for observing the session events, but can't affect them.
     ///
     /// For example, you can use it to log network requests using [Pulse](https://github.com/kean/Pulse)
     /// which is optimized to work with images.
@@ -23,7 +22,7 @@ public final class DataLoader: DataLoading, _DataLoaderObserving, @unchecked Sen
     /// (ImagePipeline.shared.configuration.dataLoader as? DataLoader)?.delegate = URLSessionProxyDelegate()
     /// ```
     ///
-    /// - note: The delegate retained.
+    /// - note: The delegate is retained.
     public var delegate: URLSessionDelegate? {
         didSet { impl.delegate = delegate }
     }

--- a/Sources/Nuke/Nuke.docc/Customization/LoadingData/loading-data.md
+++ b/Sources/Nuke/Nuke.docc/Customization/LoadingData/loading-data.md
@@ -70,8 +70,3 @@ public class AlamofireDataLoader: Nuke.DataLoading {
 - ``DataLoading``
 - ``DataLoader``
 - ``Cancellable``
-
-### Monitoring Data Events
-
-- ``DataLoaderObserving``
-- ``DataTaskEvent``

--- a/Sources/Nuke/Nuke.docc/Customization/LoadingData/loading-data.md
+++ b/Sources/Nuke/Nuke.docc/Customization/LoadingData/loading-data.md
@@ -12,6 +12,14 @@ The `URLSession` class natively supports the following URL schemes: `data`, `fil
 
 The default ``DataLoader`` works great for most situation, but if you need to provide a custom networking layer, you can using a ``DataLoading`` protocol. See also, [Alamofire Plugin](https://github.com/kean/Nuke-Alamofire-Plugin).
 
+## Monitoring Network Requests
+
+Nuke can be used with [Pulse](https://github.com/kean/Pulse) for monitoring network traffic.
+
+```swift
+(ImagePipeline.shared.configuration.dataLoader as? DataLoader)?.delegate = URLSessionProxyDelegate()
+```
+
 ## Resumable Downloads
 
 If the data task is terminated when the image is partially loaded (either because of a failure or a cancellation), the next load will resume where the previous left off. Resumable downloads require the server to support [HTTP Range Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). Nuke supports both validators: `ETag` and `Last-Modified`. Resumable downloads are enabled by default. You can learn more in ["Resumable Downloads"](https://kean.blog/post/resumable-downloads).

--- a/Sources/Nuke/Nuke.docc/Essentials/getting-started.md
+++ b/Sources/Nuke/Nuke.docc/Essentials/getting-started.md
@@ -75,6 +75,12 @@ ImagePipeline.shared = ImagePipeline(configuration: .withDataCache)
 
 One of the key Nuke's features is performance. It does a lot by default: custom cache layers, coalescing of equivalent requests, resumable HTTP downloads, and more. But there are certain things that the user of the framework can also do to use it more effectively, for example, <doc:prefetching>. To learn more about what you can do to improve image loading performance in your apps, see <doc:performance-guide>.
 
+In order to optimize performance, you need to be able to monitor it. And that's where [Pulse](https://github.com/kean/Pulse) network logging framework comes in handy. It is optimized for working with images and is easy to integrate:
+
+```swift
+(ImagePipeline.shared.configuration.dataLoader as? DataLoader)?.delegate = URLSessionProxyDelegate()
+```
+
 ## NukeUI
 
 **NukeUI** is a module that provides async image views for SwiftUI, UIKit, and AppKit.

--- a/Sources/Nuke/Nuke.docc/Extensions/DataLoader-Extension.md
+++ b/Sources/Nuke/Nuke.docc/Extensions/DataLoader-Extension.md
@@ -1,0 +1,22 @@
+# ``Nuke/DataLoader``
+
+
+## Topics
+
+### Initializers
+
+- ``init(configuration:validate:)``
+
+### Loading Data
+
+- ``loadData(with:didReceiveData:completion:)``
+
+### Observing Events
+
+- ``delegate``
+
+### Deprecated
+
+- ``observer``
+- ``DataLoaderObserving``
+- ``DataTaskEvent``

--- a/Sources/NukeUI/Internal.swift
+++ b/Sources/NukeUI/Internal.swift
@@ -89,6 +89,7 @@ extension NSColor {
 
 #if os(iOS) || os(tvOS)
 extension UIView.ContentMode {
+    // swiftlint:disable:next cyclomatic_complexity
     init(resizingMode: ImageResizingMode) {
         switch resizingMode {
         case .fill: self = .scaleToFill


### PR DESCRIPTION
[Pulse 2.0](https://github.com/kean/Pulse) is optimized for working with images and now is a good time to provide a convenient way to integrate it with Nuke.

- Add `delegate: URLSessionDelegate?` property to `DataLoader` for observing network events
- Deprecated the existing `observer: DataLoaderObserving`

Pulse can now be integrated with a single line of code:

```swift
(ImagePipeline.shared.configuration.dataLoader as? DataLoader)?.delegate = URLSessionProxyDelegate()
```

<img width="619" alt="Screenshot 2022-08-07 at 2 23 30 PM" src="https://user-images.githubusercontent.com/1567433/183307360-e397d52a-e2ef-421a-a391-46f7b850bf77.png">

The [demo project](https://github.com/kean/NukeDemo) was also updated to feature Pulse.

<img width="390" alt="Screenshot 2022-08-07 at 2 23 30 PM" src="https://user-images.githubusercontent.com/1567433/183307371-5c07079a-c7ff-4eb3-9ca2-70a991364fc3.png">


