### PR TITLE
Fix image loading test

### DIFF
--- a/Tests/NukeExtensionsTests/ImageViewIntegrationTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewIntegrationTests.swift
@@ -70,7 +70,7 @@ class ImageViewIntegrationTests: XCTestCase {
     func testLoadImageWithInvalidURLString() {
         // WHEN
         let expectation = self.expectation(description: "Image loaded")
-        NukeExtensions.loadImage(with: URL(string: "http://example.com/invalid url"), into: imageView) { result in
+        NukeExtensions.loadImage(with: URL(string: ""), into: imageView) { result in
             XCTAssertEqual(result.error, .imageRequestMissing)
             expectation.fulfill()
         }


### PR DESCRIPTION
This PR fixes `ImageViewIntegrationTests.testLoadingWithNilURL()` because the test has failed.
Loading an image from an invalid URL should return a data loading error?