### PR TITLE
Fix GaussianBlur crash on grayscale images

### DIFF
--- a/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
@@ -54,8 +54,11 @@ private extension CGImage {
         if kernelSize % 2 == 0 { kernelSize += 1 }
 
         let size = self.size
-        guard let inputCtx = CGContext.make(self, size: size, alphaInfo: .premultipliedLast),
-              let outputCtx = CGContext.make(self, size: size, alphaInfo: .premultipliedLast) else {
+        // vImageBoxConvolve_ARGB8888 needs a 32-bit ARGB layout. A grayscale
+        // source yields a 16-bit gray+alpha context (half the row stride vImage
+        // expects), so force RGB for the scratch contexts.
+        guard let inputCtx = CGContext.make(self, size: size, alphaInfo: .premultipliedLast, colorSpace: CGColorSpaceCreateDeviceRGB()),
+              let outputCtx = CGContext.make(self, size: size, alphaInfo: .premultipliedLast, colorSpace: CGColorSpaceCreateDeviceRGB()) else {
             return nil
         }
         inputCtx.draw(self, in: CGRect(origin: .zero, size: size))

--- a/Tests/Helpers/Helpers.swift
+++ b/Tests/Helpers/Helpers.swift
@@ -51,6 +51,27 @@ enum Test {
         Test.image(named: "fixture", extension: "jpeg")
     }
 
+    // Grayscale (monochrome color space) image for color-space-sensitive paths.
+    static func grayscaleImage(width: Int, height: Int) -> PlatformImage {
+        let ctx = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        )!
+        ctx.setFillColor(CGColor(gray: 0.5, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let cgImage = ctx.makeImage()!
+#if os(macOS)
+        return NSImage(cgImage: cgImage, size: NSSize(width: width, height: height))
+#else
+        return UIImage(cgImage: cgImage)
+#endif
+    }
+
     // Test.image size is 640 x 480 pixels
     static var container: ImageContainer {
         ImageContainer(image: image)

--- a/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Testing
+import Foundation
 @testable import Nuke
 
 #if !os(macOS)
@@ -94,6 +95,17 @@ struct ImageProcessorsGaussianBlurTests {
         // WHEN / THEN - must not crash and must return a valid image
         let output = try #require(processor.process(Test.image))
         #expect(output.sizeInPixels == Test.image.sizeInPixels)
+    }
+
+    @Test func blurGrayscaleImageDoesNotCrash() throws {
+        // GIVEN - a grayscale (monochrome color space) source. Its 16-bit
+        // gray+alpha scratch context used to crash vImageBoxConvolve.
+        let image = Test.grayscaleImage(width: 400, height: 225)
+        let processor = ImageProcessors.GaussianBlur(radius: 8)
+
+        // WHEN / THEN - must not crash and must return a same-size image
+        let output = try #require(processor.process(image))
+        #expect(output.sizeInPixels == CGSize(width: 400, height: 225))
     }
 
     @Test func differentRadiiProduceDifferentDescriptions() {


### PR DESCRIPTION
`ImageProcessors.GaussianBlur` crashes (SIGSEGV) on grayscale (monochrome) images like black-and-white JPEGs. It shows up on iOS and tvOS; on macOS the same out-of-bounds write happens but usually corrupts memory silently instead of faulting.

`vImageBoxConvolve_ARGB8888` assumes 4 bytes per pixel, but the scratch contexts were created with the source's own color space. For a grayscale image that's a 16-bit gray+alpha buffer (2 bytes per pixel), so vImage ends up reading and writing past the end of the allocation.

The fix creates the scratch contexts in device RGB so the buffer layout matches what vImage expects (drawing a gray image into an RGB context is lossless).