### PR TITLE
Apply if let shorthand syntax

### DIFF
--- a/Documentation/Nuke.docc/Customization/ImageFormats/supported-image-formats.md
+++ b/Documentation/Nuke.docc/Customization/ImageFormats/supported-image-formats.md
@@ -137,7 +137,7 @@ ImageDecoderRegistry.shared.register { context in
 
 let url = URL(string: "https://upload.wikimedia.org/wikipedia/commons/9/9d/Swift_logo.svg")
 ImagePipeline.shared.loadImage(with: url) { [weak self] result in
-    guard let self = self, let data = try? result.get().container.data else {
+    guard let self, let data = try? result.get().container.data else {
         return
     }
     // You can render an image using whatever size you want, vector!

--- a/Sources/Nuke/Caching/Cache.swift
+++ b/Sources/Nuke/Caching/Cache.swift
@@ -202,7 +202,7 @@ final class Cache<Key: Hashable, Value>: @unchecked Sendable {
         let cost: Int
         let expiration: Date?
         var isExpired: Bool {
-            guard let expiration = expiration else {
+            guard let expiration else {
                 return false
             }
             return expiration.timeIntervalSinceNow < 0

--- a/Sources/Nuke/Decoding/AssetType.swift
+++ b/Sources/Nuke/Decoding/AssetType.swift
@@ -53,7 +53,7 @@ extension AssetType {
                 return false
             }
             return zip(numbers.indices, numbers).allSatisfy { index, number in
-                guard let number = number else { return true }
+                guard let number else { return true }
                 guard (index + offset) < data.count else { return false }
                 return data[index + offset] == number
             }

--- a/Sources/Nuke/Decoding/ImageDecoders+Default.swift
+++ b/Sources/Nuke/Decoding/ImageDecoders+Default.swift
@@ -51,7 +51,7 @@ extension ImageDecoders {
             defer { lock.unlock() }
 
             func makeImage() -> PlatformImage? {
-                if let thumbnail = self.thumbnail {
+                if let thumbnail {
                     return makeThumbnail(data: data, options: thumbnail)
                 }
                 return ImageDecoders.Default._decode(data, scale: scale)

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -131,7 +131,7 @@ extension PlatformImage {
     ///
     /// - parameter drawRect: `nil` by default. If `nil` will use the canvas rect.
     func draw(inCanvasWithSize canvasSize: CGSize, drawRect: CGRect? = nil) -> PlatformImage? {
-        guard let cgImage = cgImage else {
+        guard let cgImage else {
             return nil
         }
         guard let ctx = CGContext.make(cgImage, size: canvasSize) else {
@@ -151,7 +151,7 @@ extension PlatformImage {
             return preparingForDisplay()
         }
 #endif
-        guard let cgImage = cgImage else {
+        guard let cgImage else {
             return nil
         }
         return draw(inCanvasWithSize: cgImage.size, drawRect: CGRect(origin: .zero, size: cgImage.size))

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -107,7 +107,7 @@ struct ImageProcessingExtensions {
         ctx.clip()
         ctx.draw(cgImage, in: CGRect(origin: CGPoint.zero, size: cgImage.size))
 
-        if let border = border {
+        if let border {
             ctx.setStrokeColor(border.color.cgColor)
             ctx.addPath(path)
             ctx.setLineWidth(border.width)

--- a/Sources/Nuke/Internal/ImagePublisher.swift
+++ b/Sources/Nuke/Internal/ImagePublisher.swift
@@ -62,7 +62,7 @@ private final class ImageSubscription<S>: Subscription where S: Subscriber, S: S
              with: request,
              queue: nil,
              progress: { response, _, _ in
-                 if let response = response {
+                 if let response {
                     // Send progressively decoded image (if enabled and if any)
                      _ = subscriber.receive(response)
                  }

--- a/Sources/Nuke/Internal/ImagePublisher.swift
+++ b/Sources/Nuke/Internal/ImagePublisher.swift
@@ -47,7 +47,7 @@ private final class ImageSubscription<S>: Subscription where S: Subscriber, S: S
 
     func request(_ demand: Subscribers.Demand) {
         guard demand > 0 else { return }
-        guard let subscriber = subscriber else { return }
+        guard let subscriber else { return }
 
         if let image = pipeline.cache[request] {
             _ = subscriber.receive(ImageResponse(container: image, request: request, cacheType: .memory))

--- a/Sources/Nuke/Internal/LinkedList.swift
+++ b/Sources/Nuke/Internal/LinkedList.swift
@@ -30,7 +30,7 @@ final class LinkedList<Element> {
 
     /// Adds a node to the end of the list.
     func append(_ node: Node) {
-        if let last = last {
+        if let last {
             last.next = node
             node.previous = last
             self.last = node

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -169,7 +169,7 @@ public final class ImagePipeline: @unchecked Sendable {
                         continuation.resume(throwing: CancellationError())
                     }
                     self.startImageTask(task, progress: { response, progress in
-                        if let response = response {
+                        if let response {
                             context?.previews?.yield(response)
                         } else {
                             context?.progress?.yield(progress)

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -308,7 +308,7 @@ public final class ImagePipeline: @unchecked Sendable {
 
         tasks[task] = makeTaskLoadImage(for: task.request)
             .subscribe(priority: task.priority.taskPriority, subscriber: task) { [weak self, weak task] event in
-                guard let self = self, let task = task else { return }
+                guard let self, let task else { return }
 
                 if event.isCompleted {
                     self.tasks[task] = nil
@@ -425,7 +425,7 @@ public final class ImagePipeline: @unchecked Sendable {
 
         tasks[task] = makeTaskLoadData(for: task.request)
             .subscribe(priority: task.priority.taskPriority, subscriber: task) { [weak self, weak task] event in
-                guard let self = self, let task = task else { return }
+                guard let self, let task else { return }
 
                 if event.isCompleted {
                     self.tasks[task] = nil

--- a/Sources/Nuke/Pipeline/ImagePipelineConfiguration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipelineConfiguration.swift
@@ -201,7 +201,7 @@ extension ImagePipeline {
             config.dataLoader = dataLoader
 
             let dataCache = try? DataCache(name: name)
-            if let sizeLimit = sizeLimit {
+            if let sizeLimit {
                 dataCache?.sizeLimit = sizeLimit
             }
             config.dataCache = dataCache

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -128,7 +128,7 @@ public final class ImagePrefetcher: @unchecked Sendable {
         }
         let task = Task(request: request, key: key)
         task.operation = queue.add { [weak self] finish in
-            guard let self = self else { return finish() }
+            guard let self else { return finish() }
             self.loadImage(task: task, finish: finish)
         }
         tasks[key] = task

--- a/Sources/Nuke/Tasks/AsyncTask.swift
+++ b/Sources/Nuke/Tasks/AsyncTask.swift
@@ -243,7 +243,7 @@ extension AsyncTask {
         /// - notes: Returns `nil` if the task is already disposed.
         func subscribe<NewValue>(_ task: AsyncTask<NewValue, Error>, onValue: @escaping (Value, Bool) -> Void) -> TaskSubscription? {
             subscribe(subscriber: task) { [weak task] event in
-                guard let task = task else { return }
+                guard let task else { return }
                 switch event {
                 case let .value(value, isCompleted):
                     onValue(value, isCompleted)

--- a/Sources/Nuke/Tasks/AsyncTask.swift
+++ b/Sources/Nuke/Tasks/AsyncTask.swift
@@ -174,7 +174,7 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
         }
 
         inlineSubscription?.closure(event)
-        if let subscriptions = subscriptions {
+        if let subscriptions {
             for subscription in subscriptions.values {
                 subscription.closure(event)
             }
@@ -203,7 +203,7 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
     // MARK: - Priority
 
     private func updatePriority(suggestedPriority: TaskPriority?) {
-        if let suggestedPriority = suggestedPriority, suggestedPriority >= priority {
+        if let suggestedPriority, suggestedPriority >= priority {
             // No need to recompute, won't go higher than that
             priority = suggestedPriority
             return
@@ -212,7 +212,7 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
         var newPriority = inlineSubscription?.priority
         // Same as subscriptions.map { $0?.priority }.max() but without allocating
         // any memory for redundant arrays
-        if let subscriptions = subscriptions {
+        if let subscriptions {
             for subscription in subscriptions.values {
                 if newPriority == nil {
                     newPriority = subscription.priority

--- a/Sources/Nuke/Tasks/OperationTask.swift
+++ b/Sources/Nuke/Tasks/OperationTask.swift
@@ -18,7 +18,7 @@ final class OperationTask<T: Sendable>: AsyncTask<T, Swift.Error> {
 
     override func start() {
         operation = queue.add { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let result = Result(catching: { try self.process() })
             self.pipeline.queue.async {
                 switch result {

--- a/Sources/Nuke/Tasks/TaskFetchDecodedImage.swift
+++ b/Sources/Nuke/Tasks/TaskFetchDecodedImage.swift
@@ -50,7 +50,7 @@ final class TaskFetchDecodedImage: ImagePipelineTask<ImageResponse> {
             didFinishDecoding(decoder: decoder, context: context, result: decode())
         } else {
             operation = pipeline.configuration.imageDecodingQueue.add { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 let result = decode()
                 self.pipeline.queue.async {

--- a/Sources/Nuke/Tasks/TaskFetchDecodedImage.swift
+++ b/Sources/Nuke/Tasks/TaskFetchDecodedImage.swift
@@ -74,7 +74,7 @@ final class TaskFetchDecodedImage: ImagePipelineTask<ImageResponse> {
     // Lazily creates decoding for task
     private func getDecoder(for context: ImageDecodingContext) -> (any ImageDecoding)? {
         // Return the existing processor in case it has already been created.
-        if let decoder = self.decoder {
+        if let decoder {
             return decoder
         }
         let decoder = pipeline.delegate.imageDecoder(for: context, pipeline: pipeline)

--- a/Sources/Nuke/Tasks/TaskFetchOriginalImageData.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalImageData.swift
@@ -100,7 +100,7 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
         // Check if this is the first response.
         if urlResponse == nil {
             // See if the server confirmed that the resumable data can be used
-            if let resumableData = resumableData, ResumableData.isResumedResponse(response) {
+            if let resumableData, ResumableData.isResumedResponse(response) {
                 data = resumableData.data
                 resumedDataCount = Int64(resumableData.data.count)
                 signpost(self, "LoadImageData", .event, "Resumed with data \(Formatter.bytes(resumedDataCount))")
@@ -128,7 +128,7 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
     }
 
     private func dataTaskDidFinish(error: Swift.Error?) {
-        if let error = error {
+        if let error {
             tryToSaveResumableData()
             send(error: .dataLoadingFailed(error: error))
             return

--- a/Sources/Nuke/Tasks/TaskFetchOriginalImageData.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalImageData.swift
@@ -23,7 +23,7 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
             // Rate limiter is synchronized on pipeline's queue. Delayed work is
             // executed asynchronously also on the same queue.
             rateLimiter.execute { [weak self] in
-                guard let self = self, !self.isDisposed else {
+                guard let self, !self.isDisposed else {
                     return false
                 }
                 self.loadData(urlRequest: urlRequest)
@@ -41,7 +41,7 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
             // Wrap data request in an operation to limit the maximum number of
             // concurrent data tasks.
             operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
-                guard let self = self else {
+                guard let self else {
                     return finish()
                 }
                 self.pipeline.queue.async {
@@ -72,13 +72,13 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
 
         let dataLoader = pipeline.delegate.dataLoader(for: request, pipeline: pipeline)
         let dataTask = dataLoader.loadData(with: urlRequest, didReceiveData: { [weak self] data, response in
-            guard let self = self else { return }
+            guard let self else { return }
             self.pipeline.queue.async {
                 self.dataTask(didReceiveData: data, response: response)
             }
         }, completion: { [weak self] error in
             finish() // Finish the operation!
-            guard let self = self else { return }
+            guard let self else { return }
             signpost(self, "LoadImageData", .end, "Finished with size \(Formatter.bytes(self.data.count))")
             self.pipeline.queue.async {
                 self.dataTaskDidFinish(error: error)
@@ -86,7 +86,7 @@ final class TaskFetchOriginalImageData: ImagePipelineTask<(Data, URLResponse?)> 
         })
 
         onCancelled = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             signpost(self, "LoadImageData", .end, "Cancelled")
             dataTask.cancel()

--- a/Sources/Nuke/Tasks/TaskFetchWithPublisher.swift
+++ b/Sources/Nuke/Tasks/TaskFetchWithPublisher.swift
@@ -16,7 +16,7 @@ final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
             // Wrap data request in an operation to limit the maximum number of
             // concurrent data tasks.
             operation = pipeline.configuration.dataLoadingQueue.add { [weak self] finish in
-                guard let self = self else {
+                guard let self else {
                     return finish()
                 }
                 self.pipeline.queue.async {
@@ -39,12 +39,12 @@ final class TaskFetchWithPublisher: ImagePipelineTask<(Data, URLResponse?)> {
 
         let cancellable = publisher.sink(receiveCompletion: { [weak self] result in
             finish() // Finish the operation!
-            guard let self = self else { return }
+            guard let self else { return }
             self.pipeline.queue.async {
                 self.dataTaskDidFinish(result)
             }
         }, receiveValue: { [weak self] data in
-            guard let self = self else { return }
+            guard let self else { return }
             self.pipeline.queue.async {
                 self.data.append(data)
             }

--- a/Sources/Nuke/Tasks/TaskLoadData.swift
+++ b/Sources/Nuke/Tasks/TaskLoadData.swift
@@ -22,7 +22,7 @@ final class TaskLoadData: ImagePipelineTask<(Data, URLResponse?)> {
             pipeline.cache.cachedData(for: request)
         }
         pipeline.queue.async {
-            if let data = data {
+            if let data {
                 self.send(value: (data, nil), isCompleted: true)
             } else {
                 self.loadData()

--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -67,7 +67,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
             didDecodeCachedData(decode())
         } else {
             operation = pipeline.configuration.imageDecodingQueue.add { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 let response = decode()
                 self.pipeline.queue.async {
                     self.didDecodeCachedData(response)
@@ -161,7 +161,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
                 return response
             }
         }).subscribe(priority: priority) { [weak self] event in
-            guard let self = self else { return }
+            guard let self else { return }
             if event.isCompleted {
                 self.dependency2 = nil
             }
@@ -196,7 +196,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
         guard !isDisposed else { return }
 
         operation = pipeline.configuration.imageDecompressingQueue.add { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let response = signpost("DecompressImage", isCompleted ? "FinalImage" : "ProgressiveImage") {
                 self.pipeline.delegate.decompress(response: response, request: self.request, pipeline: self.pipeline)
@@ -240,7 +240,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
         let encoder = pipeline.delegate.imageEncoder(for: context, pipeline: pipeline)
         let key = pipeline.cache.makeDataCacheKey(for: request)
         pipeline.configuration.imageEncodingQueue.addOperation { [weak pipeline, request] in
-            guard let pipeline = pipeline else { return }
+            guard let pipeline else { return }
             let encodedData = signpost("EncodeImage") {
                 encoder.encode(response.container, context: context)
             }

--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -40,7 +40,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
             pipeline.cache.cachedData(for: request)
         }
         pipeline.queue.async {
-            if let data = data {
+            if let data {
                 self.didReceiveCachedData(data)
             } else {
                 self.fetchImage()
@@ -77,7 +77,7 @@ final class TaskLoadImage: ImagePipelineTask<ImageResponse> {
     }
 
     private func didDecodeCachedData(_ response: ImageResponse?) {
-        if let response = response {
+        if let response {
             decompressImage(response, isCompleted: true, isFromDiskCache: true)
         } else {
             fetchImage()

--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -286,7 +286,7 @@ private final class ImageViewController {
         }
 
         task = pipeline.loadImage(with: request, queue: .main, progress: { [weak self] response, completedCount, totalCount in
-            if let response = response, options.isProgressiveRenderingEnabled {
+            if let response, options.isProgressiveRenderingEnabled {
                 self?.handle(partialImage: response)
             }
             progress?(response, completedCount, totalCount)

--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -238,7 +238,7 @@ private final class ImageViewController {
     ) -> ImageTask? {
         cancelOutstandingTask()
 
-        guard let imageView = imageView else {
+        guard let imageView else {
             return nil
         }
 
@@ -254,7 +254,7 @@ private final class ImageViewController {
         }
 
         // Handle a scenario where request is `nil` (in the same way as a failure)
-        guard var request = request else {
+        guard var request else {
             if options.isPrepareForReuseEnabled {
                 imageView.nuke_display(image: nil, data: nil)
             }
@@ -323,7 +323,7 @@ private final class ImageViewController {
 #if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
 
     private func display(_ image: ImageContainer, _ isFromMemory: Bool, _ response: ImageLoadingOptions.ResponseType) {
-        guard let imageView = imageView else {
+        guard let imageView else {
             return
         }
 
@@ -371,7 +371,7 @@ extension ImageViewController {
 #if os(iOS) || os(tvOS) || os(visionOS)
 
     private func runFadeInTransition(image: ImageContainer, params: ImageLoadingOptions.Transition.Parameters, response: ImageLoadingOptions.ResponseType) {
-        guard let imageView = imageView else {
+        guard let imageView else {
             return
         }
 
@@ -385,7 +385,7 @@ extension ImageViewController {
     }
 
     private func runSimpleFadeIn(image: ImageContainer, params: ImageLoadingOptions.Transition.Parameters) {
-        guard let imageView = imageView else {
+        guard let imageView else {
             return
         }
 

--- a/Sources/NukeUI/FetchImage.swift
+++ b/Sources/NukeUI/FetchImage.swift
@@ -104,7 +104,7 @@ public final class FetchImage: ObservableObject, Identifiable {
 
         reset()
 
-        guard var request = request else {
+        guard var request else {
             handle(result: .failure(ImagePipeline.Error.imageRequestMissing))
             return
         }
@@ -132,7 +132,7 @@ public final class FetchImage: ObservableObject, Identifiable {
         let task = pipeline.loadImage(
             with: request,
             progress: { [weak self] response, completed, total in
-                guard let self = self else { return }
+                guard let self else { return }
                 if let response {
                     withTransaction(self.transaction) {
                         self.handle(preview: response)
@@ -143,7 +143,7 @@ public final class FetchImage: ObservableObject, Identifiable {
                 }
             },
             completion: { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 withTransaction(self.transaction) {
                     self.handle(result: result.mapError { $0 })
                 }
@@ -205,7 +205,7 @@ public final class FetchImage: ObservableObject, Identifiable {
         // Not using `first()` because it should support progressive decoding
         isLoading = true
         cancellable = publisher.sink(receiveCompletion: { [weak self] completion in
-            guard let self = self else { return }
+            guard let self else { return }
             self.isLoading = false
             switch completion {
             case .finished:
@@ -216,7 +216,7 @@ public final class FetchImage: ObservableObject, Identifiable {
                 self.result = .failure(error)
             }
         }, receiveValue: { [weak self] response in
-            guard let self = self else { return }
+            guard let self else { return }
             self.lastResponse = response
             self.imageContainer = response.container
         })

--- a/Sources/NukeUI/FetchImage.swift
+++ b/Sources/NukeUI/FetchImage.swift
@@ -112,7 +112,7 @@ public final class FetchImage: ObservableObject, Identifiable {
         if !processors.isEmpty && request.processors.isEmpty {
             request.processors = processors
         }
-        if let priority = self.priority {
+        if let priority {
             request.priority = priority
         }
 
@@ -133,7 +133,7 @@ public final class FetchImage: ObservableObject, Identifiable {
             with: request,
             progress: { [weak self] response, completed, total in
                 guard let self = self else { return }
-                if let response = response {
+                if let response {
                     withTransaction(self.transaction) {
                         self.handle(preview: response)
                     }

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -134,7 +134,7 @@ public struct LazyImage<Content: View>: View {
 
     public var body: some View {
         ZStack {
-            if let makeContent = makeContent {
+            if let makeContent {
                 makeContent(viewModel)
             } else {
                 makeDefaultContent(for: viewModel)

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -261,7 +261,7 @@ public final class LazyImageView: _PlatformBaseView {
             isResetNeeded = true
         }
 
-        guard var request = request else {
+        guard var request else {
             handle(result: .failure(ImagePipeline.Error.imageRequestMissing), isSync: true)
             return
         }
@@ -290,7 +290,7 @@ public final class LazyImageView: _PlatformBaseView {
             with: request,
             queue: .main,
             progress: { [weak self] response, completed, total in
-                guard let self = self else { return }
+                guard let self else { return }
                 let progress = ImageTask.Progress(completed: completed, total: total)
                 if let response {
                     self.handle(preview: response)
@@ -358,7 +358,7 @@ public final class LazyImageView: _PlatformBaseView {
     }
 
     private func setPlaceholderImage(_ placeholderImage: PlatformImage?) {
-        guard let placeholderImage = placeholderImage else {
+        guard let placeholderImage else {
             placeholderView = nil
             return
         }
@@ -393,7 +393,7 @@ public final class LazyImageView: _PlatformBaseView {
     }
 
     private func setFailureImage(_ failureImage: PlatformImage?) {
-        guard let failureImage = failureImage else {
+        guard let failureImage else {
             failureView = nil
             return
         }

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -125,7 +125,7 @@ public final class LazyImageView: _PlatformBaseView {
     /// dynamically. `nil` by default.
     public var priority: ImageRequest.Priority? {
         didSet {
-            if let priority = self.priority {
+            if let priority {
                 imageTask?.priority = priority
             }
         }
@@ -266,10 +266,10 @@ public final class LazyImageView: _PlatformBaseView {
             return
         }
 
-        if let processors = self.processors, !processors.isEmpty, request.processors.isEmpty {
+        if let processors, !processors.isEmpty, request.processors.isEmpty {
             request.processors = processors
         }
-        if let priority = self.priority {
+        if let priority {
             request.priority = priority
         }
 
@@ -292,7 +292,7 @@ public final class LazyImageView: _PlatformBaseView {
             progress: { [weak self] response, completed, total in
                 guard let self = self else { return }
                 let progress = ImageTask.Progress(completed: completed, total: total)
-                if let response = response {
+                if let response {
                     self.handle(preview: response)
                     self.onPreview?(response)
                 } else {
@@ -366,10 +366,10 @@ public final class LazyImageView: _PlatformBaseView {
     }
 
     private func setPlaceholderView(_ oldView: _PlatformBaseView?, _ newView: _PlatformBaseView?) {
-        if let oldView = oldView {
+        if let oldView {
             oldView.removeFromSuperview()
         }
-        if let newView = newView {
+        if let newView {
             newView.isHidden = !imageView.isHidden
             insertSubview(newView, at: 0)
             setNeedsUpdateConstraints()
@@ -401,10 +401,10 @@ public final class LazyImageView: _PlatformBaseView {
     }
 
     private func setFailureView(_ oldView: _PlatformBaseView?, _ newView: _PlatformBaseView?) {
-        if let oldView = oldView {
+        if let oldView {
             oldView.removeFromSuperview()
         }
-        if let newView = newView {
+        if let newView {
             newView.isHidden = true
             insertSubview(newView, at: 0)
             setNeedsUpdateConstraints()

--- a/Sources/NukeVideo/VideoPlayerView.swift
+++ b/Sources/NukeVideo/VideoPlayerView.swift
@@ -130,7 +130,7 @@ public final class VideoPlayerView: _PlatformBaseView {
     }
 
     public func play() {
-        guard let asset = asset else {
+        guard let asset else {
             return
         }
 

--- a/Tests/CombineExtensions.swift
+++ b/Tests/CombineExtensions.swift
@@ -31,7 +31,7 @@ extension Subscriptions {
         }
 
         func start(_ closure: @escaping (AnySubscriber<Output, Failure>) -> Void) {
-            if let subscriber = subscriber {
+            if let subscriber {
                 closure(AnySubscriber(subscriber))
             }
         }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -316,7 +316,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         // applies the remaining processors and delivers it
         let previewDelivered = self.expectation(description: "previewDelivered")
         pipeline.loadImage(with: request) { response, _, _ in
-            guard let response = response else {
+            guard let response else {
                 return XCTFail()
             }
             XCTAssertEqual(response.image.nk_test_processorIDs, ["2"])
@@ -339,7 +339,7 @@ class ImagePipelineProgressiveDecodingTests: XCTestCase {
         // applies the remaining processors and delivers it
         let previewDelivered = self.expectation(description: "previewDelivered")
         pipeline.loadImage(with: request) { response, _, _ in
-            guard let response = response else {
+            guard let response else {
                 return
             }
             XCTAssertTrue(response.container.isPreview)


### PR DESCRIPTION
if let shorthand syntax was introduced since swift 5.7. ([SE-3045](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md))

I replace codes by using following regexs.

regex | replacement
--- | --- 
if let (.+)? = \1 \{ | if let $1 {
if let (.+)? = \1, | if let $1,
if let (.+)? = self.\1 \{ | if let $1 {
if let (.+)? = self.\1, | if let $1,