### PR TITLE
Fix isResetEnabled progressive image loading

### DIFF
--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -242,8 +242,10 @@ public final class LazyImageView: _PlatformBaseView {
         reset(clearImage: true)
     }
 
-    private func reset(clearImage: Bool) {
-        cancel()
+    private func reset(clearImage: Bool, shouldCancel: Bool = true) {
+        if shouldCancel {
+            cancel()
+        }
 
         if clearImage {
             if imageView.image != nil { imageView.image = nil }
@@ -365,7 +367,7 @@ public final class LazyImageView: _PlatformBaseView {
     }
 
     private func display(_ container: ImageContainer, isFromMemory: Bool) {
-        resetIfNeeded(clearImage: false)
+        resetIfNeeded(clearImage: false, shouldCancel: !container.isPreview)
 
         // Remove the view created for the previous response (a progressive
         // preview or a cached preview) before displaying the new one.
@@ -496,9 +498,9 @@ public final class LazyImageView: _PlatformBaseView {
         case fill
     }
 
-    private func resetIfNeeded(clearImage: Bool = true) {
+    private func resetIfNeeded(clearImage: Bool = true, shouldCancel: Bool = true) {
         if isResetNeeded {
-            reset(clearImage: clearImage)
+            reset(clearImage: clearImage, shouldCancel: shouldCancel)
         }
     }
 }

--- a/Tests/NukeUITests/LazyImageViewTests.swift
+++ b/Tests/NukeUITests/LazyImageViewTests.swift
@@ -651,6 +651,44 @@ struct LazyImageViewTests {
         #expect(view.imageView.image != nil)
         #expect(view.imageView.image !== firstImage)
     }
+
+    @Test func isResetEnabledFalseDisplaysProgressivePreviewsWithoutCancellingTask() async throws {
+        let progressiveLoader = MockProgressiveDataLoader()
+        view.pipeline = ImagePipeline {
+            $0.dataLoader = progressiveLoader
+            $0.imageCache = nil
+            $0.isProgressiveDecodingEnabled = true
+            $0.progressiveDecodingInterval = 0
+            $0.imageProcessingQueue.maxConcurrentOperationCount = 1
+        }
+        // The reset is deferred until a new image is ready, so it is applied
+        // when the first preview is displayed.
+        view.isResetEnabled = false
+
+        var previewCount = 0
+        var taskCancelledByPreview = false
+        let previewExpectation = TestExpectation()
+        view.onPreview = { _ in
+            previewCount += 1
+            // Applying the deferred reset must not cancel the ongoing request.
+            if view.imageTask == nil { taskCancelledByPreview = true }
+            if previewCount == 1 { previewExpectation.fulfill() }
+            progressiveLoader.resume()
+        }
+
+        let completionExpectation = TestExpectation()
+        view.onCompletion = { _ in completionExpectation.fulfill() }
+        view.url = Test.url
+
+        await previewExpectation.wait()
+        #expect(view.imageView.image != nil)
+        try #require(!taskCancelledByPreview)
+
+        // The request survived the preview and delivered the final image.
+        await completionExpectation.wait()
+        #expect(previewCount > 0)
+        #expect(view.imageView.image != nil)
+    }
 }
 
 #endif


### PR DESCRIPTION
Fixes #883, progressive image download canceled if `isResetEnabled == true` when request is started