### PR TITLE
Fully deprecate previously soft-deprecated ImageRequestConvertible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,18 @@ jobs:
           Scripts/test.sh -s "Nuke" -d "OS=16.1,name=Apple TV"
           Scripts/test.sh -s "NukeUI" -d "OS=16.1,name=Apple TV"
           Scripts/test.sh -s "Nuke Extensions" -d "OS=16.1,name=Apple TV"
-  watchos-latest:
-    name: Unit Tests (watchOS 9.1, Xcode 14.1)
-    runs-on: macOS-12
-    env: 
-      DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Tests
-        run: |
-          Scripts/test.sh -s "Nuke" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
-          Scripts/test.sh -s "NukeUI" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
-          Scripts/test.sh -s "Nuke Extensions" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
+#  watchos-latest:
+#    name: Unit Tests (watchOS 9.1, Xcode 14.1)
+#    runs-on: macOS-12
+#    env: 
+#      DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Run Tests
+#        run: |
+#          Scripts/test.sh -s "Nuke" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
+#          Scripts/test.sh -s "NukeUI" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
+#          Scripts/test.sh -s "Nuke Extensions" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
   ios-xcode-13:
     name: Unit Tests (iOS 15.5, Xcode 13.4.1)
     runs-on: macOS-12

--- a/Sources/Nuke/Internal/Deprecated.swift
+++ b/Sources/Nuke/Internal/Deprecated.swift
@@ -93,32 +93,34 @@ extension ImagePipeline.Configuration {
     public typealias DataCachePolicy = ImagePipeline.DataCachePolicy
 }
 
-// MARK: - ImageRequestConvertible
-
-/// Represents a type that can be converted to an ``ImageRequest``.
-///
-/// - warning: Soft-deprecated in Nuke 11.0.
+/// Deprecated in Nuke 11.6. (Soft-deprecated in Nuke 11.0).
+@available(*, deprecated, message: "Please use ImageRequest or URL directrly`")
 public protocol ImageRequestConvertible {
     /// Returns a request.
     func asImageRequest() -> ImageRequest
 }
 
+@available(*, deprecated, message: "Please use ImageRequest or URL directrly`")
 extension ImageRequest: ImageRequestConvertible {
     public func asImageRequest() -> ImageRequest { self }
 }
 
+@available(*, deprecated, message: "Please use ImageRequest or URL directrly`")
 extension URL: ImageRequestConvertible {
     public func asImageRequest() -> ImageRequest { ImageRequest(url: self) }
 }
 
+@available(*, deprecated, message: "Please use ImageRequest or URL directrly`")
 extension Optional: ImageRequestConvertible where Wrapped == URL {
     public func asImageRequest() -> ImageRequest { ImageRequest(url: self) }
 }
 
+@available(*, deprecated, message: "Please use ImageRequest or URL directrly`")
 extension URLRequest: ImageRequestConvertible {
     public func asImageRequest() -> ImageRequest { ImageRequest(urlRequest: self) }
 }
 
+@available(*, deprecated, message: "Please use ImageRequest or URL directrly`")
 extension String: ImageRequestConvertible {
     public func asImageRequest() -> ImageRequest { ImageRequest(url: URL(string: self)) }
 }
@@ -155,4 +157,44 @@ public enum DataTaskEvent {
 protocol _DataLoaderObserving: AnyObject {
     func dataTask(_ dataTask: URLSessionDataTask, didReceiveEvent event: DataTaskEvent)
     func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics)
+}
+
+extension ImagePipeline {
+    @available(*, deprecated, message: "Please use either `loadData` that accepts `ImageRequest` as a parameter or, preferably, the new async/await APIs")
+    @discardableResult public func loadData(
+        with request: any ImageRequestConvertible,
+        completion: @escaping (Result<(data: Data, response: URLResponse?), Error>) -> Void
+    ) -> ImageTask {
+        loadData(with: request.asImageRequest(), queue: nil, progress: nil, completion: completion)
+    }
+
+    @available(*, deprecated, message: "Please use either `loadData` that accepts `ImageRequest` as a parameter or, preferably, the new async/await APIs")
+    @discardableResult public func loadData(
+        with request: any ImageRequestConvertible,
+        queue: DispatchQueue? = nil,
+        progress: ((_ completed: Int64, _ total: Int64) -> Void)?,
+        completion: @escaping (Result<(data: Data, response: URLResponse?), Error>) -> Void
+    ) -> ImageTask {
+        loadData(with: request.asImageRequest(), isConfined: false, queue: queue, progress: progress, completion: completion)
+    }
+
+    @available(*, deprecated, message: "Please use either `loadImage` that accepts `ImageRequest` as a parameter or, preferably, the new async/await APIs")
+    @discardableResult public func loadImage(
+        with request: any ImageRequestConvertible,
+        completion: @escaping (_ result: Result<ImageResponse, Error>) -> Void
+    ) -> ImageTask {
+        loadImage(with: request.asImageRequest(), queue: nil, progress: nil, completion: completion)
+    }
+
+    @available(*, deprecated, message: "Please use either `loadImage` that accepts `ImageRequest` as a parameter or, preferably, the new async/await APIs")
+    @discardableResult public func loadImage(
+        with request: any ImageRequestConvertible,
+        queue: DispatchQueue? = nil,
+        progress: ((_ response: ImageResponse?, _ completed: Int64, _ total: Int64) -> Void)?,
+        completion: @escaping (_ result: Result<ImageResponse, Error>) -> Void
+    ) -> ImageTask {
+        loadImage(with: request.asImageRequest(), isConfined: false, queue: queue, progress: {
+            progress?($0, $1.completed, $1.total)
+        }, completion: completion)
+    }
 }

--- a/Sources/Nuke/Nuke.docc/Extensions/ImagePipeline-Extension.md
+++ b/Sources/Nuke/Nuke.docc/Extensions/ImagePipeline-Extension.md
@@ -125,21 +125,29 @@ Every image preview goes through the same processing and decompression phases th
 - ``configuration-swift.property``
 - ``Configuration-swift.struct``
 
-### Loading Images
+### Loading Images (Async/Await)
 
 - ``image(for:delegate:)-9mq8k``
 - ``image(for:delegate:)-2v6n0``
-- ``loadImage(with:completion:)``
-- ``loadImage(with:queue:progress:completion:)``
+
+### Loading Images (Combine)
+
 - ``imagePublisher(with:)-8j2bd``
 - ``imagePublisher(with:)-3pzm6``
+
+### Loading Images (Closures)
+
+- ``loadImage(with:completion:)-6q74f``
+- ``loadImage(with:completion:)-43osv``
+- ``loadImage(with:queue:progress:completion:)-83u7i``
 
 ### Loading Data
 
 - ``data(for:)-86rhw``
 - ``data(for:)-54h5g``
-- ``loadData(with:completion:)``
-- ``loadData(with:queue:progress:completion:)``
+- ``loadData(with:completion:)-815rt``
+- ``loadData(with:completion:)-6cwk3``
+- ``loadData(with:queue:progress:completion:)-3ibfw``
 
 ### Accessing Cached Images
 
@@ -153,3 +161,10 @@ Every image preview goes through the same processing and decompression phases th
 ### Error Handling
 
 - ``Error``
+
+### Deprecated
+
+- ``loadImage(with:completion:)-6zpbm``
+- ``loadImage(with:queue:progress:completion:)-4thmv``
+- ``loadData(with:completion:)-4iiji``
+- ``loadData(with:queue:progress:completion:)-4j70q``

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -206,6 +206,19 @@ public final class ImagePipeline: @unchecked Sendable {
     ///   - completion: A closure to be called on the main thread when the request
     ///   is finished.
     @discardableResult public func loadImage(
+        with url: URL,
+        completion: @escaping (_ result: Result<ImageResponse, Error>) -> Void
+    ) -> ImageTask {
+        loadImage(with: ImageRequest(url: url), queue: nil, progress: nil, completion: completion)
+    }
+
+    /// Loads an image for the given request.
+    ///
+    /// - parameters:
+    ///   - request: An image request.
+    ///   - completion: A closure to be called on the main thread when the request
+    ///   is finished.
+    @discardableResult public func loadImage(
         with request: ImageRequest,
         completion: @escaping (_ result: Result<ImageResponse, Error>) -> Void
     ) -> ImageTask {
@@ -323,6 +336,15 @@ public final class ImagePipeline: @unchecked Sendable {
     }
 
     // MARK: - Loading Data (Closures)
+
+    /// Loads image data for the given request. The data doesn't get decoded
+    /// or processed in any other way.
+    @discardableResult public func loadData(
+        with url: URL,
+        completion: @escaping (Result<(data: Data, response: URLResponse?), Error>) -> Void
+    ) -> ImageTask {
+        loadData(with: ImageRequest(url: url), queue: nil, progress: nil, completion: completion)
+    }
 
     /// Loads image data for the given request. The data doesn't get decoded
     /// or processed in any other way.

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -206,7 +206,7 @@ public final class ImagePipeline: @unchecked Sendable {
     ///   - completion: A closure to be called on the main thread when the request
     ///   is finished.
     @discardableResult public func loadImage(
-        with request: any ImageRequestConvertible,
+        with request: ImageRequest,
         completion: @escaping (_ result: Result<ImageResponse, Error>) -> Void
     ) -> ImageTask {
         loadImage(with: request, queue: nil, progress: nil, completion: completion)
@@ -223,7 +223,7 @@ public final class ImagePipeline: @unchecked Sendable {
     ///   - completion: A closure to be called on the main thread when the request
     ///   is finished.
     @discardableResult public func loadImage(
-        with request: any ImageRequestConvertible,
+        with request: ImageRequest,
         queue: DispatchQueue? = nil,
         progress: ((_ response: ImageResponse?, _ completed: Int64, _ total: Int64) -> Void)?,
         completion: @escaping (_ result: Result<ImageResponse, Error>) -> Void
@@ -234,13 +234,13 @@ public final class ImagePipeline: @unchecked Sendable {
     }
 
     func loadImage(
-        with request: any ImageRequestConvertible,
+        with request: ImageRequest,
         isConfined: Bool,
         queue callbackQueue: DispatchQueue?,
         progress: ((ImageResponse?, ImageTask.Progress) -> Void)?,
         completion: @escaping (Result<ImageResponse, Error>) -> Void
     ) -> ImageTask {
-        let task = makeImageTask(request: request.asImageRequest(), queue: callbackQueue)
+        let task = makeImageTask(request: request, queue: callbackQueue)
         delegate.imageTaskCreated(task)
         func start() {
             startImageTask(task, progress: progress, completion: completion)
@@ -327,7 +327,7 @@ public final class ImagePipeline: @unchecked Sendable {
     /// Loads image data for the given request. The data doesn't get decoded
     /// or processed in any other way.
     @discardableResult public func loadData(
-        with request: any ImageRequestConvertible,
+        with request: ImageRequest,
         completion: @escaping (Result<(data: Data, response: URLResponse?), Error>) -> Void
     ) -> ImageTask {
         loadData(with: request, queue: nil, progress: nil, completion: completion)
@@ -347,7 +347,7 @@ public final class ImagePipeline: @unchecked Sendable {
     ///   - progress: A closure to be called periodically on the main thread when the progress is updated.
     ///   - completion: A closure to be called on the main thread when the request is finished.
     @discardableResult public func loadData(
-        with request: any ImageRequestConvertible,
+        with request: ImageRequest,
         queue: DispatchQueue? = nil,
         progress: ((_ completed: Int64, _ total: Int64) -> Void)?,
         completion: @escaping (Result<(data: Data, response: URLResponse?), Error>) -> Void
@@ -356,13 +356,13 @@ public final class ImagePipeline: @unchecked Sendable {
     }
 
     func loadData(
-        with request: any ImageRequestConvertible,
+        with request: ImageRequest,
         isConfined: Bool,
         queue: DispatchQueue?,
         progress: ((_ completed: Int64, _ total: Int64) -> Void)?,
         completion: @escaping (Result<(data: Data, response: URLResponse?), Error>) -> Void
     ) -> ImageTask {
-        let task = makeImageTask(request: request.asImageRequest(), queue: queue, isDataTask: true)
+        let task = makeImageTask(request: request, queue: queue, isDataTask: true)
         func start() {
             startDataTask(task, progress: progress, completion: completion)
         }

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -358,8 +358,8 @@ public final class ImagePipeline: @unchecked Sendable {
     /// Loads the image data for the given request. The data doesn't get decoded
     /// or processed in any other way.
     ///
-    /// You can call ``loadImage(with:completion:)`` for the request at any point after calling
-    /// ``loadData(with:completion:)``, the pipeline will use the same operation to load the data,
+    /// You can call ``loadImage(with:completion:)-43osv`` for the request at any point after calling
+    /// ``loadData(with:completion:)-6cwk3``, the pipeline will use the same operation to load the data,
     /// no duplicated work will be performed.
     ///
     /// - parameters:

--- a/Sources/Nuke/Pipeline/ImagePipelineConfiguration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipelineConfiguration.swift
@@ -216,8 +216,8 @@ extension ImagePipeline {
         /// For requests with no processors, store original image data, unless
         /// the resource is local (file:// or data:// scheme is used).
         ///
-        /// - important: With this policy, the pipeline ``ImagePipeline/loadData(with:completion:)`` method
-        /// will not store the images in the disk cache for requests with
+        /// - important: With this policy, the pipeline's ``ImagePipeline/loadData(with:completion:)-6cwk3``
+        /// method will not store the images in the disk cache for requests with
         /// any processors applied – this method only loads data and doesn't
         /// decode images.
         case automatic
@@ -233,8 +233,8 @@ extension ImagePipeline {
         /// different than provided by a server, e.g. decompressed. In other
         /// scenarios, consider using ``automatic`` policy instead.
         ///
-        /// - important: With this policy, the pipeline ``ImagePipeline/loadData(with:completion:)`` method
-        /// will not store the images in the disk cache – this method only
+        /// - important: With this policy, the pipeline's ``ImagePipeline/loadData(with:completion:)-6cwk3``
+        /// method will not store the images in the disk cache – this method only
         /// loads data and doesn't decode images.
         case storeEncodedImages
 

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -58,9 +58,9 @@ extension ImageProcessing {
 }
 
 extension ImageCaching {
-    subscript(request: any ImageRequestConvertible) -> ImageContainer? {
-        get { self[ImageCacheKey(request: request.asImageRequest())] }
-        set { self[ImageCacheKey(request: request.asImageRequest())] = newValue }
+    subscript(request: ImageRequest) -> ImageContainer? {
+        get { self[ImageCacheKey(request: request)] }
+        set { self[ImageCacheKey(request: request)] = newValue }
     }
 }
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineConfigurationTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineConfigurationTests.swift
@@ -47,7 +47,7 @@ class ImagePipelineConfigurationTests: XCTestCase {
 
         // When/Then
         let expectation = self.expectation(description: "Image Loaded")
-        pipeline.loadImage(with: Test.url, progress: { _, _, _ in
+        pipeline.loadImage(with: Test.request, progress: { _, _, _ in
             XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
         }, completion: { _ in
             XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
@@ -116,7 +116,7 @@ class ImagePipelineLoadDataTests: XCTestCase {
         }
 
         // WHEN
-        let record = expect(pipeline).toLoadData(with: URL(string: "http://example.com/invalid url"))
+        let record = expect(pipeline).toLoadData(with: ImageRequest(url: URL(string: "http://example.com/invalid url")))
         wait()
 
         // THEN

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -118,7 +118,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         let finalLoaded = self.expectation(description: "Final image loaded")
 
         pipeline.loadImage(
-            with: Test.url,
+            with: Test.request,
             progress: { image, _, _ in
                 XCTAssertNil(image, "Expected partial images to never be produced") // Partial images never produced.
                 self.dataLoader.resume()

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -93,7 +93,7 @@ class ImagePipelineTests: XCTestCase {
 
         // When/Then
         let expectation = self.expectation(description: "Image Loaded")
-        pipeline.loadImage(with: Test.url, queue: queue, progress: { _, _, _ in
+        pipeline.loadImage(with: Test.request, queue: queue, progress: { _, _, _ in
             XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
         }, completion: { _ in
             XCTAssertNotNil(DispatchQueue.getSpecific(key: queueKey))
@@ -588,7 +588,7 @@ class ImagePipelineTests: XCTestCase {
 
         // WHEN
         for _ in 0...100 {
-            expect(pipeline).toFailRequest(URL(string: "http://example.com/invalid url"))
+            expect(pipeline).toFailRequest(ImageRequest(url: URL(string: "http://example.com/invalid url")))
             wait()
         }
     }

--- a/Tests/NukeTests/ImagePrefetcherTests.swift
+++ b/Tests/NukeTests/ImagePrefetcherTests.swift
@@ -41,10 +41,10 @@ final class ImagePrefetcherTests: XCTestCase {
         dataLoader.isSuspended = true
 
         expect(prefetcher.queue).toEnqueueOperationsWithCount(1)
-        prefetcher.startPrefetching(with: [Test.url])
+        prefetcher.startPrefetching(with: [Test.request])
         wait()
 
-        expect(pipeline).toLoadImage(with: Test.url)
+        expect(pipeline).toLoadImage(with: Test.request)
         pipeline.queue.async {
             self.dataLoader.isSuspended = false
         }
@@ -256,9 +256,9 @@ final class ImagePrefetcherTests: XCTestCase {
         let expectation = self.expectation(description: "PrefecherDidComplete")
         prefetcher.didComplete = expectation.fulfill
 
-        imageCache[Test.url] = Test.container
+        imageCache[Test.request] = Test.container
 
-        prefetcher.startPrefetching(with: [Test.url])
+        prefetcher.startPrefetching(with: [Test.request])
         wait()
     }
 

--- a/Tests/XCTestCase+Nuke.swift
+++ b/Tests/XCTestCase+Nuke.swift
@@ -25,12 +25,12 @@ struct TestExpectationImagePipeline {
     let pipeline: ImagePipeline
 
     @discardableResult
-    func toLoadImage(with request: ImageRequestConvertible, completion: @escaping ((Result<ImageResponse, ImagePipeline.Error>) -> Void)) -> TestRecordedImageRequest {
+    func toLoadImage(with request: ImageRequest, completion: @escaping ((Result<ImageResponse, ImagePipeline.Error>) -> Void)) -> TestRecordedImageRequest {
         toLoadImage(with: request, progress: nil, completion: completion)
     }
 
     @discardableResult
-    func toLoadImage(with request: ImageRequestConvertible,
+    func toLoadImage(with request: ImageRequest,
                      progress: ((_ intermediateResponse: ImageResponse?, _ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void)? = nil,
                      completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) -> TestRecordedImageRequest {
         let record = TestRecordedImageRequest()
@@ -46,12 +46,12 @@ struct TestExpectationImagePipeline {
     }
 
     @discardableResult
-    func toFailRequest(_ request: ImageRequestConvertible, completion: @escaping ((Result<ImageResponse, ImagePipeline.Error>) -> Void)) -> ImageTask {
+    func toFailRequest(_ request: ImageRequest, completion: @escaping ((Result<ImageResponse, ImagePipeline.Error>) -> Void)) -> ImageTask {
         toFailRequest(request, progress: nil, completion: completion)
     }
 
     @discardableResult
-    func toFailRequest(_ request: ImageRequestConvertible,
+    func toFailRequest(_ request: ImageRequest,
                        progress: ((_ intermediateResponse: ImageResponse?, _ completedUnitCount: Int64, _ totalUnitCount: Int64) -> Void)? = nil,
                        completion: ((Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil) -> ImageTask {
         let expectation = test.expectation(description: "Image request failed \(request)")
@@ -63,16 +63,16 @@ struct TestExpectationImagePipeline {
         }
     }
 
-    func toFailRequest(_ request: ImageRequestConvertible, with expectedError: ImagePipeline.Error, file: StaticString = #file, line: UInt = #line) {
+    func toFailRequest(_ request: ImageRequest, with expectedError: ImagePipeline.Error, file: StaticString = #file, line: UInt = #line) {
         toFailRequest(request) { result in
             XCTAssertEqual(result.error, expectedError, file: file, line: line)
         }
     }
 
     @discardableResult
-    func toLoadData(with request: ImageRequestConvertible) -> TestRecorededDataTask {
+    func toLoadData(with request: ImageRequest) -> TestRecorededDataTask {
         let record = TestRecorededDataTask()
-        let request = request.asImageRequest()
+        let request = request
         let expectation = test.expectation(description: "Data loaded for \(request)")
         record._task = pipeline.loadData(with: request, progress: nil) { result in
             XCTAssertTrue(Thread.isMainThread)


### PR DESCRIPTION
Most of the APIs that use `ImageRequestConvertible` were originally deprecated in [Nuke 11.0](https://github.com/kean/Nuke/pull/567), except for a couple of methods in `ImagePipeline`. This PR fully deprecated `ImageRequestConvertible` so that it could be completely removed in the upcoming major release next year.