### PR TITLE
`didComplete` edge cases.

### DIFF
--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -126,7 +126,7 @@ public final class ImagePrefetcher: @unchecked Sendable {
 
         let key = request.makeImageLoadKey()
         guard tasks[key] == nil else {
-            return false// Already started prefetching
+            return true// Already started prefetching
         }
 
         let task = Task(request: request, key: key)


### PR DESCRIPTION
Call `didComplete` even when images are cached or when tried to prefetch empty list.
@kean sorry, seems to be fixed now + handled edge case when tried to load empty list.