### PR TITLE
Fix typos

### DIFF
--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -240,7 +240,7 @@ private struct LazyImageDemoView: View {
                 }
             }
             .processors(isBlured ? [ImageProcessors.GaussianBlur()] : [])
-            .id(imageViewId) // Example of how to implement retyr
+            .id(imageViewId) // Example of how to implement retry
 
             Spacer()
             VStack(alignment: .leading, spacing: 16) {


### PR DESCRIPTION
Hello, I found a typo and will correct it.

- Fix typos
  - retyr  → retry


When I was looking at the LazyImageDemoView demo, there was a word I didn't know, "retyr", which confused me, so I fixed it.