### PR TITLE
Fix “unrecognized selector sent to instance” crash in transition on iOS < 17

### DIFF
--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -413,9 +413,9 @@ extension ImageViewController {
         transitionView.frame = imageView.frame
         transitionView.tintColor = imageView.tintColor
         transitionView.tintAdjustmentMode = imageView.tintAdjustmentMode
-        #if swift(>=5.9) // preferredImageDynamicRange was back-ported to all iOS/tvOS versions, but only available when using the iOS/tvOS 17+ SDKs
-        transitionView.preferredImageDynamicRange = imageView.preferredImageDynamicRange
-        #endif
+        if #available(iOS 17.0, tvOS 17.0, *) {
+            transitionView.preferredImageDynamicRange = imageView.preferredImageDynamicRange
+        }
         transitionView.preferredSymbolConfiguration = imageView.preferredSymbolConfiguration
         transitionView.isHidden = imageView.isHidden
         transitionView.clipsToBounds = imageView.clipsToBounds


### PR DESCRIPTION
Prevents an “unrecognized selector sent to instance” crash caused by UIKit incorrectly marking [`UIImageIVew.preferredImageDynamicRange`](https://developer.apple.com/documentation/uikit/uiimageview/4173133-preferredimagedynamicrange) available since iOS 2.0. Its actual availability is iOS 17.0+

The reference to `preferredImageDynamicRange` was added in https://github.com/kean/Nuke/pull/787 and released in Nuke v12.7.1

<img width="908" alt="Incorrect documentation" src="https://github.com/kean/Nuke/assets/915431/cbd806f3-f44b-4aea-9db6-cefedf46dd92">