### PR TITLE
Add more flexible target size options to ImageRequest.ThumbnailOptions

### DIFF
--- a/Documentation/Nuke.docc/Performance/performance-guide.md
+++ b/Documentation/Nuke.docc/Performance/performance-guide.md
@@ -14,18 +14,16 @@ Bitmapped images take a lot of space in memory. For example, take a 6000x4000px 
 
 By default, Nuke stores decompressed (bitmapped) images in the memory cache. But this strategy might not be optimal for high-resolution images like this. Consider either downsampling such images or disabling memory cache for them to avoid taking too much memory.  
 
-Some image formats, such as jpeg, can have thumbnails embedded in the original image data. If you are working with a large image and want to show only a thumbnail, consider using [`ImageRequest.ThumbnailOptions`](https://kean-docs.github.io/nuke/documentation/nuke/imagerequest/thumbnailoptions).
-
 ## Downsample Images
 
-Ideally, the app should download the images optimized for the target device screen size; but it's not always feasible. To reduce the memory usage, downsample the images.
+Ideally, the app should download the images optimized for the target device screen size, but it's not always possible. To reduce the memory usage, downsample the images.
 
 ```swift
-// Target size is in points.
-let request = ImageRequest(url: URL(string: "http://..."), processors: [.resize(width: 320)])
+// Target size is in points
+let request = ImageRequest(url: url,  processors: [.resize(width: 320)])
 ```
 
-> Tips: See [Image and Graphics Best Practices](https://developer.apple.com/videos/play/wwdc2018/219) to learn more about image decoding and downsampling.
+> Tip: Some image formats, such as jpeg, can have thumbnails embedded in the original image data. If you are working with a large image and want to show only a thumbnail, consider using ``ImageRequest/ThumbnailOptions``. If the thumbnails aren't available, they are generated. It can be up to 2x faster than using ``ImageProcessors/Resize`` for high-resolution images. 
 
 ## Aggressive Cache
 

--- a/Documentation/Nuke.docc/Performance/performance-guide.md
+++ b/Documentation/Nuke.docc/Performance/performance-guide.md
@@ -23,7 +23,7 @@ Ideally, the app should download the images optimized for the target device scre
 let request = ImageRequest(url: url,  processors: [.resize(width: 320)])
 ```
 
-> Tip: Some image formats, such as jpeg, can have thumbnails embedded in the original image data. If you are working with a large image and want to show only a thumbnail, consider using ``ImageRequest/ThumbnailOptions``. If the thumbnails aren't available, they are generated. It can be up to 2x faster than using ``ImageProcessors/Resize`` for high-resolution images. 
+> Tip: Some image formats, such as jpeg, can have thumbnails embedded in the original image data. If you are working with a large image and want to show only a thumbnail, consider using ``ImageRequest/ThumbnailOptions``. If the thumbnails aren't available, they are generated. It can be up to 4x faster than using ``ImageProcessors/Resize`` for high-resolution images. 
 
 ## Aggressive Cache
 

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		0C1453A12657EFA7005E24B3 /* ImagePipelineObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C14539F2657EFA7005E24B3 /* ImagePipelineObserver.swift */; };
 		0C179C7B2283597F008AB488 /* ImageEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C179C7A2283597F008AB488 /* ImageEncoding.swift */; };
 		0C1B9880294E28D800C09310 /* Nuke.docc in Sources */ = {isa = PBXBuildFile; fileRef = 0C1B987F294E28D800C09310 /* Nuke.docc */; };
+		0C1C201D29ABBF19004B38FD /* Nuke.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C9174901BAE99EE004A7905 /* Nuke.framework */; };
+		0C1C201E29ABBF19004B38FD /* Nuke.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C9174901BAE99EE004A7905 /* Nuke.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0C1E620B1D6F817700AD5CF5 /* ImageRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1E620A1D6F817700AD5CF5 /* ImageRequestTests.swift */; };
 		0C1ECA421D526461009063A9 /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7C06871BCA888800089D7F /* ImageCacheTests.swift */; };
 		0C211E502856328500F48AA6 /* DataLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C211E4F2856328500F48AA6 /* DataLoaderTests.swift */; };
@@ -267,6 +269,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0C1C201F29ABBF19004B38FD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0C9174871BAE99EE004A7905 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0C91748F1BAE99EE004A7905;
+			remoteInfo = Nuke;
+		};
 		0C38DB49285690D20027F9FF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0C9174871BAE99EE004A7905 /* Project object */;
@@ -319,6 +328,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				0C55FD1128567875000FD2C9 /* NukeExtensions.framework in Embed Frameworks */,
+				0C1C201E29ABBF19004B38FD /* Nuke.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -592,6 +602,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C55FD1028567875000FD2C9 /* NukeExtensions.framework in Frameworks */,
+				0C1C201D29ABBF19004B38FD /* Nuke.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1216,6 +1227,7 @@
 			);
 			dependencies = (
 				0C55FD0F28567875000FD2C9 /* PBXTargetDependency */,
+				0C1C202029ABBF19004B38FD /* PBXTargetDependency */,
 			);
 			name = "Nuke Tests Host";
 			productName = "Nuke iOS Tests Host";
@@ -1758,6 +1770,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0C1C202029ABBF19004B38FD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0C91748F1BAE99EE004A7905 /* Nuke */;
+			targetProxy = 0C1C201F29ABBF19004B38FD /* PBXContainerItemProxy */;
+		};
 		0C38DB4A285690D20027F9FF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 0C38DAA128568FAE0027F9FF /* NukeUI */;

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Combine
+import CoreGraphics
 
 /// Represents an image request that specifies what images to download, how to
 /// process them, set the request priority, and more.

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -365,21 +365,17 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     ///
     /// For more info, see https://developer.apple.com/documentation/imageio/cgimagesource/image_source_option_dictionary_keys
     public struct ThumbnailOptions: Hashable, Sendable {
-        /// The maximum width and height in pixels of a thumbnail. If this key
-        /// is not specified, the width and height of a thumbnail is not limited
-        /// and thumbnails may be as big as the image itself.
-        public var maxPixelSize: Float
+        let size: ImageTargetSize
+        let contentMode: ImageProcessingOptions.ContentMode
 
         /// Whether a thumbnail should be automatically created for an image if
         /// a thumbnail isn't present in the image source file. The thumbnail is
-        /// created from the full image, subject to the limit specified by
-        /// ``maxPixelSize``.
+        /// created from the full image, subject to the limit specified by size.
         public var createThumbnailFromImageIfAbsent = true
 
         /// Whether a thumbnail should be created from the full image even if a
         /// thumbnail is present in the image source file. The thumbnail is created
-        /// from the full image, subject to the limit specified by
-        /// ``maxPixelSize``.
+        /// from the full image, subject to the limit specified by size.
         public var createThumbnailFromImageAlways = true
 
         /// Whether the thumbnail should be rotated and scaled according to the
@@ -390,20 +386,13 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
         /// creation time.
         public var shouldCacheImmediately = true
 
-        public init(maxPixelSize: Float,
-                    createThumbnailFromImageIfAbsent: Bool = true,
-                    createThumbnailFromImageAlways: Bool = true,
-                    createThumbnailWithTransform: Bool = true,
-                    shouldCacheImmediately: Bool = true) {
-            self.maxPixelSize = maxPixelSize
-            self.createThumbnailFromImageIfAbsent = createThumbnailFromImageIfAbsent
-            self.createThumbnailFromImageAlways = createThumbnailFromImageAlways
-            self.createThumbnailWithTransform = createThumbnailWithTransform
-            self.shouldCacheImmediately = shouldCacheImmediately
+        public init(size: CGSize, unit: ImageProcessingOptions.Unit = .points, contentMode: ImageProcessingOptions.ContentMode = .aspectFill) {
+            self.size = ImageTargetSize(size: size, unit: unit)
+            self.contentMode = contentMode
         }
 
         var identifier: String {
-            "com.github/kean/nuke/thumbnail?mxs=\(maxPixelSize),options=\(createThumbnailFromImageIfAbsent)\(createThumbnailFromImageAlways)\(createThumbnailWithTransform)\(shouldCacheImmediately)"
+            "com.github/kean/nuke/thumbnail?width=\(size.cgSize.width),height=\(size.cgSize.height),contentMode=\(contentMode),options=\(createThumbnailFromImageIfAbsent)\(createThumbnailFromImageAlways)\(createThumbnailWithTransform)\(shouldCacheImmediately)"
         }
     }
 

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -418,6 +418,11 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
             self.targetSize = .flexible(size: ImageTargetSize(size: size, unit: unit), contentMode: contentMode)
         }
 
+        /// Generates a thumbnail from the given image data.
+        public func makeThumbnail(with data: Data) -> PlatformImage? {
+            Nuke.makeThumbnail(data: data, options: self)
+        }
+
         var identifier: String {
             "com.github/kean/nuke/thumbnail?\(targetSize.parameters),options=\(createThumbnailFromImageIfAbsent)\(createThumbnailFromImageAlways)\(createThumbnailWithTransform)\(shouldCacheImmediately)"
         }

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -28,7 +28,7 @@ struct ImageProcessingExtensions {
     let image: PlatformImage
 
     func byResizing(to targetSize: CGSize,
-                    contentMode: ImageProcessors.Resize.ContentMode,
+                    contentMode: ImageProcessingOptions.ContentMode,
                     upscale: Bool) -> PlatformImage? {
         guard let cgImage = image.cgImage else {
             return nil
@@ -201,7 +201,7 @@ extension CGFloat {
 }
 
 extension CGSize {
-    func getScale(targetSize: CGSize, contentMode: ImageProcessors.Resize.ContentMode) -> CGFloat {
+    func getScale(targetSize: CGSize, contentMode: ImageProcessingOptions.ContentMode) -> CGFloat {
         let scaleHor = targetSize.width / width
         let scaleVert = targetSize.height / height
 

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -380,7 +380,9 @@ private func getMaxPixelSize(for source: CGImageSource, options thumbnailOptions
         }
 
         let orientation = (properties[kCGImagePropertyOrientation] as? UInt32).flatMap(CGImagePropertyOrientation.init) ?? .up
+#if canImport(UIKit)
         targetSize = targetSize.rotatedForOrientation(orientation)
+#endif
 
         let imageSize = CGSize(width: width, height: height)
         let scale = imageSize.getScale(targetSize: targetSize, contentMode: contentMode)

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -240,21 +240,6 @@ extension CGImagePropertyOrientation {
         }
     }
 }
-
-extension UIImage.Orientation {
-    init(_ orientation: CGImagePropertyOrientation) {
-        switch orientation {
-        case .up: self = .up
-        case .upMirrored: self = .upMirrored
-        case .down: self = .down
-        case .downMirrored: self = .downMirrored
-        case .left: self = .left
-        case .leftMirrored: self = .leftMirrored
-        case .right: self = .right
-        case .rightMirrored: self = .rightMirrored
-        }
-    }
-}
 #endif
 
 #if os(iOS) || os(tvOS) || os(watchOS)

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -240,10 +240,34 @@ extension CGImagePropertyOrientation {
         }
     }
 }
+
+extension UIImage.Orientation {
+    init(_ orientation: CGImagePropertyOrientation) {
+        switch orientation {
+        case .up: self = .up
+        case .upMirrored: self = .upMirrored
+        case .down: self = .down
+        case .downMirrored: self = .downMirrored
+        case .left: self = .left
+        case .leftMirrored: self = .leftMirrored
+        case .right: self = .right
+        case .rightMirrored: self = .rightMirrored
+        }
+    }
+}
 #endif
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 private extension CGSize {
+    func rotatedForOrientation(_ imageOrientation: CGImagePropertyOrientation) -> CGSize {
+        switch imageOrientation {
+        case .left, .leftMirrored, .right, .rightMirrored:
+            return CGSize(width: height, height: width) // Rotate 90 degrees
+        case .up, .upMirrored, .down, .downMirrored:
+            return self
+        }
+    }
+
     func rotatedForOrientation(_ imageOrientation: UIImage.Orientation) -> CGSize {
         switch imageOrientation {
         case .left, .leftMirrored, .right, .rightMirrored:
@@ -343,14 +367,34 @@ func makeThumbnail(data: Data, options: ImageRequest.ThumbnailOptions) -> Platfo
     guard let source = CGImageSourceCreateWithData(data as CFData, [kCGImageSourceShouldCache: false] as CFDictionary) else {
         return nil
     }
+
+    let maxPixelSize = getMaxPixelSize(for: source, options: options)
     let options = [
         kCGImageSourceCreateThumbnailFromImageAlways: options.createThumbnailFromImageAlways,
         kCGImageSourceCreateThumbnailFromImageIfAbsent: options.createThumbnailFromImageIfAbsent,
         kCGImageSourceShouldCacheImmediately: options.shouldCacheImmediately,
         kCGImageSourceCreateThumbnailWithTransform: options.createThumbnailWithTransform,
-        kCGImageSourceThumbnailMaxPixelSize: options.maxPixelSize] as [CFString: Any]
+        kCGImageSourceThumbnailMaxPixelSize: maxPixelSize] as [CFString: Any]
     guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
         return nil
     }
     return PlatformImage(cgImage: image)
+}
+
+private func getMaxPixelSize(for source: CGImageSource, options thumbnailOptions: ImageRequest.ThumbnailOptions) -> CGFloat {
+    var targetSize = thumbnailOptions.size.cgSize
+    let options = [kCGImageSourceShouldCache: false] as CFDictionary
+    guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, options) as? [CFString: Any],
+          let width = properties[kCGImagePropertyPixelWidth] as? CGFloat,
+          let height = properties[kCGImagePropertyPixelHeight] as? CGFloat else {
+        return max(targetSize.width, targetSize.height)
+    }
+
+    let orientation = (properties[kCGImagePropertyOrientation] as? UInt32).flatMap(CGImagePropertyOrientation.init) ?? .up
+    targetSize = targetSize.rotatedForOrientation(orientation)
+
+    let imageSize = CGSize(width: width, height: height)
+    let scale = imageSize.getScale(targetSize: targetSize, contentMode: thumbnailOptions.contentMode)
+    let size = imageSize.scaled(by: scale).rounded()
+    return max(size.width, size.height)
 }

--- a/Sources/Nuke/Processing/ImageProcessingOptions.swift
+++ b/Sources/Nuke/Processing/ImageProcessingOptions.swift
@@ -65,4 +65,22 @@ public enum ImageProcessingOptions: Sendable {
             "Border(color: \(color.hex), width: \(width) pixels)"
         }
     }
+
+    /// An option for how to resize the image.
+    public enum ContentMode: CustomStringConvertible, Sendable {
+        /// Scales the image so that it completely fills the target area.
+        /// Maintains the aspect ratio of the original image.
+        case aspectFill
+
+        /// Scales the image so that it fits the target size. Maintains the
+        /// aspect ratio of the original image.
+        case aspectFit
+
+        public var description: String {
+            switch self {
+            case .aspectFill: return ".aspectFill"
+            case .aspectFit: return ".aspectFit"
+            }
+        }
+    }
 }

--- a/Sources/Nuke/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Resize.swift
@@ -14,7 +14,7 @@ import AppKit
 extension ImageProcessors {
     /// Scales an image to a specified size.
     public struct Resize: ImageProcessing, Hashable, CustomStringConvertible {
-        private let size: Size
+        private let size: ImageTargetSize
         private let contentMode: ImageProcessingOptions.ContentMode
         private let crop: Bool
         private let upscale: Bool
@@ -32,7 +32,7 @@ extension ImageProcessors {
         ///   Does nothing with content mode .aspectFill.
         ///  - upscale: By default, upscaling is not allowed.
         public init(size: CGSize, unit: ImageProcessingOptions.Unit = .points, contentMode: ImageProcessingOptions.ContentMode = .aspectFill, crop: Bool = false, upscale: Bool = false) {
-            self.size = Size(size: size, unit: unit)
+            self.size = ImageTargetSize(size: size, unit: unit)
             self.contentMode = contentMode
             self.crop = crop
             self.upscale = upscale
@@ -76,7 +76,7 @@ extension ImageProcessors {
 }
 
 // Adds Hashable without making changes to public CGSize API
-private struct Size: Hashable {
+struct ImageTargetSize: Hashable {
     let cgSize: CGSize
 
     /// Creates the size in pixels by scaling to the input size to the screen scale

--- a/Sources/Nuke/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Resize.swift
@@ -15,27 +15,12 @@ extension ImageProcessors {
     /// Scales an image to a specified size.
     public struct Resize: ImageProcessing, Hashable, CustomStringConvertible {
         private let size: Size
-        private let contentMode: ContentMode
+        private let contentMode: ImageProcessingOptions.ContentMode
         private let crop: Bool
         private let upscale: Bool
 
-        /// An option for how to resize the image.
-        public enum ContentMode: CustomStringConvertible, Sendable {
-            /// Scales the image so that it completely fills the target area.
-            /// Maintains the aspect ratio of the original image.
-            case aspectFill
-
-            /// Scales the image so that it fits the target size. Maintains the
-            /// aspect ratio of the original image.
-            case aspectFit
-
-            public var description: String {
-                switch self {
-                case .aspectFill: return ".aspectFill"
-                case .aspectFit: return ".aspectFit"
-                }
-            }
-        }
+        @available(*, deprecated, message: "Renamed to `ImageProcessingOptions.ContentMode")
+        public typealias ContentMode = ImageProcessingOptions.ContentMode
 
         /// Initializes the processor with the given size.
         ///
@@ -46,7 +31,7 @@ extension ImageProcessors {
         ///   - crop: If `true` will crop the image to match the target size.
         ///   Does nothing with content mode .aspectFill.
         ///  - upscale: By default, upscaling is not allowed.
-        public init(size: CGSize, unit: ImageProcessingOptions.Unit = .points, contentMode: ContentMode = .aspectFill, crop: Bool = false, upscale: Bool = false) {
+        public init(size: CGSize, unit: ImageProcessingOptions.Unit = .points, contentMode: ImageProcessingOptions.ContentMode = .aspectFill, crop: Bool = false, upscale: Bool = false) {
             self.size = Size(size: size, unit: unit)
             self.contentMode = contentMode
             self.crop = crop

--- a/Sources/Nuke/Processing/ImageProcessors.swift
+++ b/Sources/Nuke/Processing/ImageProcessors.swift
@@ -25,7 +25,7 @@ extension ImageProcessing where Self == ImageProcessors.Resize {
     ///   - crop: If `true` will crop the image to match the target size. Does
     ///   nothing with content mode .aspectFill. `false` by default.
     ///   - upscale: Upscaling is not allowed by default.
-    public static func resize(size: CGSize, unit: ImageProcessingOptions.Unit = .points, contentMode: ImageProcessors.Resize.ContentMode = .aspectFill, crop: Bool = false, upscale: Bool = false) -> ImageProcessors.Resize {
+    public static func resize(size: CGSize, unit: ImageProcessingOptions.Unit = .points, contentMode: ImageProcessingOptions.ContentMode = .aspectFill, crop: Bool = false, upscale: Bool = false) -> ImageProcessors.Resize {
         ImageProcessors.Resize(size: size, unit: unit, contentMode: contentMode, crop: crop, upscale: upscale)
     }
 

--- a/Sources/Nuke/Processing/ImageProcessors.swift
+++ b/Sources/Nuke/Processing/ImageProcessors.swift
@@ -20,7 +20,7 @@ extension ImageProcessing where Self == ImageProcessors.Resize {
     ///
     /// - parameters
     ///   - size: The target size.
-    ///   - unit: Unit of the target size.
+    ///   - unit: Unit of the target size. By default, `.points`.
     ///   - contentMode: Target content mode.
     ///   - crop: If `true` will crop the image to match the target size. Does
     ///   nothing with content mode .aspectFill. `false` by default.
@@ -33,7 +33,7 @@ extension ImageProcessing where Self == ImageProcessors.Resize {
     ///
     /// - parameters:
     ///   - width: The target width.
-    ///   - unit: Unit of the target size.
+    ///   - unit: Unit of the target size. By default, `.points`.
     ///   - upscale: `false` by default.
     public static func resize(width: CGFloat, unit: ImageProcessingOptions.Unit = .points, upscale: Bool = false) -> ImageProcessors.Resize {
         ImageProcessors.Resize(width: width, unit: unit, upscale: upscale)
@@ -43,7 +43,7 @@ extension ImageProcessing where Self == ImageProcessors.Resize {
     ///
     /// - parameters:
     ///   - height: The target height.
-    ///   - unit: Unit of the target size.
+    ///   - unit: Unit of the target size. By default, `.points`.
     ///   - upscale: `false` by default.
     public static func resize(height: CGFloat, unit: ImageProcessingOptions.Unit = .points, upscale: Bool = false) -> ImageProcessors.Resize {
         ImageProcessors.Resize(height: height, unit: unit, upscale: upscale)

--- a/Tests/NukePerformanceTests/ImageProcessingPerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImageProcessingPerformanceTests.swift
@@ -40,7 +40,7 @@ class ImageProcessingPerformanceTests: XCTestCase {
         }
     }
 
-    // MARK: Creating Thumbnals
+    // MARK: Creating Thumbnails
 
     func testResizeImage() throws {
         let image = try XCTUnwrap(makeHighResolutionImage())

--- a/Tests/NukePerformanceTests/ImageProcessingPerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImageProcessingPerformanceTests.swift
@@ -17,7 +17,6 @@ class ImageProcessingPerformanceTests: XCTestCase {
     }
 
     func testComparingTwoProcessorCompositions() {
-
         let lhs = ImageProcessors.Composition([MockImageProcessor(id: "123"), ImageProcessors.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
         let rhs = ImageProcessors.Composition([MockImageProcessor(id: "124"), ImageProcessors.Resize(size: CGSize(width: 1, height: 1), contentMode: .aspectFill, upscale: false)])
 
@@ -40,4 +39,46 @@ class ImageProcessingPerformanceTests: XCTestCase {
             }
         }
     }
+
+    // MARK: Creating Thumbnals
+
+    func testResizeImage() throws {
+        let image = try XCTUnwrap(makeHighResolutionImage())
+        let processor = ImageProcessors.Resize(size: CGSize(width: 64, height: 64), unit: .pixels)
+
+        measure {
+            for _ in 0..<10 {
+                _ = processor.process(image)
+            }
+        }
+    }
+
+    func testCreateThumbnail() throws {
+        let image = try XCTUnwrap(makeHighResolutionImage())
+        let data = try XCTUnwrap(ImageEncoders.ImageIO(type: .jpeg).encode(image))
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 64, height: 64), unit: .pixels)
+
+        measure {
+            for _ in 0..<10 {
+                _ = options.makeThumbnail(with: data)
+            }
+        }
+    }
+
+    // Should be roughly identical to the flexible target size.
+    func testCreateThumbnailStaticSize() throws {
+        let image = try XCTUnwrap(makeHighResolutionImage())
+        let data = try XCTUnwrap(ImageEncoders.ImageIO(type: .jpeg).encode(image))
+        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 64)
+
+        measure {
+            for _ in 0..<10 {
+                _ = options.makeThumbnail(with: data)
+            }
+        }
+    }
+}
+
+private func makeHighResolutionImage() -> PlatformImage? {
+    ImageProcessors.Resize(width: 4000, unit: .pixels, upscale: true).process(Test.image)
 }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
@@ -133,7 +133,7 @@ class ImagePipelineCoalescingTests: XCTestCase {
         dataLoader.queue.isSuspended = true
 
         // GIVEN requests with the same URLs but one accesses thumbnail
-        let request1 = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(maxPixelSize: 400)])
+        let request1 = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)])
         let request2 = ImageRequest(url: Test.url)
 
         // WHEN loading images for those requests

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
@@ -133,7 +133,7 @@ class ImagePipelineCoalescingTests: XCTestCase {
         dataLoader.queue.isSuspended = true
 
         // GIVEN requests with the same URLs but one accesses thumbnail
-        let request1 = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)])
+        let request1 = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(maxPixelSize: 400)])
         let request2 = ImageRequest(url: Test.url)
 
         // WHEN loading images for those requests

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDataCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDataCacheTests.swift
@@ -48,7 +48,7 @@ class ImagePipelineDataCachingTests: XCTestCase {
     
     func testGeneratedThumbnailDataIsStoredIncache() {
         // When
-        let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(maxPixelSize: 400)])
+        let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)])
         expect(pipeline).toLoadImage(with: request)
         
         // Then

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineImageCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineImageCacheTests.swift
@@ -100,7 +100,7 @@ class ImagePipelineImageCacheTests: XCTestCase {
 
     func testGeneratedThumbnailDataIsStoredIncache() throws {
         // When
-        let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(maxPixelSize: 400)])
+        let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)])
         expect(pipeline).toLoadImage(with: request)
 
         // Then

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -325,7 +325,7 @@ class ImagePipelineTests: XCTestCase {
 
     func testThatThumbnailIsGenerated() {
         // GIVEN
-        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
+        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
         
         // WHEN
@@ -341,7 +341,7 @@ class ImagePipelineTests: XCTestCase {
     
     func testThumbnailIsGeneratedOnDecodingQueue() {
         // GIVEN
-        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
+        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
         
         // WHEN/THEN
@@ -355,7 +355,7 @@ class ImagePipelineTests: XCTestCase {
         pipeline.configuration.imageDecompressingQueue.isSuspended = true
         
         // GIVEN
-        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
+        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
         
         // WHEN/THEN
@@ -378,6 +378,12 @@ class ImagePipelineTests: XCTestCase {
     }
     
     func testCacheKeyForRequestWithThumbnail() {
+        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
+        let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
+        XCTAssertEqual(pipeline.cache.makeDataCacheKey(for: request), "http://test.comcom.github/kean/nuke/thumbnail?maxPixelSize=400.0,options=truetruetruetrue")
+    }
+
+    func testCacheKeyForRequestWithThumbnailFlexibleSize() {
         let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
         XCTAssertEqual(pipeline.cache.makeDataCacheKey(for: request), "http://test.comcom.github/kean/nuke/thumbnail?width=400.0,height=400.0,contentMode=.aspectFit,options=truetruetruetrue")

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -322,10 +322,10 @@ class ImagePipelineTests: XCTestCase {
 #endif
     
     // MARK: - Thubmnail
-    
+
     func testThatThumbnailIsGenerated() {
         // GIVEN
-        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
         
         // WHEN
@@ -341,7 +341,7 @@ class ImagePipelineTests: XCTestCase {
     
     func testThumbnailIsGeneratedOnDecodingQueue() {
         // GIVEN
-        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
         
         // WHEN/THEN
@@ -355,7 +355,7 @@ class ImagePipelineTests: XCTestCase {
         pipeline.configuration.imageDecompressingQueue.isSuspended = true
         
         // GIVEN
-        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
         
         // WHEN/THEN
@@ -378,9 +378,9 @@ class ImagePipelineTests: XCTestCase {
     }
     
     func testCacheKeyForRequestWithThumbnail() {
-        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
         let request = ImageRequest(url: Test.url, userInfo: [.thumbnailKey: options])
-        XCTAssertEqual(pipeline.cache.makeDataCacheKey(for: request), "http://test.comcom.github/kean/nuke/thumbnail?mxs=400.0,options=truetruetruetrue")
+        XCTAssertEqual(pipeline.cache.makeDataCacheKey(for: request), "http://test.comcom.github/kean/nuke/thumbnail?width=400.0,height=400.0,contentMode=.aspectFit,options=truetruetruetrue")
     }
     
     // MARK: - Invalidate

--- a/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
@@ -12,11 +12,83 @@ import XCTest
 class ImageThumbnailTest: XCTestCase {
 
     func testThatImageIsResized() throws {
+            for _ in 0..<100 {
+                let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
+                let _ = makeThumbnail(data: Test.data, options: options)
+            }
+
         // WHEN
-        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
         let output = try XCTUnwrap(makeThumbnail(data: Test.data, options: options))
 
         // THEN
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 400, height: 300))
     }
+
+    func testThatImageIsResizedToFill() throws {
+        // Given
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFill)
+
+        // When
+        let output = try XCTUnwrap(makeThumbnail(data: Test.data, options: options))
+
+        // Then
+        XCTAssertEqual(output.sizeInPixels, CGSize(width: 533, height: 400))
+    }
+
+    func testThatImageIsResizedToFillPNG() throws {
+        // Given
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 180, height: 180), unit: .pixels, contentMode: .aspectFill)
+
+        // When
+        // Input: 640 × 360
+        let output = try XCTUnwrap(makeThumbnail(data: Test.data(name: "fixture", extension: "png"), options: options))
+
+        // Then
+        XCTAssertEqual(output.sizeInPixels, CGSize(width: 320, height: 180))
+    }
+
+    func testThatImageIsResizedToFit() throws {
+        // Given
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
+
+        // When
+        let output = try XCTUnwrap(makeThumbnail(data: Test.data, options: options))
+
+        // Then
+        XCTAssertEqual(output.sizeInPixels, CGSize(width: 400, height: 300))
+    }
+
+    func testThatImageIsResizedToFitPNG() throws {
+        // Given
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 160, height: 160), unit: .pixels, contentMode: .aspectFit)
+
+        // When
+        // Input: 640 × 360
+        let output = try XCTUnwrap(makeThumbnail(data: Test.data(name: "fixture", extension: "png"), options: options))
+
+        // Then
+        XCTAssertEqual(output.sizeInPixels, CGSize(width: 160, height: 90))
+    }
+
+#if os(iOS) || os(tvOS) || os(watchOS)
+    func testResizeImageWithOrientationRight() throws {
+        // Given an image with `right` orientation. From the user perspective,
+        // the image a landscape image with s size 640x480px. The raw pixel
+        // data, on the other hand, is 480x640px.
+        let input = try XCTUnwrap(Test.data(name: "left-orientation", extension: "jpeg"))
+        XCTAssertEqual(PlatformImage(data: input)?.imageOrientation, .right)
+
+        // When we resize the image to fit 320x480px frame, we expect the processor
+        // to take image orientation into the account and produce a 320x240px.
+        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 320, height: 1000), unit: .pixels, contentMode: .aspectFit)
+        let output = try XCTUnwrap(makeThumbnail(data: input, options: options))
+
+        // Then the output thumbnail is rotated
+        XCTAssertEqual(output.sizeInPixels, CGSize(width: 320, height: 240))
+        XCTAssertEqual(output.imageOrientation, .up)
+        // Then the image is resized according to orientation
+        XCTAssertEqual(output.size, CGSize(width: 320, height: 240))
+    }
+#endif
 }

--- a/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
@@ -12,13 +12,8 @@ import XCTest
 class ImageThumbnailTest: XCTestCase {
 
     func testThatImageIsResized() throws {
-            for _ in 0..<100 {
-                let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
-                let _ = makeThumbnail(data: Test.data, options: options)
-            }
-
         // WHEN
-        let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
+        let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
         let output = try XCTUnwrap(makeThumbnail(data: Test.data, options: options))
 
         // THEN

--- a/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
@@ -14,7 +14,7 @@ class ImageThumbnailTest: XCTestCase {
     func testThatImageIsResized() throws {
         // WHEN
         let options = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
-        let output = try XCTUnwrap(makeThumbnail(data: Test.data, options: options))
+        let output = try XCTUnwrap(options.makeThumbnail(with: Test.data))
 
         // THEN
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 400, height: 300))
@@ -25,7 +25,7 @@ class ImageThumbnailTest: XCTestCase {
         let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFill)
 
         // When
-        let output = try XCTUnwrap(makeThumbnail(data: Test.data, options: options))
+        let output = try XCTUnwrap(options.makeThumbnail(with: Test.data))
 
         // Then
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 533, height: 400))
@@ -48,7 +48,7 @@ class ImageThumbnailTest: XCTestCase {
         let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFit)
 
         // When
-        let output = try XCTUnwrap(makeThumbnail(data: Test.data, options: options))
+        let output = try XCTUnwrap(options.makeThumbnail(with: Test.data))
 
         // Then
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 400, height: 300))
@@ -60,7 +60,7 @@ class ImageThumbnailTest: XCTestCase {
 
         // When
         // Input: 640 × 360
-        let output = try XCTUnwrap(makeThumbnail(data: Test.data(name: "fixture", extension: "png"), options: options))
+        let output = try XCTUnwrap(options.makeThumbnail(with: Test.data(name: "fixture", extension: "png")))
 
         // Then
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 160, height: 90))
@@ -77,7 +77,7 @@ class ImageThumbnailTest: XCTestCase {
         // When we resize the image to fit 320x480px frame, we expect the processor
         // to take image orientation into the account and produce a 320x240px.
         let options = ImageRequest.ThumbnailOptions(size: CGSize(width: 320, height: 1000), unit: .pixels, contentMode: .aspectFit)
-        let output = try XCTUnwrap(makeThumbnail(data: input, options: options))
+        let output = try XCTUnwrap(options.makeThumbnail(with: input))
 
         // Then the output thumbnail is rotated
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 320, height: 240))

--- a/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
@@ -139,7 +139,6 @@ class ImageProcessorsResizeTests: XCTestCase {
 #endif
     
 #if os(iOS) || os(tvOS) || os(watchOS)
-    @MainActor
     func testResizeImageWithOrientationLeft() throws {
         // Given an image with `right` orientation. From the user perspective,
         // the image a landscape image with s size 640x480px. The raw pixel
@@ -158,8 +157,7 @@ class ImageProcessorsResizeTests: XCTestCase {
         // Then the image is resized according to orientation
         XCTAssertEqual(output.size, CGSize(width: 320, height: 240))
     }
-    
-    @MainActor
+
     func testResizeAndCropWithOrientationLeft() throws {
         // Given an image with `right` orientation. From the user perspective,
         // the image a landscape image with s size 640x480px. The raw pixel


### PR DESCRIPTION
In the previous version, the only available option was `maxPixelSize`:

```swift
// Before
ImageRequest.ThumbnailOptions(maxPixelSize: 64)
```

The main issue with `maxPixelSize` is that it creates a thumbnail that _fits_ the target size. For example, if you have a wide image with `2000x400` pixel size and resize it to `maxPixelSize: 40`, the thumbnail will have the size `40x8` pixels. There was no way to create a `200x40` thumbnail, which is what you typically want to make sure the images have enough pixels to look good.

In addition to `init(maxPixelSize:)`, there is now a new initializer with the parameters that directly match `ImageProcessors.Resize`, so it's easy to switch between them.

```swift
// After
ImageRequest.ThumbnailOptions(size: CGSize(width: 64, height: 64), contentMode: .aspectFill)

// Produces the same result as the following processor
ImageProcessors.Resize(size: CGSize(width: 64, height: 64), contentMode: .aspectFill)
```

The default `contentMode` is `.aspectFill` – the same as for `ImageProcessors.Resize`. And the default target size unit is `.points`.

