### PR TITLE
Mark DataLoading completion closures as Sendable

### DIFF
--- a/Sources/Nuke/Loading/DataLoading.swift
+++ b/Sources/Nuke/Loading/DataLoading.swift
@@ -11,8 +11,8 @@ public protocol DataLoading: Sendable {
     /// - parameter completion: Must be called once after all (or none in case
     /// of an error) `didReceiveData` closures have been called.
     func loadData(with request: URLRequest,
-                  didReceiveData: @escaping (Data, URLResponse) -> Void,
-                  completion: @escaping (Error?) -> Void) -> any Cancellable
+                  didReceiveData: @Sendable @escaping (Data, URLResponse) -> Void,
+                  completion: @Sendable @escaping (Error?) -> Void) -> any Cancellable
 }
 
 /// A unit of work that can be cancelled.


### PR DESCRIPTION
I know you're focusing on Nuke 13, but this little change would help us out a lot without any downsides.

We implement our own `DataLoading` loader using async/await but we can't use the `DataLoading` closures in a `Task` due to them not being Sendable.

🙏 