### PR TITLE
Allow configuration of `CALayer` frame animations of the `VideoPlayerView`

### DIFF
--- a/Sources/NukeUI/Image.swift
+++ b/Sources/NukeUI/Image.swift
@@ -18,6 +18,7 @@ public struct Image: NSViewRepresentable {
     let onCreated: ((ImageView) -> Void)?
     var isAnimatedImageRenderingEnabled: Bool?
     var isVideoRenderingEnabled: Bool?
+    var isVideoFrameAnimationEnabled: Bool?
     var isVideoLooping: Bool?
     var resizingMode: ImageResizingMode?
 

--- a/Sources/NukeUI/Image.swift
+++ b/Sources/NukeUI/Image.swift
@@ -48,6 +48,7 @@ public struct Image: UIViewRepresentable {
     let onCreated: ((ImageView) -> Void)?
     var isAnimatedImageRenderingEnabled: Bool?
     var isVideoRenderingEnabled: Bool?
+    var isVideoFrameAnimationEnabled: Bool?
     var isVideoLooping: Bool?
     var resizingMode: ImageResizingMode?
 
@@ -80,6 +81,7 @@ extension Image {
         }
         if let value = resizingMode { imageView.resizingMode = value }
         if let value = isVideoRenderingEnabled { imageView.isVideoRenderingEnabled = value }
+        if let value = isVideoFrameAnimationEnabled { imageView.isVideoFrameAnimationEnabled = value }
         if let value = isAnimatedImageRenderingEnabled { imageView.isAnimatedImageRenderingEnabled = value }
         if let value = isVideoLooping { imageView.isVideoLooping = value }
     }
@@ -100,6 +102,12 @@ extension Image {
     public func videoLoopingEnabled(_ isEnabled: Bool) -> Self {
         var copy = self
         copy.isVideoLooping = isEnabled
+        return copy
+    }
+
+    public func videoFrameAnimationEnabled(_ isEnabled: Bool) -> Self {
+        var copy = self
+        copy.isVideoFrameAnimationEnabled = isEnabled
         return copy
     }
 

--- a/Sources/NukeUI/ImageView.swift
+++ b/Sources/NukeUI/ImageView.swift
@@ -102,6 +102,13 @@ public class ImageView: _PlatformBaseView {
     /// `true` by default. Set to `true` to enable video support.
     public var isVideoRenderingEnabled = true
 
+    /// `true` by default. If disabled, the video will resize with the frame without animations
+    public var isVideoFrameAnimationEnabled = true {
+        didSet {
+            _videoPlayerView?.animatesFrameChanges = isVideoFrameAnimationEnabled
+        }
+    }
+
     // MARK: Initializers
 
     override public init(frame: CGRect) {
@@ -172,6 +179,7 @@ public class ImageView: _PlatformBaseView {
         if isVideoRenderingEnabled, let asset = container.asset {
             videoPlayerView.isHidden = false
             videoPlayerView.isLooping = isVideoLooping
+            videoPlayerView.animatesFrameChanges = isVideoFrameAnimationEnabled
             videoPlayerView.asset = asset
             videoPlayerView.play()
             return

--- a/Sources/NukeUI/VideoPlayerView.swift
+++ b/Sources/NukeUI/VideoPlayerView.swift
@@ -18,6 +18,9 @@ public final class VideoPlayerView: _PlatformBaseView {
         }
     }
 
+    /// `true` by default. If disabled, the video will resize with the frame without animations
+    public var animatesFrameChanges = true
+
     /// `true` by default. If disabled, will only play a video once.
     public var isLooping = true {
         didSet {
@@ -57,13 +60,19 @@ public final class VideoPlayerView: _PlatformBaseView {
     override public func layoutSubviews() {
         super.layoutSubviews()
 
+        CATransaction.begin()
+        CATransaction.setDisableActions(!animatesFrameChanges)
         _playerLayer?.frame = bounds
+        CATransaction.commit()
     }
     #elseif os(macOS)
     override public func layout() {
         super.layout()
 
+        CATransaction.begin()
+        CATransaction.setDisableActions(!animatesFrameChanges)
         _playerLayer?.frame = bounds
+        CATransaction.commit()
     }
 #endif
 


### PR DESCRIPTION
# Summary

Changing the frame of a `LazyImage` that is rendering a video leads to an undesired animation while the `AVPlayerLayer` that drives `VideoPlayerView` is resized to its containing view. In changes here, I've added a configuration to disable the implicit animation associated with updating that layer's frame.

<details>
<summary>Reproducing sample project</summary>

```swift
import NukeUI
import SwiftUI

@main
struct Application: App {
    var body: some Scene {
        WindowGroup {
            ContentView()
        }
    }
}


struct ContentView: View {
    let url = URL(string: "https://media.tenor.com/o656qFKDzeUAAAPo/rick-astley-never-gonna-give-you-up.mp4")!

    @State var scale: CGFloat = 0

    var body: some View {
        VStack {
            let size = (scale + 1) * 150
            LazyImage(url: url) { state in
                state.image
            }
            .frame(width: size, height: size)
            .padding()
            .background(.yellow, in: RoundedRectangle(cornerRadius: 8, style: .continuous))

            Spacer()

            Slider(value: $scale, in: 0...1)
        }
        .padding()
    }
}
```
</details>

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

```swift
LazyImage(url: url) { state in
  state.image
}
```
</td>
<td>

```swift
LazyImage(url: url) { state in
  state.image?
    .videoFrameAnimationEnabled(false)
}
```
</td>
</tr>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/4276827/202251976-855ae4d3-4dd4-4f53-bfbe-aefa8d65d409.mp4" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/4276827/202252221-2b9fd525-7843-466f-b958-543f75fe3ece.mp4" />
</td>
</tr>
</table>


---

# Other notes

I couldn't find any contributing guidelines, so let me know if I've missed a step or two in surfacing this issue and suggesting changes.
