### PR TITLE
Pass alphaInfo from CGImage to CGContext during decompression

### DIFF
--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -134,7 +134,7 @@ extension PlatformImage {
         guard let cgImage = cgImage else {
             return nil
         }
-        guard let ctx = CGContext.make(cgImage, size: canvasSize) else {
+        guard let ctx = CGContext.make(cgImage, size: canvasSize, alphaInfo: cgImage.alphaInfo) else {
             return nil
         }
         ctx.draw(cgImage, in: drawRect ?? CGRect(origin: .zero, size: canvasSize))


### PR DESCRIPTION
Partially transparent images sometimes are improperly rendered with decompression on. It's somewhat difficult to reproduce as it requires using partially transparent images and rendering multiple images at the same time.

It looks like Nuke is defaulting to CGAlphaInfo `.premultipliedLast` which causes an issue. CGImage has Alpha information, passing it fixes the issue.