### PR TITLE
Add usePlaceholderAsFailure to show placeholder in case of image loading failure

### DIFF
--- a/Sources/NukeUI/Internal.swift
+++ b/Sources/NukeUI/Internal.swift
@@ -29,12 +29,14 @@ typealias _PlatformColor = UIColor
 extension _PlatformBaseView {
     @discardableResult
     func pinToSuperview() -> [NSLayoutConstraint] {
+        guard let superview else { return [] }
+        
         translatesAutoresizingMaskIntoConstraints = false
         let constraints = [
-            topAnchor.constraint(equalTo: superview!.topAnchor),
-            bottomAnchor.constraint(equalTo: superview!.bottomAnchor),
-            leftAnchor.constraint(equalTo: superview!.leftAnchor),
-            rightAnchor.constraint(equalTo: superview!.rightAnchor)
+            topAnchor.constraint(equalTo: superview.topAnchor),
+            bottomAnchor.constraint(equalTo: superview.bottomAnchor),
+            leftAnchor.constraint(equalTo: superview.leftAnchor),
+            rightAnchor.constraint(equalTo: superview.rightAnchor)
         ]
         NSLayoutConstraint.activate(constraints)
         return constraints
@@ -42,10 +44,12 @@ extension _PlatformBaseView {
 
     @discardableResult
     func centerInSuperview() -> [NSLayoutConstraint] {
+        guard let superview else { return [] }
+        
         translatesAutoresizingMaskIntoConstraints = false
         let constraints = [
-            centerXAnchor.constraint(equalTo: superview!.centerXAnchor),
-            centerYAnchor.constraint(equalTo: superview!.centerYAnchor)
+            centerXAnchor.constraint(equalTo: superview.centerXAnchor),
+            centerYAnchor.constraint(equalTo: superview.centerYAnchor)
         ]
         NSLayoutConstraint.activate(constraints)
         return constraints

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -53,6 +53,8 @@ public final class LazyImageView: _PlatformBaseView {
         }
     }
 
+    public var usePlaceholderAsFailure = true
+    
     private var placeholderViewConstraints: [NSLayoutConstraint] = []
 
     // MARK: Failure View
@@ -323,7 +325,11 @@ public final class LazyImageView: _PlatformBaseView {
         case let .success(response):
             display(response.container, isFromMemory: isSync)
         case .failure:
-            setFailureViewHidden(false)
+            if usePlaceholderAsFailure {
+                setPlaceholderViewHidden(false)
+            } else {
+                setFailureViewHidden(false)
+            }
         }
 
         imageTask = nil


### PR DESCRIPTION

I added `usePlaceholderAsFailure` because I think there are a lot of cases where people might want to keep the placeholder visible even if the image fails to load.
