### PR TITLE
Enable visionOS support for all APIs

### DIFF
--- a/Sources/Nuke/Caching/Cache.swift
+++ b/Sources/Nuke/Caching/Cache.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit.UIApplication
 #endif
 
@@ -55,7 +55,7 @@ final class Cache<Key: Hashable, Value>: @unchecked Sendable {
         }
         self.memoryPressure.resume()
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         registerForEnterBackground()
 #endif
     }
@@ -67,7 +67,7 @@ final class Cache<Key: Hashable, Value>: @unchecked Sendable {
         memoryPressure.cancel()
     }
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     private func registerForEnterBackground() {
         notificationObserver = NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { [weak self] _ in
             self?.clearCacheOnEnterBackground()

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -146,7 +146,7 @@ extension PlatformImage {
 
     /// Decompresses the input image by drawing in the the `CGContext`.
     func decompressed(isUsingPrepareForDisplay: Bool) -> PlatformImage? {
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         if isUsingPrepareForDisplay, #available(iOS 15.0, tvOS 15.0, *) {
             return preparingForDisplay()
         }

--- a/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2015-2024 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 import Foundation
 import CoreImage

--- a/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2015-2024 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 import Foundation
 import CoreImage

--- a/Sources/Nuke/Processing/ImageProcessors.swift
+++ b/Sources/Nuke/Processing/ImageProcessors.swift
@@ -86,7 +86,7 @@ extension ImageProcessing where Self == ImageProcessors.Anonymous {
     }
 }
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 extension ImageProcessing where Self == ImageProcessors.CoreImageFilter {
     /// Applies Core Image filter – `CIFilter` – to the image.

--- a/Sources/NukeExtensions/ImageLoadingOptions.swift
+++ b/Sources/NukeExtensions/ImageLoadingOptions.swift
@@ -23,7 +23,7 @@ public struct ImageLoadingOptions {
     /// Image to be displayed when the request fails. `nil` by default.
     public var failureImage: PlatformImage?
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
     /// The image transition animation performed when displaying a loaded image.
     /// Only runs when the image was not found in memory cache. `nil` by default.
@@ -66,7 +66,7 @@ public struct ImageLoadingOptions {
     /// request. `[]` by default.
     public var processors: [any ImageProcessing] = []
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
     /// Content modes to be used for each image type (placeholder, success,
     /// failure). `nil`  by default (don't change content mode).
@@ -132,7 +132,7 @@ public struct ImageLoadingOptions {
 
 #endif
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
     /// - parameters:
     ///   - placeholder: Placeholder to be displayed when the image is loading.
@@ -175,7 +175,7 @@ public struct ImageLoadingOptions {
     public struct Transition {
         var style: Style
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         enum Style { // internal representation
             case fadeIn(parameters: Parameters)
             case custom((ImageDisplayingView, UIImage) -> Void)

--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -12,7 +12,7 @@ import UIKit.UIColor
 import AppKit.NSImage
 #endif
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 /// Displays images. Add the conformance to this protocol to your views to make
 /// them compatible with Nuke image loading extensions.
@@ -45,7 +45,7 @@ extension Nuke_ImageDisplaying {
 }
 #endif
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 /// A `UIView` that implements `ImageDisplaying` protocol.
 public typealias ImageDisplayingView = UIView & Nuke_ImageDisplaying
@@ -198,7 +198,7 @@ private final class ImageViewController {
     private var task: ImageTask?
     private var options: ImageLoadingOptions
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     // Image view used for cross-fade transition between images with different
     // content modes.
     private lazy var transitionImageView = UIImageView()
@@ -245,7 +245,7 @@ private final class ImageViewController {
         self.options = options
 
         if options.isPrepareForReuseEnabled { // enabled by default
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
             imageView.layer.removeAllAnimations()
 #elseif os(macOS)
             let layer = (imageView as? NSView)?.layer ?? imageView.layer
@@ -320,7 +320,7 @@ private final class ImageViewController {
         display(response.container, false, .success)
     }
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
     private func display(_ image: ImageContainer, _ isFromMemory: Bool, _ response: ImageLoadingOptions.ResponseType) {
         guard let imageView = imageView else {
@@ -329,7 +329,7 @@ private final class ImageViewController {
 
         var image = image
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         if let tintColor = options.tintColor(for: response) {
             image.image = image.image.withRenderingMode(.alwaysTemplate)
             imageView.tintColor = tintColor
@@ -349,7 +349,7 @@ private final class ImageViewController {
             imageView.display(image)
         }
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         if let contentMode = options.contentMode(for: response) {
             imageView.contentMode = contentMode
         }
@@ -368,7 +368,7 @@ private final class ImageViewController {
 // MARK: - ImageViewController (Transitions)
 
 extension ImageViewController {
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
     private func runFadeInTransition(image: ImageContainer, params: ImageLoadingOptions.Transition.Parameters, response: ImageLoadingOptions.ResponseType) {
         guard let imageView = imageView else {

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -222,7 +222,7 @@ private struct LazyImageDemoView: View {
                     image.resizable().aspectRatio(contentMode: .fit)
                 }
             }
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
             .processors(isBlured ? [ImageProcessors.GaussianBlur()] : [])
 #endif
             .id(imageViewId) // Example of how to implement retry
@@ -240,7 +240,7 @@ private struct LazyImageDemoView: View {
                 Toggle("Apply Blur", isOn: $isBlured)
             }
             .padding()
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
             .background(Material.ultraThick)
 #endif
         }

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -373,7 +373,7 @@ public final class LazyImageView: _PlatformBaseView {
             newView.isHidden = !imageView.isHidden
             insertSubview(newView, at: 0)
             setNeedsUpdateConstraints()
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
             if let spinner = newView as? UIActivityIndicatorView {
                 spinner.startAnimating()
             }

--- a/Sources/NukeVideo/VideoPlayerView.swift
+++ b/Sources/NukeVideo/VideoPlayerView.swift
@@ -60,7 +60,7 @@ public final class VideoPlayerView: _PlatformBaseView {
 
     private var _playerLayer: AVPlayerLayer?
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     override public func layoutSubviews() {
         super.layoutSubviews()
 
@@ -114,7 +114,7 @@ public final class VideoPlayerView: _PlatformBaseView {
             object: player?.currentItem
         )
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(applicationWillEnterForeground),
@@ -173,7 +173,7 @@ public final class VideoPlayerView: _PlatformBaseView {
         }
     }
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     override public func willMove(toWindow newWindow: UIWindow?) {
         if newWindow != nil && shouldResumeOnInterruption {
             player?.play()

--- a/Tests/NukeExtensions.swift
+++ b/Tests/NukeExtensions.swift
@@ -67,7 +67,7 @@ extension ImageCaching {
 #if os(macOS)
 import Cocoa
 typealias _ImageView = NSImageView
-#elseif os(iOS) || os(tvOS)
+#elseif os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 typealias _ImageView = UIImageView
 #endif

--- a/Tests/NukeExtensionsTests/ImageViewExtensionsProgressiveDecodingTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewExtensionsProgressiveDecodingTests.swift
@@ -40,7 +40,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         }
     }
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
     @MainActor
     func testParitalImagesAreDisplayed() {

--- a/Tests/NukeExtensionsTests/ImageViewExtensionsTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewExtensionsTests.swift
@@ -9,7 +9,7 @@ import TVUIKit
 @testable import Nuke
 @testable import NukeExtensions
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 @MainActor
 class ImageViewExtensionsTests: XCTestCase {

--- a/Tests/NukeExtensionsTests/ImageViewIntegrationTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewIntegrationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import Nuke
 @testable import NukeExtensions
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 @MainActor
 class ImageViewIntegrationTests: XCTestCase {
@@ -114,7 +114,7 @@ class ImageViewIntegrationTests: XCTestCase {
     
     // MARK: - Data Passed
     
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     private final class MockView: UIView, Nuke_ImageDisplaying {
         func nuke_display(image: PlatformImage?, data: Data?) {
             recordedData.append(data)

--- a/Tests/NukeExtensionsTests/ImageViewLoadingOptionsTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewLoadingOptionsTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import Nuke
 @testable import NukeExtensions
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 @MainActor
 class ImageViewLoadingOptionsTests: XCTestCase {
@@ -198,7 +198,7 @@ class ImageViewLoadingOptionsTests: XCTestCase {
     
 #endif
     
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     
     // MARK: - Tint Colors
     
@@ -328,7 +328,7 @@ class ImageViewLoadingOptionsTests: XCTestCase {
     
     // MARK: - Misc
     
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     func testTransitionCrossDissolve() {
         // GIVEN
         var options = ImageLoadingOptions()

--- a/Tests/NukeExtensionsTests/NukeExtensionsTestsHelpers.swift
+++ b/Tests/NukeExtensionsTests/NukeExtensionsTestsHelpers.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import Nuke
 @testable import NukeExtensions
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 extension XCTestCase {
     @MainActor
     func expectToFinishLoadingImage(with request: ImageRequest,

--- a/Tests/NukeTests/ImageCacheTests.swift
+++ b/Tests/NukeTests/ImageCacheTests.swift
@@ -307,7 +307,7 @@ class ImageCacheTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(cache.totalCost, 0)
     }
     
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     func testThatSomeImagesAreRemovedOnDidEnterBackground() async {
         // GIVEN
         cache.costLimit = Int.max

--- a/Tests/NukeTests/ImageDecoderTests.swift
+++ b/Tests/NukeTests/ImageDecoderTests.swift
@@ -142,7 +142,7 @@ class ImageDecoderTests: XCTestCase {
         XCTAssertNil(container.data)
     }
     
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
     func testDecodeBaselineWebP() throws {
         if #available(OSX 11.0, iOS 14.0, watchOS 7.0, tvOS 999.0, *) {
             let data = Test.data(name: "baseline", extension: "webp")

--- a/Tests/NukeTests/ImageEncoderTests.swift
+++ b/Tests/NukeTests/ImageEncoderTests.swift
@@ -61,7 +61,7 @@ final class ImageEncoderTests: XCTestCase {
         XCTAssertNil(AssetType(data)) // TODO: update when HEIF support is added
     }
     
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     
     func testEncodeCoreImageBackedImage() throws {
         // Given

--- a/Tests/NukeTests/ImagePipelineTests/DocumentationTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/DocumentationTests.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Nuke
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import UIKit
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineFormatsTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineFormatsTests.swift
@@ -36,7 +36,7 @@ class ImagePipelineFormatsTests: XCTestCase {
         let image = try XCTUnwrap(result?.value?.image)
         let cgImage = try XCTUnwrap(image.cgImage)
         let colorSpace = try XCTUnwrap(cgImage.colorSpace)
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
         XCTAssertTrue(colorSpace.isWideGamutRGB)
 #elseif os(watchOS)
         XCTAssertFalse(colorSpace.isWideGamutRGB)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -330,7 +330,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
     
     // MARK: Scale
     
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     func testOverridingImageScaleWithFloat() throws {
         // GIVEN
         let request = ImageRequest(url: Test.url, userInfo: [.scaleKey: 7.0])

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -350,7 +350,7 @@ class ImagePipelineTests: XCTestCase {
         wait()
     }
     
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     func testThumnbailIsntDecompressed() {
         pipeline.configuration.imageDecompressingQueue.isSuspended = true
         

--- a/Tests/NukeTests/ImageProcessorsTests/CircleTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/CircleTests.swift
@@ -9,7 +9,7 @@ import XCTest
     import UIKit
 #endif
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 class ImageProcessorsCircleTests: XCTestCase {
 
     func _testThatImageIsCroppedToSquareAutomatically() throws {

--- a/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import UIKit
 #endif
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 class ImageProcessorsCoreImageFilterTests: XCTestCase {
     func testApplySepia() throws {
@@ -62,7 +62,7 @@ class ImageProcessorsCoreImageFilterTests: XCTestCase {
         }
     }
     
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     func testApplyFilterToCIImage() throws {
         // GIVEN image backed by CIImage
         let input = PlatformImage(ciImage: CIImage(cgImage: Test.image.cgImage!))

--- a/Tests/NukeTests/ImageProcessorsTests/DecompressionTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/DecompressionTests.swift
@@ -32,7 +32,7 @@ class ImageDecompressionTests: XCTestCase {
         // The original image doesn't have an alpha channel (kCGImageAlphaNone),
         // but this parameter combination (8 bbc and kCGImageAlphaNone) is not
         // supported by CGContext. Thus we are switching to a different format.
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         if #available(iOS 15.0, tvOS 15.0, *) {
             XCTAssertEqual(output.cgImage?.bitsPerPixel, 8) // Yay, preparingForDisplay supports it
             XCTAssertEqual(output.cgImage?.bitsPerComponent, 8)

--- a/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
@@ -9,7 +9,7 @@ import XCTest
     import UIKit
 #endif
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
 class ImageProcessorsGaussianBlurTest: XCTestCase {
     func testApplyBlur() {

--- a/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ImageDownsampleTests.swift
@@ -66,7 +66,7 @@ class ImageThumbnailTest: XCTestCase {
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 160, height: 90))
     }
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     func testResizeImageWithOrientationRight() throws {
         // Given an image with `right` orientation. From the user perspective,
         // the image a landscape image with s size 640x480px. The raw pixel

--- a/Tests/NukeTests/ImageProcessorsTests/ImageProcessorsProtocolExtensionsTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ImageProcessorsProtocolExtensionsTests.swift
@@ -68,7 +68,7 @@ class ImageProcessorsProtocolExtensionsTests: XCTestCase {
         XCTAssertEqual(request.processors.first?.identifier, processor.identifier)
     }
     
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
     func testPassingProcessorsUsingProtocolExtensionsCoreImageFilterWithNameOnly() throws {
         let name = "CISepiaTone"
         let processor = ImageProcessors.CoreImageFilter(name: name)

--- a/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
@@ -109,7 +109,7 @@ class ImageProcessorsResizeTests: XCTestCase {
         // Then image is resized but isn't cropped
         XCTAssertEqual(output.sizeInPixels, CGSize(width: 480, height: 320))
         let colorSpace = try XCTUnwrap(output.cgImage?.colorSpace)
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
         XCTAssertTrue(colorSpace.isWideGamutRGB)
 #elseif os(watchOS)
         XCTAssertFalse(colorSpace.isWideGamutRGB)
@@ -138,7 +138,7 @@ class ImageProcessorsResizeTests: XCTestCase {
     }
 #endif
     
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     func testResizeImageWithOrientationLeft() throws {
         // Given an image with `right` orientation. From the user perspective,
         // the image a landscape image with s size 640x480px. The raw pixel
@@ -181,7 +181,7 @@ class ImageProcessorsResizeTests: XCTestCase {
     
 #endif
     
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     func testThatScalePreserved() throws {
         // Given
         let processor = ImageProcessors.Resize(size: CGSize(width: 400, height: 400), unit: .pixels, contentMode: .aspectFill)

--- a/Tests/NukeTests/ImageProcessorsTests/RoundedCornersTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/RoundedCornersTests.swift
@@ -49,7 +49,7 @@ class ImageProcessorsRoundedCornersTests: XCTestCase {
 
         // Then image is resized but isn't cropped
         let colorSpace = try XCTUnwrap(output.cgImage?.colorSpace)
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
         XCTAssertTrue(colorSpace.isWideGamutRGB)
 #elseif os(watchOS)
         XCTAssertFalse(colorSpace.isWideGamutRGB)

--- a/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
+++ b/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
@@ -115,7 +115,7 @@ class ThreadSafetyTests: XCTestCase {
             { cache.removeAll() }
         ]
         
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         ops.append {
             NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
         }

--- a/Tests/XCTestCase+Nuke.swift
+++ b/Tests/XCTestCase+Nuke.swift
@@ -6,7 +6,7 @@ import XCTest
 import Foundation
 @testable import Nuke
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import UIKit
 #endif
 


### PR DESCRIPTION
Package support for visionOS was enabled in https://github.com/kean/Nuke/pull/743, but almost all the APIs were not specifically enabled for visionOS, so it wasn't really usable when updating my iOS app to run natively on visionOS. This enables visionOS everywhere iOS is enabled with a single exception (`UIScreen` isn't available on visionOS).

