### PR TITLE
Compare URL schemes case-insensitively in isLocalResource

### DIFF
--- a/Sources/Nuke/Internal/Extensions.swift
+++ b/Sources/Nuke/Internal/Extensions.swift
@@ -32,7 +32,9 @@ private let sha1HexChars: [UInt8] = Array("0123456789abcdef".utf8)
 
 extension URL {
     var isLocalResource: Bool {
-        scheme == "file" || scheme == "data"
+        // URI schemes are case-insensitive (RFC 3986).
+        guard let scheme = scheme?.lowercased() else { return false }
+        return scheme == "file" || scheme == "data"
     }
 }
 

--- a/Tests/NukeTests/ExtensionsTests.swift
+++ b/Tests/NukeTests/ExtensionsTests.swift
@@ -1,0 +1,52 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import Foundation
+@testable import Nuke
+
+@Suite(.timeLimit(.minutes(5)))
+struct ExtensionsTests {
+
+    // MARK: - URL.isLocalResource
+
+    @Test(arguments: [
+        "file:///var/tmp/image.jpeg",
+        "FILE:///var/tmp/image.jpeg",
+        "File:///var/tmp/image.jpeg"
+    ])
+    func fileURLIsLocalResourceRegardlessOfSchemeCase(string: String) throws {
+        let url = try #require(URL(string: string))
+        #expect(url.isLocalResource)
+    }
+
+    @Test(arguments: [
+        "data:image/jpeg;base64,AAAA",
+        "Data:image/jpeg;base64,AAAA",
+        "DATA:image/jpeg;base64,AAAA"
+    ])
+    func dataURLIsLocalResourceRegardlessOfSchemeCase(string: String) throws {
+        let url = try #require(URL(string: string))
+        #expect(url.isLocalResource)
+    }
+
+    @Test(arguments: [
+        "http://example.com/image.jpeg",
+        "https://example.com/image.jpeg",
+        "HTTP://example.com/image.jpeg",
+        "ftp://example.com/image.jpeg",
+        "filesystem://example.com/image.jpeg",
+        "database:image.jpeg"
+    ])
+    func remoteURLIsNotLocalResource(string: String) throws {
+        let url = try #require(URL(string: string))
+        #expect(!url.isLocalResource)
+    }
+
+    @Test func urlWithoutSchemeIsNotLocalResource() throws {
+        let url = try #require(URL(string: "images/image.jpeg"))
+        #expect(url.scheme == nil)
+        #expect(!url.isLocalResource)
+    }
+}

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineLocalResourcesTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineLocalResourcesTests.swift
@@ -107,6 +107,41 @@ struct ImagePipelineLocalResourcesTests {
         }
     }
 
+    // MARK: - Case-Insensitive Schemes
+
+    /// URI schemes are case-insensitive (RFC 3986), so `FILE://` has to be
+    /// treated exactly like `file://`.
+    @Test func uppercaseFileURLIsLoadedDirectlyAndIsNotStoredInTheDataCache() async throws {
+        // Given
+        let fileURL = try makeTemporaryFile(with: Test.data)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let path = fileURL.absoluteString.dropFirst("file://".count)
+        let url = try #require(URL(string: "FILE://" + path))
+
+        // When
+        let image = try await pipeline.image(for: ImageRequest(url: url))
+
+        // Then
+        #expect(image.sizeInPixels == CGSize(width: 640, height: 480))
+        #expect(dataLoader.createdTaskCount == 0)
+        #expect(dataCache.writeCount == 0)
+        #expect(dataCache.store.isEmpty)
+    }
+
+    @Test func uppercaseDataURLIsLoadedDirectlyAndIsNotStoredInTheDataCache() async throws {
+        // Given
+        let url = try #require(URL(string: "DATA:image/jpeg;base64,\(Test.data.base64EncodedString())"))
+
+        // When
+        let image = try await pipeline.image(for: ImageRequest(url: url))
+
+        // Then
+        #expect(image.sizeInPixels == CGSize(width: 640, height: 480))
+        #expect(dataLoader.createdTaskCount == 0)
+        #expect(dataCache.writeCount == 0)
+        #expect(dataCache.store.isEmpty)
+    }
+
     // MARK: - Disabling Local Resources Support
 
     @Test func localResourcesGoThroughTheDataLoaderWhenSupportIsDisabled() async throws {


### PR DESCRIPTION
`URL.isLocalResource` compared `scheme` against "file"/"data" with `==`, but URI schemes are case-insensitive (RFC 3986). URLs such as `FILE://…` or `Data:…` were therefore treated as remote: they were loaded through the data loader instead of read directly, and their bytes were duplicated into `DataCache`.

The comparison is now case-insensitive. Adds unit tests for `isLocalResource` and pipeline tests asserting that `FILE://` and `DATA:` URLs skip the data loader and are not written to the disk cache.