### PR TITLE
Fix a crash when resizing to a non-finite size

### DIFF
--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -36,6 +36,9 @@ struct ImageProcessingExtensions {
 #if canImport(UIKit)
         let targetSize = targetSize.rotatedForOrientation(CGImagePropertyOrientation(image.imageOrientation))
 #endif
+        guard targetSize.isFinite else {
+            return nil // Nothing to draw, and NaN would slip past the scale check
+        }
         let scale = cgImage.size.getScale(targetSize: targetSize, contentMode: contentMode)
         guard scale < 1 || upscale else {
             return image // The image doesn't require scaling
@@ -54,6 +57,9 @@ struct ImageProcessingExtensions {
 #if canImport(UIKit)
         let targetSize = targetSize.rotatedForOrientation(CGImagePropertyOrientation(image.imageOrientation))
 #endif
+        guard targetSize.isFinite else {
+            return nil // Nothing to draw
+        }
         var scale = cgImage.size.getScale(targetSize: targetSize, contentMode: .aspectFill)
         var canvasSize = targetSize
         if scale > 1 && !upscale {
@@ -178,10 +184,17 @@ extension CGContext {
     }
 
     static func make(_ image: CGImage, size: CGSize, alphaInfo: CGImageAlphaInfo?, colorSpace: CGColorSpace) -> CGContext? {
-        CGContext(
+        // The target sizes come straight from the user, e.g. from
+        // `ImageProcessors.Resize`, and `Int(_:)` traps on the values that an
+        // `Int` can't represent – NaN, infinity, and anything out of range.
+        guard let width = size.width.pixelDimension,
+              let height = size.height.pixelDimension else {
+            return nil
+        }
+        return CGContext(
             data: nil,
-            width: Int(size.width),
-            height: Int(size.height),
+            width: width,
+            height: height,
             bitsPerComponent: 8,
             bytesPerRow: 0,
             space: colorSpace,
@@ -208,9 +221,26 @@ extension CGFloat {
         case .points: return self * Screen.scale
         }
     }
+
+    /// Returns the value as a canvas dimension in pixels, or `nil` if it can't
+    /// be represented by one because it's not finite, is out of range, or is
+    /// too small to draw in. The comparisons are always `false` for NaN.
+    var pixelDimension: Int? {
+        // The upper bound is well above anything Core Graphics can allocate and
+        // is only there to keep the conversion in range on 32-bit platforms.
+        guard self >= 1, self <= 1_073_741_824 else {
+            return nil
+        }
+        return Int(self)
+    }
 }
 
 extension CGSize {
+    /// Returns `true` if neither of the dimensions is NaN or infinite.
+    var isFinite: Bool {
+        width.isFinite && height.isFinite
+    }
+
     func getScale(targetSize: CGSize, contentMode: ImageProcessingOptions.ContentMode) -> CGFloat {
         let scaleHor = targetSize.width / width
         let scaleVert = targetSize.height / height

--- a/Tests/NukeTests/GraphicsTests.swift
+++ b/Tests/NukeTests/GraphicsTests.swift
@@ -210,6 +210,46 @@ struct GraphicsTests {
         #expect(output.sizeInPixels == CGSize(width: 100, height: 100))
     }
 
+    // MARK: - Invalid Target Sizes
+
+    /// The target sizes come straight from the user and converting a non-finite
+    /// `CGFloat` to an `Int` traps, so the invalid sizes have to be rejected
+    /// before the context is created.
+    @Test(arguments: [
+        CGSize(width: CGFloat.nan, height: CGFloat.nan),
+        CGSize(width: 40, height: CGFloat.nan),
+        CGSize(width: CGFloat.nan, height: 40),
+        CGSize(width: CGFloat.infinity, height: CGFloat.infinity),
+        CGSize(width: 40, height: CGFloat.infinity),
+        CGSize(width: -CGFloat.infinity, height: -CGFloat.infinity),
+        CGSize(width: 0, height: 0),
+        CGSize(width: -40, height: -40)
+    ])
+    func drawingPrimitivesReturnNilForInvalidTargetSizes(targetSize: CGSize) {
+        // Given
+        let input = Test.rgbImage(width: 40, height: 40)
+
+        // Then every drawing primitive bails out instead of crashing
+        #expect(input.draw(inCanvasWithSize: targetSize) == nil)
+        #expect(input.processed.byResizing(to: targetSize, contentMode: .aspectFill, upscale: false) == nil)
+        #expect(input.processed.byResizing(to: targetSize, contentMode: .aspectFill, upscale: true) == nil)
+        #expect(input.processed.byResizing(to: targetSize, contentMode: .aspectFit, upscale: false) == nil)
+        #expect(input.processed.byResizing(to: targetSize, contentMode: .aspectFit, upscale: true) == nil)
+        #expect(input.processed.byResizingAndCropping(to: targetSize, upscale: false) == nil)
+        #expect(input.processed.byResizingAndCropping(to: targetSize, upscale: true) == nil)
+    }
+
+    @Test func drawingReturnsNilForFiniteButOutOfRangeTargetSize() {
+        // Given a size that is finite but is way out of the `Int` range
+        let input = Test.rgbImage(width: 40, height: 40)
+        let targetSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+        // Then
+        #expect(input.draw(inCanvasWithSize: targetSize) == nil)
+        #expect(input.processed.byResizing(to: targetSize, contentMode: .aspectFill, upscale: true) == nil)
+        #expect(input.processed.byResizingAndCropping(to: targetSize, upscale: true) == nil)
+    }
+
     // MARK: - Images Without a Backing CGImage
 
     @Test func drawingPrimitivesReturnNilForImagesWithoutCGImage() {

--- a/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
@@ -400,6 +400,25 @@ struct ImageProcessorsResizeTests {
         #expect(size.width > 0)
     }
 
+    /// The processing is expected to fail instead of trapping when converting
+    /// the target size to the context dimensions, and to fail consistently
+    /// regardless of whether the image is cropped.
+    @Test(arguments: [
+        CGSize(width: CGFloat.nan, height: CGFloat.nan),
+        CGSize(width: 400, height: CGFloat.nan),
+        CGSize(width: CGFloat.infinity, height: CGFloat.infinity),
+        CGSize(width: 400, height: -CGFloat.infinity),
+        CGSize(width: 0, height: 0),
+        CGSize(width: -400, height: -400)
+    ], [true, false])
+    func thatProcessingFailsForInvalidTargetSize(size: CGSize, crop: Bool) {
+        // Given
+        let processor = ImageProcessors.Resize(size: size, unit: .pixels, crop: crop)
+
+        // When/Then
+        #expect(processor.process(Test.image) == nil)
+    }
+
     // Just make sure these initializers are still available.
     @Test func initializer() {
         _ = ImageProcessors.Resize(height: 10)


### PR DESCRIPTION
`CGContext.make` converted the target size with `Int(_:)`, which traps on a `CGFloat` that is NaN, infinite, or out of the `Int` range, so `ImageProcessors.Resize(size: CGSize(width: .nan, height: .nan))` crashed the processing queue.

The dimensions are now validated before the conversion and the context creation returns `nil`, which the processors already treat as a failure. The resizing paths also reject non-finite target sizes up front so that cropping and non-cropping behave the same way instead of silently returning the original image.

Based on #886, which touches the same function. Merge that one first; the base will retarget to `main` automatically.