### PR TITLE
Remove useless extension

### DIFF
--- a/Sources/Nuke/Caching/Cache.swift
+++ b/Sources/Nuke/Caching/Cache.swift
@@ -20,8 +20,8 @@ final class Cache<Key: Hashable, Value>: @unchecked Sendable {
     }
 
     var conf: Configuration {
-        get { lock.sync { _conf } }
-        set { lock.sync { _conf = newValue } }
+        get { lock.withLock { _conf } }
+        set { lock.withLock { _conf = newValue } }
     }
 
     private var _conf: Configuration {
@@ -29,11 +29,11 @@ final class Cache<Key: Hashable, Value>: @unchecked Sendable {
     }
 
     var totalCost: Int {
-        lock.sync { _totalCost }
+        lock.withLock { _totalCost }
     }
 
     var totalCount: Int {
-        lock.sync { map.count }
+        lock.withLock { map.count }
     }
 
     private var _totalCost = 0
@@ -160,7 +160,7 @@ final class Cache<Key: Hashable, Value>: @unchecked Sendable {
     }
 
     func trim(toCost limit: Int) {
-        lock.sync { _trim(toCost: limit) }
+        lock.withLock { _trim(toCost: limit) }
     }
 
     private func _trim(toCost limit: Int) {
@@ -168,7 +168,7 @@ final class Cache<Key: Hashable, Value>: @unchecked Sendable {
     }
 
     func trim(toCount limit: Int) {
-        lock.sync { _trim(toCount: limit) }
+        lock.withLock { _trim(toCount: limit) }
     }
 
     private func _trim(toCount limit: Int) {

--- a/Sources/Nuke/Caching/DataCache.swift
+++ b/Sources/Nuke/Caching/DataCache.swift
@@ -251,9 +251,9 @@ public final class DataCache: DataCaching, @unchecked Sendable {
     /// operations for the given key are finished.
     public func flush(for key: String) {
         queue.sync {
-            guard let change = lock.sync({ staging.changes[key] }) else { return }
+            guard let change = lock.withLock({ staging.changes[key] }) else { return }
             perform(change)
-            lock.sync { staging.flushed(change) }
+            lock.withLock { staging.flushed(change) }
         }
     }
 

--- a/Sources/Nuke/Internal/Extensions.swift
+++ b/Sources/Nuke/Internal/Extensions.swift
@@ -27,14 +27,6 @@ extension String {
     }
 }
 
-extension NSLock {
-    func sync<T>(_ closure: () -> T) -> T {
-        lock()
-        defer { unlock() }
-        return closure()
-    }
-}
-
 extension URL {
     var isLocalResource: Bool {
         scheme == "file" || scheme == "data"


### PR DESCRIPTION
Removed unnecessary extension, because in iOS 8.0/macOS 10.10/tvOS 9.0/watchOS 2.0 it is already in the Foundation.
https://developer.apple.com/documentation/foundation/nslocking/4059821-withlock

All tests on all platforms were successful.

