### PR TITLE
Add the ability to render static gifs

### DIFF
--- a/Sources/NukeUI/Gifu/Classes/Animator.swift
+++ b/Sources/NukeUI/Gifu/Classes/Animator.swift
@@ -44,6 +44,15 @@ class Animator {
     return frameStore?.frameCount ?? 0
   }
 
+  /// Tests if the `data` is truly an **animated** gif
+  public static func isAnimatedGif(data: Data) -> Bool {
+    if let imageSource = CGImageSourceCreateWithData(data as CFData, nil) {
+      return imageSource.isAnimatedGIF
+    } else {
+      return false
+    }
+  }
+
   /// Creates a new animator with a delegate.
   ///
   /// - parameter view: A view object that implements the `GIFAnimatable` protocol.

--- a/Sources/NukeUI/ImageView.swift
+++ b/Sources/NukeUI/ImageView.swift
@@ -170,7 +170,7 @@ public class ImageView: _PlatformBaseView {
             return
         }
 #if (os(iOS) || os(tvOS)) && !targetEnvironment(macCatalyst)
-        if isAnimatedImageRenderingEnabled, let data = container.data, container.type == .gif {
+        if isAnimatedImageRenderingEnabled, let data = container.data, container.type == .gif, Animator.isAnimatedGif(data: data) {
             animatedImageView.animate(withGIFData: data)
             animatedImageView.isHidden = false
             return


### PR DESCRIPTION
The ImageView now tests if a gif is an animated gif, so that the animator only tries to animate it, if necessary. A static gif is rendered like any other image.

Previously, it was tried to animate every gif, whether it truly was animated or not. That resulted in no image being rendered at all.