### PR TITLE
Fix Xcode 15.3 concurrency warnings when using `Screen.scale`

### DIFF
--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -314,7 +314,6 @@ extension CGSize {
     }
 }
 
-@MainActor
 enum Screen {
 #if os(iOS) || os(tvOS)
     /// Returns the current screen scale.


### PR DESCRIPTION
Fixes https://github.com/kean/Nuke/issues/765.  The viral nature of concurrency unfortunately means that the blast radius is pretty high for just 2 warning fixes:

- Adds `@MainActor` to direct and downstream callers of `Screen.scale`
- Adds `@MainActor` to downstream callers in tests
- Moves `@MainActor` from XCTestCases to individual test functions instead
- Switches the image pipeline thread safety test from resizing to blurring.  This avoids marking the test as `@MainActor` which would destroy its ability to test threading.