### PR TITLE
Correct fade transition when content modes differ

### DIFF
--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -400,7 +400,7 @@ extension ImageViewController {
         )
     }
 
-    /// Performs cross-dissolve animation alonside transition to a new content
+    /// Performs cross-dissolve animation alongside transition to a new content
     /// mode. This isn't natively supported feature and it requires a second
     /// image view. There might be better ways to implement it.
     private func runCrossDissolveWithContentMode(imageView: UIImageView, image: ImageContainer, params: ImageLoadingOptions.Transition.Parameters) {
@@ -410,8 +410,12 @@ extension ImageViewController {
         // Create a transition view which mimics current view's contents.
         transitionView.image = imageView.image
         transitionView.contentMode = imageView.contentMode
-        imageView.addSubview(transitionView)
-        transitionView.frame = imageView.bounds
+        imageView.superview?.insertSubview(transitionView, aboveSubview: imageView)
+        transitionView.frame = imageView.frame
+        transitionView.clipsToBounds = imageView.clipsToBounds
+        transitionView.layer.cornerRadius = imageView.layer.cornerRadius
+        transitionView.layer.cornerCurve = imageView.layer.cornerCurve
+        transitionView.layer.maskedCorners = imageView.layer.maskedCorners
 
         // "Manual" cross-fade.
         transitionView.alpha = 1


### PR DESCRIPTION
Previously `runCrossDissolveWithContentMode` was adding the `transitionView` as a subview of the `imageView` and settting `imageView.alpha = 0`. This resulted in the image immediately disappearing since the `alpha` of subviews is multiplied by the `alpha` of super views.

This PR adds the `transitionView` to the `superview` of the `imageView` so the two image view's alphas are independent and properly cross-dissolve.