### PR TITLE
Add support for loading image into TVPosterView

### DIFF
--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -70,6 +70,17 @@ extension NSImageView: Nuke_ImageDisplaying {
 }
 #endif
 
+#if os(tvOS)
+import TVUIKit
+
+extension TVPosterView: Nuke_ImageDisplaying {
+    /// Displays an image.
+    open func nuke_display(image: UIImage?, data: Data? = nil) {
+        self.image = image
+    }
+}
+#endif
+
 // MARK: - ImageView Extensions
 
 /// Loads an image with the given request and displays it in the view.

--- a/Tests/NukeExtensionsTests/ImageViewExtensionsTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewExtensionsTests.swift
@@ -3,6 +3,9 @@
 // Copyright (c) 2015-2022 Alexander Grebenyuk (github.com/kean).
 
 import XCTest
+#if os(tvOS)
+import TVUIKit
+#endif
 @testable import Nuke
 @testable import NukeExtensions
 
@@ -50,6 +53,20 @@ class ImageViewExtensionsTests: XCTestCase {
         // Expect the image to be downloaded and displayed
         XCTAssertNotNil(imageView.image)
     }
+
+    #if os(tvOS)
+    func testImageLoadedToTVPosterView() {
+        // Use local instance for this tvOS specific test for simplicity
+        let posterView = TVPosterView()
+
+        // When requesting an image with request
+        expectToLoadImage(with: Test.request, into: posterView)
+        wait()
+
+        // Expect the image to be downloaded and displayed
+        XCTAssertNotNil(posterView.image)
+    }
+    #endif
 
     func testImageLoadedWithURL() {
         // When requesting an image with URL


### PR DESCRIPTION
`TVPosterView` now supports loading image using Nuke out-of-the-box (`TVPosterView` now conforms to `Nuke_ImageDisplaying`).

`TVPosterView` is a crucial UI component on tvOS.
While it is easy to add this conformance in your project, imho it is nice to have it out of the box in the library.

---

In my specific case, having it directly in the library is actually the only way to make my whole project to compile.

Custom conformance in my project worked fine with Nuke v. 10, but since update to v. 11 (which moves these extensions to `NukeExtensions`), using custom extension will no longer compile.

I guess it is caused by how Swift access control works + specific setup of my project (private frameworks with multi-level hierarchy + Nuke hidden privately in one of private frameworks under custom wrapper interface).

---

Thanks a lot for considering my change.
And big thanks for your time and effort on this amazing library! 🙂