### PR TITLE
Add isVideoRenderingEnabled property for image

### DIFF
--- a/Sources/NukeUI/Image.swift
+++ b/Sources/NukeUI/Image.swift
@@ -73,7 +73,9 @@ public struct Image: UIViewRepresentable {
         if let resizingMode = self.resizingMode {
             imageView.resizingMode = resizingMode
         }
-        imageView.videoPlayerView.onVideoFinished = onVideoFinished
+		if imageView.isVideoRenderingEnabled {
+			imageView.videoPlayerView.onVideoFinished = onVideoFinished
+		}
         onCreated?(imageView)
         return imageView
     }

--- a/Sources/NukeUI/Image.swift
+++ b/Sources/NukeUI/Image.swift
@@ -18,18 +18,21 @@ public struct Image: NSViewRepresentable {
     let onCreated: ((ImageView) -> Void)?
     var onVideoFinished: (() -> Void)?
     var restartVideo: Bool = false
+	var isVideoRenderingEnabled: Bool = true
 
-    public init(_ image: NSImage) {
-        self.init(ImageContainer(image: image))
+    public init(_ image: NSImage, isVideoRenderingEnabled: Bool = true) {
+        self.init(ImageContainer(image: image), isVideoRenderingEnabled: isVideoRenderingEnabled)
     }
 
-    public init(_ imageContainer: ImageContainer, onCreated: ((ImageView) -> Void)? = nil) {
+	public init(_ imageContainer: ImageContainer, isVideoRenderingEnabled: Bool = true, onCreated: ((ImageView) -> Void)? = nil) {
+		self.isVideoRenderingEnabled = isVideoRenderingEnabled
         self.imageContainer = imageContainer
         self.onCreated = onCreated
     }
 
     public func makeNSView(context: Context) -> ImageView {
-        let view = ImageView()
+		let view = ImageView()
+		view.isVideoRenderingEnabled = isVideoRenderingEnabled
         view.videoPlayerView.onVideoFinished = onVideoFinished
         onCreated?(view)
         return view
@@ -52,18 +55,21 @@ public struct Image: UIViewRepresentable {
     var resizingMode: ImageResizingMode?
     var onVideoFinished: (() -> Void)?
     var restartVideo: Bool = false
+	var isVideoRenderingEnabled: Bool = true
 
-    public init(_ image: UIImage) {
-        self.init(ImageContainer(image: image))
+    public init(_ image: UIImage, isVideoRenderingEnabled: Bool = true) {
+        self.init(ImageContainer(image: image), isVideoRenderingEnabled: isVideoRenderingEnabled)
     }
 
-    public init(_ imageContainer: ImageContainer, onCreated: ((ImageView) -> Void)? = nil) {
+    public init(_ imageContainer: ImageContainer, isVideoRenderingEnabled: Bool = true, onCreated: ((ImageView) -> Void)? = nil) {
+		self.isVideoRenderingEnabled = isVideoRenderingEnabled
         self.imageContainer = imageContainer
         self.onCreated = onCreated
     }
 
     public func makeUIView(context: Context) -> ImageView {
-        let imageView = ImageView()
+		let imageView = ImageView()
+		imageView.isVideoRenderingEnabled = isVideoRenderingEnabled
         if let resizingMode = self.resizingMode {
             imageView.resizingMode = resizingMode
         }

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -254,7 +254,7 @@ public struct LazyImage<Content: View>: View {
 
     @ViewBuilder private var content: some View {
         if let makeContent = makeContent {
-            makeContent(LazyImageState(model))
+			makeContent(LazyImageState(model, isVideoRenderingEnabled: isVideoRenderingEnabled))
         } else {
             makeDefaultContent()
         }

--- a/Sources/NukeUI/LazyImageState.swift
+++ b/Sources/NukeUI/LazyImageState.swift
@@ -24,11 +24,11 @@ public struct LazyImageState {
     @MainActor
     public var image: Image? {
 #if os(macOS)
-        return imageContainer.map { Image($0) }
+        return imageContainer.map { Image($0, isVideoRenderingEnabled: isVideoRenderingEnabled) }
 #elseif os(watchOS)
-        return imageContainer.map { Image(uiImage: $0.image) }
+        return imageContainer.map { Image(uiImage: $0.image, isVideoRenderingEnabled: isVideoRenderingEnabled) }
 #else
-        return imageContainer.map { Image($0) }
+        return imageContainer.map { Image($0, isVideoRenderingEnabled: isVideoRenderingEnabled) }
 #endif
     }
 
@@ -45,11 +45,14 @@ public struct LazyImageState {
     /// The progress of the image download.
     public let progress: ImageTask.Progress
 
+	private let isVideoRenderingEnabled: Bool
+
     @MainActor
-    init(_ fetchImage: FetchImage) {
+	init(_ fetchImage: FetchImage, isVideoRenderingEnabled: Bool) {
         self.result = fetchImage.result
         self.imageContainer = fetchImage.imageContainer
         self.isLoading = fetchImage.isLoading
         self.progress = fetchImage.progress
+		self.isVideoRenderingEnabled = isVideoRenderingEnabled
     }
 }


### PR DESCRIPTION
Currently LazyImage always creates an AVPlayer, as there is no way to set the isVideoRenderingEnabled property to it.
This pull request adds a isVideoRenderingEnabled parameter to LazyImage and does not initialize AVPlayer instances if it is set to false.