### PR TITLE
fix: include WebP data in ImageContainer

### DIFF
--- a/Sources/Nuke/Decoding/ImageDecoders+Default.swift
+++ b/Sources/Nuke/Decoding/ImageDecoders+Default.swift
@@ -64,7 +64,7 @@ extension ImageDecoders {
             let type = AssetType(data)
             var container = ImageContainer(image: image)
             container.type = type
-            if type == .gif {
+            if type == .gif || type == .webp {
                 container.data = data
             }
             if numberOfScans > 0 {

--- a/Sources/Nuke/Encoding/ImageEncoding.swift
+++ b/Sources/Nuke/Encoding/ImageEncoding.swift
@@ -25,7 +25,7 @@ public protocol ImageEncoding: Sendable {
 
 extension ImageEncoding {
     public func encode(_ container: ImageContainer, context: ImageEncodingContext) -> Data? {
-        if container.type == .gif {
+        if container.type == .gif || container.type == .webp {
             return container.data
         }
         return self.encode(container.image)

--- a/Tests/NukeTests/ImageDecoderTests.swift
+++ b/Tests/NukeTests/ImageDecoderTests.swift
@@ -149,7 +149,8 @@ class ImageDecoderTests: XCTestCase {
             let data = Test.data(name: "baseline", extension: "webp")
             let container = try ImageDecoders.Default().decode(data)
             XCTAssertEqual(container.image.sizeInPixels, CGSize(width: 550, height: 368))
-            XCTAssertNil(container.data)
+            XCTAssertEqual(container.type, .webp)
+            XCTAssertNotNil(container.data)
         }
     }
 #endif


### PR DESCRIPTION
## Problem

When decoding WebP images, `nuke_display(image:data:)` always receives `nil` for the `data` parameter. This makes it impossible to implement animated WebP support (or any feature that needs the raw WebP bytes) via the `nuke_display` override.

## Root Cause

In `ImageDecoders.Default.decode(_:)`, `container.data` is only populated for GIF images:

```swift
if type == .gif {
    container.data = data  // WebP was missing here
}
```

The same GIF-only guard exists in the default `ImageEncoding.encode(_:context:)` implementation, which means re-encoding a WebP `ImageContainer` also falls back to lossy re-encoding instead of returning the original bytes.

## Solution

Extend both conditions to include `.webp`:

- `ImageDecoders+Default.swift`: attach raw data to the container for WebP, mirroring the existing GIF behaviour
- `ImageEncoding.swift`: return `container.data` directly when encoding a WebP container, avoiding unnecessary re-encoding

## Testing

Updated the existing `testDecodeBaselineWebP` test:
- Added `XCTAssertEqual(container.type, .webp)`
- Changed `XCTAssertNil(container.data)` → `XCTAssertNotNil(container.data)` to assert the data is now correctly attached

Fixes #853