### PR TITLE
Update example code for LazyImageView

### DIFF
--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -22,7 +22,7 @@ import UIKit
 /// imageView.placeholderView = UIActivityIndicatorView()
 /// imageView.priority = .high
 /// imageView.pipeline = customPipeline
-/// imageView.onCompletion = { print("Request completed")
+/// imageView.onCompletion = { print("Request completed") }
 ///
 /// imageView.url = URL(string: "https://example.com/image.jpeg")
 /// ````

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -22,7 +22,7 @@ import UIKit
 /// imageView.placeholderView = UIActivityIndicatorView()
 /// imageView.priority = .high
 /// imageView.pipeline = customPipeline
-/// imageView.onCompletion = { print("Request completed") }
+/// imageView.onCompletion = { _ in print("Request completed") }
 ///
 /// imageView.url = URL(string: "https://example.com/image.jpeg")
 /// ````

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -24,7 +24,7 @@ import UIKit
 /// imageView.pipeline = customPipeline
 /// imageView.onCompletion = { print("Request completed")
 ///
-/// imageView.source = "https://example.com/image.jpeg"
+/// imageView.url = URL(string: "https://example.com/image.jpeg")
 /// ````
 @MainActor
 public final class LazyImageView: _PlatformBaseView {


### PR DESCRIPTION
The example code for LazyImageView in the documentation still used the deprecated `source` attribute. This is a small fix to use the `url` attribute instead.

In the process of creating this PR I also came across two minor issues with the `onCompletion` closure, so I fixed those as well.