### PR TITLE
execute Task on ImagePipeline DispatchQueue using executorPreference

### DIFF
--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -264,6 +264,9 @@
 		0CF58FF726DAAC3800D2650D /* ImageDownsampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF58FF626DAAC3800D2650D /* ImageDownsampleTests.swift */; };
 		2DFD93B0233A6AB300D84DB9 /* ImagePipelineProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DFD93AF233A6AB300D84DB9 /* ImagePipelineProcessorTests.swift */; };
 		4480674C2A448C9F00DE7CF8 /* DataPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4480674B2A448C9F00DE7CF8 /* DataPublisherTests.swift */; };
+		DA64188C2C9B63DE00673B6E /* OnQueueTaskExecuter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA64188B2C9B63CA00673B6E /* OnQueueTaskExecuter.swift */; };
+		DA6418D32CA0978B00673B6E /* AsyncTaskCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6418D22CA0978900673B6E /* AsyncTaskCreator.swift */; };
+		DA6418D52CA0AADE00673B6E /* OnQueueTaskExecuterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6418D42CA0AADB00673B6E /* OnQueueTaskExecuterTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -529,6 +532,9 @@
 		0CF58FF626DAAC3800D2650D /* ImageDownsampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownsampleTests.swift; sourceTree = "<group>"; };
 		2DFD93AF233A6AB300D84DB9 /* ImagePipelineProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePipelineProcessorTests.swift; sourceTree = "<group>"; };
 		4480674B2A448C9F00DE7CF8 /* DataPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPublisherTests.swift; sourceTree = "<group>"; };
+		DA64188B2C9B63CA00673B6E /* OnQueueTaskExecuter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnQueueTaskExecuter.swift; sourceTree = "<group>"; };
+		DA6418D22CA0978900673B6E /* AsyncTaskCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTaskCreator.swift; sourceTree = "<group>"; };
+		DA6418D42CA0AADB00673B6E /* OnQueueTaskExecuterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnQueueTaskExecuterTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -689,6 +695,7 @@
 		0C55FD22285679DC000FD2C9 /* NukeTests */ = {
 			isa = PBXGroup;
 			children = (
+				DA6418D42CA0AADB00673B6E /* OnQueueTaskExecuterTests.swift */,
 				0C1E620A1D6F817700AD5CF5 /* ImageRequestTests.swift */,
 				4480674B2A448C9F00DE7CF8 /* DataPublisherTests.swift */,
 				0C7C06871BCA888800089D7F /* ImageCacheTests.swift */,
@@ -990,6 +997,8 @@
 		0CC36A0B25B8BBF800811018 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				DA6418D22CA0978900673B6E /* AsyncTaskCreator.swift */,
+				DA64188B2C9B63CA00673B6E /* OnQueueTaskExecuter.swift */,
 				0CA4ECB926E6850B00BAC8E5 /* Graphics.swift */,
 				0CC36A1825B8BC2500811018 /* RateLimiter.swift */,
 				0CC36A2425B8BC4900811018 /* Operation.swift */,
@@ -1655,6 +1664,7 @@
 				0C91B0F42438E38B007F9100 /* CompositionTests.swift in Sources */,
 				0C91B0F62438E3CB007F9100 /* GaussianBlurTests.swift in Sources */,
 				0C6D0A8820E574400037B68F /* MockDataCache.swift in Sources */,
+				DA6418D52CA0AADE00673B6E /* OnQueueTaskExecuterTests.swift in Sources */,
 				0C472F812654AA46007FC0F0 /* DeprecationTests.swift in Sources */,
 				0C9B6E7620B9F3E2001924B8 /* ImagePipelineCoalescingTests.swift in Sources */,
 				0C91B0F22438E374007F9100 /* AnonymousTests.swift in Sources */,
@@ -1707,6 +1717,7 @@
 			files = (
 				0C0FD6001CA47FE1002A78FB /* ImageProcessing.swift in Sources */,
 				0CC36A4125B8BCAC00811018 /* Log.swift in Sources */,
+				DA6418D32CA0978B00673B6E /* AsyncTaskCreator.swift in Sources */,
 				0CA4ECB126E6840900BAC8E5 /* ImageEncoders+ImageIO.swift in Sources */,
 				0C063F94266524190018F2C2 /* ImageResponse.swift in Sources */,
 				0C0FD5FC1CA47FE1002A78FB /* ImageCache.swift in Sources */,
@@ -1718,6 +1729,7 @@
 				0C179C7B2283597F008AB488 /* ImageEncoding.swift in Sources */,
 				0CB4030125B6639200F5A241 /* TaskLoadImage.swift in Sources */,
 				0CA5D954263CCEA500E08E17 /* ImagePublisher.swift in Sources */,
+				DA64188C2C9B63DE00673B6E /* OnQueueTaskExecuter.swift in Sources */,
 				0CA4ECCD26E68FA100BAC8E5 /* DataLoading.swift in Sources */,
 				0CA4ECAF26E683FD00BAC8E5 /* ImageEncoders+Default.swift in Sources */,
 				0CC36A2525B8BC4900811018 /* Operation.swift in Sources */,

--- a/Sources/Nuke/Internal/AsyncTaskCreator.swift
+++ b/Sources/Nuke/Internal/AsyncTaskCreator.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// AsyncTaskCreator creates Swift `Task` that
+/// execute the underlying passed operation.
+///
+/// AsyncTaskCreator can be thought of as a builder
+/// of Swift `Task` that could be used to
+/// build custom tasks in different environments.
+struct AsyncTaskCreator<Result: Sendable> {
+    typealias Operation = @Sendable () async throws -> Result
+
+    let _createTask: (_ operation: @escaping Operation) -> Task<Result, Error>
+
+    func createTask(operation: @escaping Operation) -> Task<Result, Error> {
+        _createTask(operation)
+    }
+}

--- a/Sources/Nuke/Internal/OnQueueTaskExecuter.swift
+++ b/Sources/Nuke/Internal/OnQueueTaskExecuter.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// OnQueueTaskExecuter is a custom `TaskExecutor` that
+/// runs jobs on a specific `DispatchQueue`.
+@available(iOSApplicationExtension 18.0, *)
+final class OnQueueTaskExecuter: TaskExecutor {
+    let queue: DispatchQueue
+    
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    func enqueue(_ job: UnownedJob) {
+        queue.async {
+            job.runSynchronously(on: self.asUnownedTaskExecutor())
+        }
+    }
+
+    func asUnownedTaskExecutor() -> UnownedTaskExecutor {
+        UnownedTaskExecutor(ordinary: self)
+    }
+}

--- a/Tests/NukeTests/OnQueueTaskExecuterTests.swift
+++ b/Tests/NukeTests/OnQueueTaskExecuterTests.swift
@@ -1,0 +1,20 @@
+@testable import Nuke
+import XCTest
+
+@available(iOS 18.0, *)
+class OnQueueTaskExecuterTests: XCTestCase {
+    func testThatTasksRunsOnQueue() async {
+        // Given
+        let queue = DispatchQueue(label: "task.queue")
+        let executor = OnQueueTaskExecuter(queue: queue)
+        let expectation = self.expectation(description: "All work executed")
+
+        // When, Then
+        Task(executorPreference: executor) {
+            dispatchPrecondition(condition: .onQueue(queue))
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation], timeout: 0.1)
+    }
+}


### PR DESCRIPTION
The ImagePipeline is currently creating a Task and then immediately switching to its internal queue. This results in unnecessary context switching from the Task’s originating queue to the pipeline’s internal queue. 

So, to optimize this and reduce this overhead, we can leverage a custom Task Executor introduced in iOS 18 to ensure that the Task's queue pool chooses the internal queue directly, thus  improving performance and minimizing context switching.

### Note:
I have not added a specific Test that validate this workflow, as in, the  Task is executed on the executer's queue. This is because the current test stack in Nuke is large and I could not figure out exactly with the limited time I have, how to leverage current components to write the tests.

I will leave it here, and hopefully, If needed, another, more codebase knowledgeable contributor can implement a test for it.