### PR TITLE
Don't store image previews in the disk cache

### DIFF
--- a/Sources/Nuke/Pipeline/ImagePipeline+Cache.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Cache.swift
@@ -72,7 +72,10 @@ extension ImagePipeline.Cache {
     /// - note: Default ``DataCache`` stores data asynchronously, so it's safe
     /// to call this method even from the main thread.
     ///
-    /// - note: Image previews are not stored.
+    /// - note: Image previews are never stored in the disk cache. They are
+    /// stored in the memory cache only if
+    /// ``ImagePipeline/Configuration-swift.struct/isStoringPreviewsInMemoryCache``
+    /// is enabled (it is, by default).
     ///
     /// - parameters:
     ///   - image: The image container to store in the cache.
@@ -83,7 +86,7 @@ extension ImagePipeline.Cache {
         if caches.contains(.memory) {
             storeCachedImageInMemoryCache(image, for: request)
         }
-        if caches.contains(.disk) {
+        if caches.contains(.disk), !image.isPreview {
             if let data = encodeImage(image, for: request) {
                 storeCachedData(data, for: request)
             }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
@@ -305,6 +305,76 @@ struct ImagePipelineCacheTests {
         #expect(diskCache.cachedData(for: cache.makeDataCacheKey(for: request)) != nil)
     }
 
+    @Test func storeCachedImagePreviewIsNotStoredInDiskCache() {
+        // GIVEN a progressive preview
+        let request = Test.request
+        let preview = ImageContainer(image: Test.image, isPreview: true)
+
+        // WHEN
+        cache.storeCachedImage(preview, for: request)
+
+        // THEN it never reaches the disk cache
+        #expect(cache.cachedData(for: request) == nil)
+        #expect(diskCache.cachedData(for: cache.makeDataCacheKey(for: request)) == nil)
+        #expect(!cache.containsData(for: request))
+    }
+
+    @Test func storeCachedImagePreviewIsNotStoredInDiskCacheWhenDiskIsTheOnlyLayer() {
+        // GIVEN a progressive preview
+        let request = Test.request
+        let preview = ImageContainer(image: Test.image, isPreview: true)
+
+        // WHEN
+        cache.storeCachedImage(preview, for: request, caches: [.disk])
+
+        // THEN nothing is written to either layer
+        #expect(cache.cachedData(for: request) == nil)
+        #expect(memoryCache[cache.makeImageCacheKey(for: request)] == nil)
+    }
+
+    @Test func storeCachedImageNonPreviewIsStoredInDiskCache() {
+        // GIVEN a final image
+        let request = Test.request
+
+        // WHEN
+        cache.storeCachedImage(Test.container, for: request)
+
+        // THEN it is written to the disk cache
+        #expect(cache.cachedData(for: request) != nil)
+        #expect(diskCache.cachedData(for: cache.makeDataCacheKey(for: request)) != nil)
+    }
+
+    @Test func storeCachedImagePreviewInMemoryCacheWhenEnabled() throws {
+        // GIVEN
+        let pipeline = pipeline.reconfigured {
+            $0.isStoringPreviewsInMemoryCache = true
+        }
+        let request = Test.request
+
+        // WHEN
+        pipeline.cache.storeCachedImage(ImageContainer(image: Test.image, isPreview: true), for: request)
+
+        // THEN the memory cache behavior is unchanged, the disk cache is untouched
+        let image = try #require(pipeline.cache.cachedImage(for: request, caches: [.memory]))
+        #expect(image.isPreview)
+        #expect(pipeline.cache.cachedData(for: request) == nil)
+    }
+
+    @Test func storeCachedImagePreviewInMemoryCacheWhenDisabled() {
+        // GIVEN
+        let pipeline = pipeline.reconfigured {
+            $0.isStoringPreviewsInMemoryCache = false
+        }
+        let request = Test.request
+
+        // WHEN
+        pipeline.cache.storeCachedImage(ImageContainer(image: Test.image, isPreview: true), for: request)
+
+        // THEN it's stored in neither layer
+        #expect(pipeline.cache.cachedImage(for: request, caches: [.memory]) == nil)
+        #expect(pipeline.cache.cachedData(for: request) == nil)
+    }
+
     // MARK: Cached Data
 
     @Test func storeCachedData() {


### PR DESCRIPTION
`ImagePipeline.Cache.storeCachedImage` documented that previews are not stored, but the disk branch had no `isPreview` check. An app passing the latest progressive `ImageContainer` would write a half-decoded scan into the data cache under the final image key, and it would be served back as the completed image on the next load.

The disk branch now skips previews, matching the invariant `TaskLoadImage.shouldStoreResponseInDataCache` already enforces. Memory-cache behavior is unchanged (still governed by `isStoringPreviewsInMemoryCache`). Doc comment updated to describe the real contract, plus tests covering both layers.