### PR TITLE
Fix thumbnail key for image request

### DIFF
--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -367,7 +367,7 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
         /// (``ImageProcessors/Resize``).
         ///
         /// - note: You must be using the default image decoder to make it work.
-        public static let thumbnailKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/thumbmnailKey"
+        public static let thumbnailKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/thumbnail"
     }
 
     /// Thumbnail options.


### PR DESCRIPTION
This PR fixes the raw value of `ImageRequest.UserInfoKey.thumbnailKey` to match the format with other keys.