### PR TITLE
Fix Resize crop path ignoring upscale: false

### DIFF
--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -45,18 +45,24 @@ struct ImageProcessingExtensions {
     }
 
     /// Crops the input image to the given size and resizes it if needed.
-    /// - note: this method will always upscale.
-    func byResizingAndCropping(to targetSize: CGSize) -> PlatformImage? {
+    /// - note: if `upscale` is `false`, the image is never enlarged: it's
+    /// cropped to the target aspect ratio at its native resolution instead.
+    func byResizingAndCropping(to targetSize: CGSize, upscale: Bool) -> PlatformImage? {
         guard let cgImage = image.cgImage else {
             return nil
         }
 #if canImport(UIKit)
         let targetSize = targetSize.rotatedForOrientation(CGImagePropertyOrientation(image.imageOrientation))
 #endif
-        let scale = cgImage.size.getScale(targetSize: targetSize, contentMode: .aspectFill)
+        var scale = cgImage.size.getScale(targetSize: targetSize, contentMode: .aspectFill)
+        var canvasSize = targetSize
+        if scale > 1 && !upscale {
+            canvasSize = targetSize.scaled(by: 1 / scale).rounded()
+            scale = 1
+        }
         let scaledSize = cgImage.size.scaled(by: scale)
-        let drawRect = scaledSize.centeredInRectWithSize(targetSize)
-        return image.draw(inCanvasWithSize: targetSize, drawRect: drawRect)
+        let drawRect = scaledSize.centeredInRectWithSize(canvasSize)
+        return image.draw(inCanvasWithSize: canvasSize, drawRect: drawRect)
     }
 
     func byDrawingInCircle(border: ImageProcessingOptions.Border?) -> PlatformImage? {

--- a/Sources/Nuke/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Resize.swift
@@ -57,7 +57,7 @@ extension ImageProcessors {
 
         public func process(_ image: PlatformImage) -> PlatformImage? {
             if crop && contentMode == .aspectFill {
-                return image.processed.byResizingAndCropping(to: size.cgSize)
+                return image.processed.byResizingAndCropping(to: size.cgSize, upscale: upscale)
             }
             return image.processed.byResizing(to: size.cgSize, contentMode: contentMode, upscale: upscale)
         }

--- a/Tests/NukeTests/GraphicsTests.swift
+++ b/Tests/NukeTests/GraphicsTests.swift
@@ -199,12 +199,12 @@ struct GraphicsTests {
         #expect(output.sizeInPixels == CGSize(width: 100, height: 100))
     }
 
-    @Test func resizingAndCroppingAlwaysUpscales() throws {
+    @Test func resizingAndCroppingUpscalesWhenRequested() throws {
         // Given
         let input = Test.rgbImage(width: 40, height: 20)
 
         // When
-        let output = try #require(input.processed.byResizingAndCropping(to: CGSize(width: 100, height: 100)))
+        let output = try #require(input.processed.byResizingAndCropping(to: CGSize(width: 100, height: 100), upscale: true))
 
         // Then
         #expect(output.sizeInPixels == CGSize(width: 100, height: 100))
@@ -223,7 +223,7 @@ struct GraphicsTests {
         #expect(input.processed.byAddingRoundedCorners(radius: 10) == nil)
         #expect(input.draw(inCanvasWithSize: CGSize(width: 10, height: 10)) == nil)
         #expect(input.processed.byResizing(to: CGSize(width: 10, height: 10), contentMode: .aspectFill, upscale: true) == nil)
-        #expect(input.processed.byResizingAndCropping(to: CGSize(width: 10, height: 10)) == nil)
+        #expect(input.processed.byResizingAndCropping(to: CGSize(width: 10, height: 10), upscale: true) == nil)
         #expect(input.decompressed(isUsingPrepareForDisplay: false) == nil)
     }
 }

--- a/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
@@ -90,6 +90,51 @@ struct ImageProcessorsResizeTests {
         #expect(output.sizeInPixels == CGSize(width: 400, height: 400))
     }
 
+    @Test func thatCroppedImageIsntUpscaledByDefault() throws {
+        // Given a target larger than the image (640x480px)
+        let processor = ImageProcessors.Resize(size: CGSize(width: 960, height: 960), unit: .pixels, crop: true)
+
+        // When
+        let output = try #require(processor.process(Test.image), "Failed to process an image")
+
+        // Then the image is cropped to the target aspect ratio but isn't enlarged
+        #expect(output.sizeInPixels == CGSize(width: 480, height: 480))
+    }
+
+    @Test func thatCroppedImageIsUpscaledIfOptionIsEnabled() throws {
+        // Given
+        let processor = ImageProcessors.Resize(size: CGSize(width: 960, height: 960), unit: .pixels, crop: true, upscale: true)
+
+        // When
+        let output = try #require(processor.process(Test.image), "Failed to process an image")
+
+        // Then
+        #expect(output.sizeInPixels == CGSize(width: 960, height: 960))
+    }
+
+    @Test func thatCroppedImageIsntUpscaledWithNonSquareTarget() throws {
+        // Given a portrait image and a larger square target
+        let input = Test.rgbImage(width: 100, height: 200)
+        let processor = ImageProcessors.Resize(size: CGSize(width: 500, height: 500), unit: .pixels, crop: true)
+
+        // When
+        let output = try #require(processor.process(input), "Failed to process an image")
+
+        // Then the image is cropped to a square at its native resolution
+        #expect(output.sizeInPixels == CGSize(width: 100, height: 100))
+    }
+
+    @Test(arguments: [false, true]) func thatCroppedImageIsDownscaledRegardlessOfUpscaleOption(upscale: Bool) throws {
+        // Given a target smaller than the image (640x480px)
+        let processor = ImageProcessors.Resize(size: CGSize(width: 300, height: 300), unit: .pixels, crop: true, upscale: upscale)
+
+        // When
+        let output = try #require(processor.process(Test.image), "Failed to process an image")
+
+        // Then
+        #expect(output.sizeInPixels == CGSize(width: 300, height: 300))
+    }
+
     @Test func thatImageIsntCroppedWithAspectFitMode() throws {
         // Given
         let processor = ImageProcessors.Resize(size: CGSize(width: 480, height: 480), unit: .pixels, contentMode: .aspectFit, crop: true)


### PR DESCRIPTION
`ImageProcessors.Resize` never forwarded `upscale` to `byResizingAndCropping`, so `crop: true` always enlarged images smaller than the target (contradicting the docs), and produced two cache entries with identical content for `upscale: true`/`false`.

`upscale` is now forwarded and honored: with `upscale: false` the image is cropped to the target aspect ratio at its native resolution instead of being enlarged. Downscaling and `upscale: true` are unchanged.

Adds coverage in `ResizeTests`.