### PR TITLE
Show placeholder view of LazyImageView by default

### DIFF
--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -161,7 +161,6 @@ public final class LazyImageView: _PlatformBaseView {
     // MARK: Private
 
     private var isResetNeeded = false
-    private var isDisplayingContent = false
 
     // MARK: Initializers
 
@@ -180,6 +179,7 @@ public final class LazyImageView: _PlatformBaseView {
     }
 
     private func didInit() {
+        imageView.isHidden = true
         addSubview(imageView)
         imageView.pinToSuperview()
 
@@ -239,7 +239,6 @@ public final class LazyImageView: _PlatformBaseView {
         setPlaceholderViewHidden(true)
         setFailureViewHidden(true)
 
-        isDisplayingContent = false
         isResetNeeded = false
     }
 
@@ -345,9 +344,6 @@ public final class LazyImageView: _PlatformBaseView {
         if !isFromMemory, let transition = transition {
             runTransition(transition, container)
         }
-
-        // It's used to determine when to perform certain transitions
-        isDisplayingContent = true
     }
 
     // MARK: Private (Placeholder View)
@@ -369,7 +365,7 @@ public final class LazyImageView: _PlatformBaseView {
             oldView.removeFromSuperview()
         }
         if let newView = newView {
-            newView.isHidden = true
+            newView.isHidden = !imageView.isHidden
             insertSubview(newView, at: 0)
             setNeedsUpdateConstraints()
 #if os(iOS) || os(tvOS)
@@ -429,7 +425,7 @@ public final class LazyImageView: _PlatformBaseView {
 #if os(iOS) || os(tvOS)
 
     private func runFadeInTransition(duration: TimeInterval) {
-        guard !isDisplayingContent else { return }
+        guard !imageView.isHidden else { return }
         imageView.alpha = 0
         UIView.animate(withDuration: duration, delay: 0, options: [.allowUserInteraction]) {
             self.imageView.alpha = 1
@@ -439,7 +435,7 @@ public final class LazyImageView: _PlatformBaseView {
 #elseif os(macOS)
 
     private func runFadeInTransition(duration: TimeInterval) {
-        guard !isDisplayingContent else { return }
+        guard !imageView.isHidden else { return }
         imageView.layer?.animateOpacity(duration: duration)
     }
 


### PR DESCRIPTION
The placeholder view of a LazyImageView was hidden by default. The view is unhidden by the `load()` method, causing the placeholder to appear. However, that assumes that the loading process is started in the first place, which may not always be the case. Consider this example:

```swift
let imageView = LazyImageView()
imageView.url = item.imageURL // may be nil, depending on my data
```

When `item.imageURL` is nil, a request is never started, and therefore the placeholder view will never be unhidden.

With this PR, placeholder views are no longer always hidden when set, but instead this now depends on whether an image is already visible. If it is, the placeholder view will still be hidden, but if it isn't, the placeholder view will be visible.

Additionally, the `imageView` itself is now hidden by default. This mirrors the state that the view is in after calling `reset()`. This ensures that `imageView.isHidden` always gives us a reliable way to know if an image is being shown or not.

Lastly, because `imageView.isHidden` can now be used to evaluate whether an image is being displayed, the dedicated `isDisplayingContent` property is no longer needed, so I replaced it with `!imageView.isHidden`.

An alternative implementation would be to keep the `isDisplayingContent` property around, and also use that to determine whether or not to hide the placeholder view when it's being set. However, the comments seemed to hint that this property was only intended for a limited use case. Additionally, this implementation seemed cleaner, as it avoids the use of a separate property to keep track of state. But if using `isDisplayingContent` is actually preferred, let me know and I can rewrite.
