### PR TITLE
Minor docs correction in FetchImage

### DIFF
--- a/Documentation/NukeUI.docc/Extensions/FetchImage-Extensions.md
+++ b/Documentation/NukeUI.docc/Extensions/FetchImage-Extensions.md
@@ -15,7 +15,7 @@ struct ImageView: View {
     var body: some View {
         ZStack {
             Rectangle().fill(Color.gray)
-            image.view?
+            image.image?
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .clipped()


### PR DESCRIPTION
This pull request addresses a property name issue within FetchImage. Previously,
the code referenced a `view` property, which does not exist.
This has now been corrected to `image`, aligning with the existing properties within FetchImage.

Thank you again for your incredible work and commitment to this project.

![CleanShot 2023-07-14 at 10 08 53](https://github.com/kean/Nuke/assets/1296540/99c427cf-d1a5-4a40-8481-42fc937363a4)