### PR TITLE
Fix cache initialization for mergeable libraries

### DIFF
--- a/Sources/Nuke/Caching/Cache.swift
+++ b/Sources/Nuke/Caching/Cache.swift
@@ -79,7 +79,7 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
         self.memoryPressure.setEventHandler { [weak self] in
             self?.removeAllCachedValues()
         }
-        self.memoryPressure.resume()
+        self.memoryPressure.activate()
 
 #if os(iOS) || os(tvOS) || os(visionOS)
         Task {


### PR DESCRIPTION
## Summary

- initialize the memory-pressure dispatch source with `activate()` when Nuke is used with mergeable libraries
- avoid resuming an already active source during cache initialization

Fixes #826

## Validation

- `swift build --target Nuke` ✅
- `swift test --filter NukeTests` could not complete locally because the installed CommandLineTools cannot resolve the existing `SwiftUIMacros.StateMacro` plugin while compiling NukeUI; this is unrelated to the changed file
