### PR TITLE
Improve cross dissolve transition accuracy

### DIFF
--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -435,9 +435,10 @@ extension ImageViewController {
                 transitionView.alpha = 0
                 imageView.alpha = 1
             },
-            completion: { isCompleted in
-                if isCompleted {
+            completion: { [weak transitionView] isCompleted in
+                if isCompleted, let transitionView {
                     transitionView.removeFromSuperview()
+                    transitionView.image = nil
                 }
             }
         )

--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -410,12 +410,17 @@ extension ImageViewController {
         // Create a transition view which mimics current view's contents.
         transitionView.image = imageView.image
         transitionView.contentMode = imageView.contentMode
-        imageView.superview?.insertSubview(transitionView, aboveSubview: imageView)
         transitionView.frame = imageView.frame
+        transitionView.tintColor = imageView.tintColor
+        transitionView.tintAdjustmentMode = imageView.tintAdjustmentMode
+        transitionView.preferredImageDynamicRange = imageView.preferredImageDynamicRange
+        transitionView.preferredSymbolConfiguration = imageView.preferredSymbolConfiguration
+        transitionView.isHidden = imageView.isHidden
         transitionView.clipsToBounds = imageView.clipsToBounds
         transitionView.layer.cornerRadius = imageView.layer.cornerRadius
         transitionView.layer.cornerCurve = imageView.layer.cornerCurve
         transitionView.layer.maskedCorners = imageView.layer.maskedCorners
+        imageView.superview?.insertSubview(transitionView, aboveSubview: imageView)
 
         // "Manual" cross-fade.
         transitionView.alpha = 1

--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -413,7 +413,9 @@ extension ImageViewController {
         transitionView.frame = imageView.frame
         transitionView.tintColor = imageView.tintColor
         transitionView.tintAdjustmentMode = imageView.tintAdjustmentMode
+        #if swift(>=5.9) // preferredImageDynamicRange was back-ported to all iOS/tvOS versions, but only available when using the iOS/tvOS 17+ SDKs
         transitionView.preferredImageDynamicRange = imageView.preferredImageDynamicRange
+        #endif
         transitionView.preferredSymbolConfiguration = imageView.preferredSymbolConfiguration
         transitionView.isHidden = imageView.isHidden
         transitionView.clipsToBounds = imageView.clipsToBounds


### PR DESCRIPTION
This PR configures the cross-dissolve image transition view to more accurately mimic the original image view. It expands upon PR https://github.com/kean/Nuke/pull/786, which added the mimicking of view masking. Now, the tint color, symbol configuration, and preferred dynamic range values are also mimicked.