### PR TITLE
Data Cache Compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,20 @@ jobs:
           Scripts/test.sh -s "Nuke" -d "OS=16.1,name=Apple TV"
           Scripts/test.sh -s "NukeUI" -d "OS=16.1,name=Apple TV"
           Scripts/test.sh -s "Nuke Extensions" -d "OS=16.1,name=Apple TV"
-  watchos-latest:
-    name: Unit Tests (watchOS 9.1, Xcode 14.1)
-    runs-on: macOS-12
-    env: 
-      DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Tests
-        run: |
-          Scripts/test.sh -s "Nuke" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
-          Scripts/test.sh -s "NukeUI" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
-          Scripts/test.sh -s "Nuke Extensions" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
+# There is a problem with watchOS runners where they often fail to launch on CI
+#
+#  watchos-latest:
+#    name: Unit Tests (watchOS 9.1, Xcode 14.1)
+#    runs-on: macOS-12
+#    env:
+#      DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Run Tests
+#        run: |
+#          Scripts/test.sh -s "Nuke" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
+#          Scripts/test.sh -s "NukeUI" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
+#          Scripts/test.sh -s "Nuke Extensions" -d "OS=9.1,name=Apple Watch Series 8 (45mm)"
   ios-xcode-13:
     name: Unit Tests (iOS 15.5, Xcode 13.4.1)
     runs-on: macOS-12

--- a/Sources/Nuke/Internal/Deprecated.swift
+++ b/Sources/Nuke/Internal/Deprecated.swift
@@ -159,6 +159,7 @@ protocol _DataLoaderObserving: AnyObject {
     func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics)
 }
 
+// Deprecated in Nuke 11.6
 extension ImagePipeline {
     @available(*, deprecated, message: "Please use either `loadData` that accepts `ImageRequest` as a parameter or, preferably, the new async/await APIs")
     @discardableResult public func loadData(

--- a/Sources/Nuke/Nuke.docc/Performance/Caching/cache-layers.md
+++ b/Sources/Nuke/Nuke.docc/Performance/Caching/cache-layers.md
@@ -95,6 +95,9 @@ let dataCache = try DataCache(name: "my-cache")
 
 dataCache.sizeLimit = 1024 * 1024 * 100 // 100 MB
 
+// Dramatically reduces space usage, but adds a slight performance hit
+dataCache.isCompressionEnable = true
+
 dataCache.storeData(data, for: "key")
 if dataCache.containsData(for: "key") {
     print("Data is cached")

--- a/Tests/NukeTests/DataCacheTests.swift
+++ b/Tests/NukeTests/DataCacheTests.swift
@@ -333,6 +333,23 @@ class DataCacheTests: XCTestCase {
         XCTAssertEqual(data, blob)
     }
 
+    // MARK: Compression
+
+    func testCompression() throws {
+        // GIVEN
+        cache.isCompressionEnabled = true
+
+        // WHEN
+        cache["key"] = Test.data
+        XCTAssertEqual(cache["key"], Test.data)
+        cache.flush()
+        XCTAssertEqual(cache["key"], Test.data)
+
+        // THEN
+        let raw = try Data(contentsOf: XCTUnwrap(cache.url(for: "key")))
+        XCTAssertTrue(raw.count < Test.data.count)
+    }
+
     // MARK: Flush
 
     func testFlush() {


### PR DESCRIPTION
Add `isCompressionEnabled` option to `DataCache` that enables compression using Apple’s [lzfse](https://en.wikipedia.org/wiki/LZFSE) algorithm offering an excellent balance between performance and compression ratio. It can reduce disk usage by up to 80%, allowing you to store many more images or reduce the cache size limit. By default, compression is disabled.