### PR TITLE
.storeAll now stores processed images for locals too, as it should be

### DIFF
--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -174,8 +174,7 @@ final class TaskLoadImage: AsyncPipelineTask<ImageResponse>, @unchecked Sendable
 
     private func shouldStoreResponseInDataCache(_ response: ImageResponse) -> Bool {
         guard !response.container.isPreview,
-              !(response.cacheType == .disk),
-              !(request.url?.isLocalResource ?? false) else {
+              !(response.cacheType == .disk) else {
             return false
         }
         let isProcessed = !request.processors.isEmpty || request.thumbnail != nil


### PR DESCRIPTION
I needed this for correct behavior in my app...
Read closely:

    /// Stores both processed images and the original image data.
        ///
        /// - note: If the **resource is local** (has file:// or data:// scheme),
        /// only the **processed images are stored**.
        case storeAll
        
PS i love this lib