### PR TITLE
Fix disk cache key collisions

### DIFF
--- a/Sources/Nuke/Pipeline/ImagePipeline+Cache.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Cache.swift
@@ -201,7 +201,14 @@ extension ImagePipeline.Cache {
         if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
             return customKey
         }
-        return "\(request.imageID ?? "")\(request.thumbnail?.identifier ?? "")\(ImageProcessors.Composition(request.processors).identifier)"
+        // The components are always separated to make sure that different
+        // requests never produce the same key, e.g. an image ID that ends with
+        // the same characters that the next component starts with.
+        return [
+            request.imageID ?? "",
+            request.thumbnail?.identifier ?? "",
+            ImageProcessors.Composition(request.processors).identifier
+        ].joined(separator: ImageProcessors.Composition.separator)
     }
 
     // MARK: Misc

--- a/Sources/Nuke/Processing/ImageProcessors+Composition.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Composition.swift
@@ -45,8 +45,13 @@ extension ImageProcessors {
 
         /// Returns combined identifier of all the underlying processors.
         public var identifier: String {
-            processors.map({ $0.identifier }).joined()
+            processors.map({ $0.identifier }).joined(separator: Composition.separator)
         }
+
+        /// Separates the individual identifiers to make sure that different
+        /// combinations never produce the same string, e.g. `["a", "bc"]` and
+        /// `["ab", "c"]`.
+        static let separator = "+"
 
         /// Creates a combined hash of all the given processors.
         public func hash(into hasher: inout Hasher) {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCacheTests.swift
@@ -516,6 +516,64 @@ struct ImagePipelineCacheTests {
         #expect(cache.makeImageCacheKey(for: Test.request) != cache.makeImageCacheKey(for: other))
     }
 
+    @Test func makeDataCacheKeyIsStable() {
+        // GIVEN two equal requests
+        let request = ImageRequest(url: Test.url, processors: [
+            ImageProcessors.Anonymous(id: "resize", { $0 }),
+            ImageProcessors.Anonymous(id: "blur", { $0 })
+        ])
+
+        // THEN they produce the same key
+        #expect(cache.makeDataCacheKey(for: request) == cache.makeDataCacheKey(for: request))
+        #expect(cache.makeDataCacheKey(for: Test.request) == cache.makeDataCacheKey(for: Test.request))
+    }
+
+    @Test func makeDataCacheKeyForProcessorsWithAmbiguousIdentifiers() {
+        // GIVEN requests with processor identifiers that concatenate to the
+        // same string
+        let lhs = ImageRequest(url: Test.url, processors: [
+            ImageProcessors.Anonymous(id: "resize-", { $0 }),
+            ImageProcessors.Anonymous(id: "largeblur", { $0 })
+        ])
+        let rhs = ImageRequest(url: Test.url, processors: [
+            ImageProcessors.Anonymous(id: "resize-large", { $0 }),
+            ImageProcessors.Anonymous(id: "blur", { $0 })
+        ])
+
+        // THEN the keys are different
+        #expect(cache.makeDataCacheKey(for: lhs) != cache.makeDataCacheKey(for: rhs))
+    }
+
+    @Test func makeDataCacheKeyForAmbiguousImageIDAndProcessorIdentifier() {
+        // GIVEN requests where the image ID and the processor identifier
+        // concatenate to the same string
+        let lhs = ImageRequest(url: Test.url).with {
+            $0.imageID = "image-1"
+            $0.processors = [ImageProcessors.Anonymous(id: "2", { $0 })]
+        }
+        let rhs = ImageRequest(url: Test.url).with {
+            $0.imageID = "image-12"
+        }
+
+        // THEN the keys are different
+        #expect(cache.makeDataCacheKey(for: lhs) != cache.makeDataCacheKey(for: rhs))
+    }
+
+    @Test func makeDataCacheKeyForAmbiguousImageIDAndThumbnailIdentifier() {
+        // GIVEN requests where the image ID and the thumbnail identifier
+        // concatenate to the same string
+        let thumbnail = ImageRequest.ThumbnailOptions(maxPixelSize: 400)
+        let lhs = ImageRequest(url: Test.url).with {
+            $0.thumbnail = thumbnail
+        }
+        let rhs = ImageRequest(url: Test.url).with {
+            $0.imageID = Test.url.absoluteString + thumbnail.identifier
+        }
+
+        // THEN the keys are different
+        #expect(cache.makeDataCacheKey(for: lhs) != cache.makeDataCacheKey(for: rhs))
+    }
+
     // MARK: Decoding Cached Data
 
     @Test func cachedImageIsNilWhenNoDecoderIsRegistered() {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
@@ -349,7 +349,7 @@ struct ImagePipelineProcessingDeduplicationTests {
     @Test func intermediateDataCacheResultsAreUsed() async throws {
         // Given
         let dataCache = MockDataCache()
-        dataCache.store[Test.url.absoluteString + "12"] = Test.data
+        dataCache.store[Test.url.absoluteString + "++1+2"] = Test.data
 
         let pipeline = pipeline.reconfigured {
             $0.dataCache = dataCache

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDataCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDataCacheTests.swift
@@ -29,7 +29,7 @@ struct ImagePipelineDataCachingTests {
     @Test func imageIsLoaded() async throws {
         // Given
         dataLoader.queue.isSuspended = true
-        dataCache.store[Test.url.absoluteString] = Test.data
+        dataCache.store[Test.url.absoluteString + "++"] = Test.data
 
         // When/Then
         _ = try await pipeline.image(for: Test.request)
@@ -163,7 +163,7 @@ struct ImagePipelineDataCachingTests {
 
     @Test func reloadIgnoringCachedData() async throws {
         // Given
-        dataCache.store[Test.url.absoluteString] = Test.data
+        dataCache.store[Test.url.absoluteString + "++"] = Test.data
 
         var request = Test.request
         request.options = [.reloadIgnoringCachedData]
@@ -177,7 +177,7 @@ struct ImagePipelineDataCachingTests {
 
     @Test func loadFromCacheOnlyDataCache() async throws {
         // Given
-        dataCache.store[Test.url.absoluteString] = Test.data
+        dataCache.store[Test.url.absoluteString + "++"] = Test.data
 
         var request = Test.request
         request.options = [.returnCacheDataDontLoad]
@@ -268,7 +268,7 @@ struct ImagePipelineDataCachePolicyTests {
     @Test func processedImageLoadedFromDataCache() async throws {
         // Given processed image data stored in data cache
         dataLoader.queue.isSuspended = true
-        dataCache.store[Test.url.absoluteString + "1"] = Test.data
+        dataCache.store[Test.url.absoluteString + "++1"] = Test.data
 
         // When/Then
         _ = try await pipeline.image(for: request)
@@ -281,7 +281,7 @@ struct ImagePipelineDataCachePolicyTests {
     @Test func processedImageIsDecompressed() async throws {
         // Given processed image data stored in data cache
         dataLoader.queue.isSuspended = true
-        dataCache.store[Test.url.absoluteString + "1"] = Test.data
+        dataCache.store[Test.url.absoluteString + "++1"] = Test.data
 
         // When/Then
         let response = try await pipeline.imageTask(with: request).response
@@ -296,7 +296,7 @@ struct ImagePipelineDataCachePolicyTests {
             $0.imageCache = cache
         }
         dataLoader.queue.isSuspended = true
-        dataCache.store[Test.url.absoluteString + "1"] = Test.data
+        dataCache.store[Test.url.absoluteString + "++1"] = Test.data
 
         // When
         _ = try await pipeline.image(for: request)
@@ -317,7 +317,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // Given processed image data stored in data cache
         dataLoader.queue.isSuspended = true
-        dataCache.store[Test.url.absoluteString + "1"] = Test.data
+        dataCache.store[Test.url.absoluteString + "++1"] = Test.data
 
         // When/Then
         let response = try await pipeline.imageTask(with: request).response
@@ -344,7 +344,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // THEN encoded processed image is stored in disk cache
         #expect(encoder.encodeCount == 1)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -363,7 +363,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // THEN original image data is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -383,8 +383,8 @@ struct ImagePipelineDataCachePolicyTests {
         // encoded processed image is stored in disk cache
         // original image data is stored in disk cache
         #expect(encoder.encodeCount == 1)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") != nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 2)
         #expect(dataCache.store.count == 2)
     }
@@ -405,7 +405,7 @@ struct ImagePipelineDataCachePolicyTests {
         // THEN
         // encoded processed image is stored in disk cache
         #expect(encoder.encodeCount == 1)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
         #expect(dataLoader.createdTaskCount == 0)
@@ -428,7 +428,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // THEN encoded processed image is stored in disk cache
         #expect(encoder.encodeCount == 1)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -448,7 +448,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // THEN
         #expect(encoder.encodeCount == 1)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -468,8 +468,8 @@ struct ImagePipelineDataCachePolicyTests {
         // encoded processed image is stored in disk cache
         // encoded original image is stored in disk cache
         #expect(encoder.encodeCount == 2)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") != nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 2)
         #expect(dataCache.store.count == 2)
     }
@@ -490,7 +490,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // THEN encoded processed image is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -509,7 +509,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // THEN original image data is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -532,7 +532,7 @@ struct ImagePipelineDataCachePolicyTests {
         // encoded processed image is stored in disk cache
         // encoded original image is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -555,8 +555,8 @@ struct ImagePipelineDataCachePolicyTests {
         // THEN encoded processed image is stored in disk cache and
         // original image data stored in disk cache
         #expect(encoder.encodeCount == 1)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") != nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 2)
         #expect(dataCache.store.count == 2)
     }
@@ -575,7 +575,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // THEN original image data is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -595,8 +595,8 @@ struct ImagePipelineDataCachePolicyTests {
         // encoded processed image is stored in disk cache
         // original image data is stored in disk cache
         #expect(encoder.encodeCount == 1)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") != nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 2)
         #expect(dataCache.store.count == 2)
     }
@@ -710,7 +710,7 @@ struct ImagePipelineDataCachePolicyTests {
 
         // Then
         #expect(isCustomEncoderCalled)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "1") == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++1") == nil)
     }
 
     // MARK: Integration with Thumbnail Feature
@@ -724,7 +724,7 @@ struct ImagePipelineDataCachePolicyTests {
         _ = try await pipeline.image(for: request)
 
         // THEN
-        #expect(dataCache.containsData(for: "http://test.com/example.jpeg"))
+        #expect(dataCache.containsData(for: "http://test.com/example.jpeg++"))
     }
 
     // MARK: - Thumbnail + Original Data Reuse
@@ -732,7 +732,7 @@ struct ImagePipelineDataCachePolicyTests {
     @Test func thumbnailRequestReusesOriginalDataFromDiskCache() async throws {
         // GIVEN original image is loaded (no thumbnail), caching original data to disk
         _ = try await pipeline.image(for: Test.request)
-        #expect(dataCache.containsData(for: Test.url.absoluteString))
+        #expect(dataCache.containsData(for: Test.url.absoluteString + "++"))
 
         // WHEN a thumbnail of the same URL is requested
         var thumbnailRequest = ImageRequest(url: Test.url)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
@@ -160,7 +160,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN nothing is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") == nil)
         #expect(dataCache.writeCount == 0)
         #expect(dataCache.store.count == 0)
     }
@@ -179,7 +179,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN original image data is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -197,8 +197,8 @@ struct ImagePipelineLoadDataTests {
         // THEN
         // only original image is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") == nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -219,7 +219,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN nothing is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -238,7 +238,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN original image data is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -256,8 +256,8 @@ struct ImagePipelineLoadDataTests {
         // THEN
         // only original image is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") == nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -278,7 +278,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN nothing is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") == nil)
         #expect(dataCache.writeCount == 0)
         #expect(dataCache.store.count == 0)
     }
@@ -297,7 +297,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN original image data is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") == nil)
         #expect(dataCache.writeCount == 0)
         #expect(dataCache.store.count == 0)
     }
@@ -315,8 +315,8 @@ struct ImagePipelineLoadDataTests {
         // THEN
         // only original image is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") == nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") == nil)
         #expect(dataCache.writeCount == 0)
         #expect(dataCache.store.count == 0)
     }
@@ -337,7 +337,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN nothing is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -356,7 +356,7 @@ struct ImagePipelineLoadDataTests {
 
         // THEN original image data is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }
@@ -374,8 +374,8 @@ struct ImagePipelineLoadDataTests {
         // THEN
         // only original image is stored in disk cache
         #expect(encoder.encodeCount == 0)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString + "p1") == nil)
-        #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++p1") == nil)
+        #expect(dataCache.cachedData(for: Test.url.absoluteString + "++") != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
     }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
@@ -102,7 +102,7 @@ struct ImagePipelineTaskLifetimeTests {
 
     @Test func taskIsRemovedOnDiskCacheHitForDataRequest() async throws {
         // Given cached data, `TaskLoadData` finishes the task synchronously
-        dataCache.store[Test.url.absoluteString] = Test.data
+        dataCache.store[Test.url.absoluteString + "++"] = Test.data
 
         // When
         _ = try await pipeline.data(for: Test.request)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -272,20 +272,20 @@ struct ImagePipelineTests {
 
     @Test func cacheKeyForRequest() {
         let request = Test.request
-        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpeg")
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpeg++")
     }
 
     @Test func cacheKeyForRequestWithProcessors() {
         var request = Test.request
         request.processors = [ImageProcessors.Anonymous(id: "1", { $0 })]
-        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpeg1")
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpeg++1")
     }
 
     @Test func cacheKeyForRequestWithThumbnail() {
         let request = ImageRequest(url: Test.url).with {
             $0.thumbnail = .init(maxPixelSize: 400)
         }
-        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpegcom.github/kean/nuke/thumbnail?maxPixelSize=400.0,options=truetruetruetrue")
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpeg+com.github/kean/nuke/thumbnail?maxPixelSize=400.0,options=truetruetruetrue+")
     }
 
     @Test func cacheKeyForRequestWithThumbnailFlexibleSize() {
@@ -296,7 +296,7 @@ struct ImagePipelineTests {
                 contentMode: .aspectFit
             )
         }
-        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpegcom.github/kean/nuke/thumbnail?width=400.0,height=400.0,contentMode=.aspectFit,options=truetruetruetrue")
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpeg+com.github/kean/nuke/thumbnail?width=400.0,height=400.0,contentMode=.aspectFit,options=truetruetruetrue+")
     }
 
     // MARK: - Invalidate

--- a/Tests/NukeTests/ImageProcessorsTests/CompositionTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/CompositionTests.swift
@@ -88,6 +88,17 @@ struct ImageProcessorsCompositionTests {
         #expect(lhs.hashableIdentifier != rhs.hashableIdentifier)
     }
 
+    @Test func identifiersWithProcessorsThatConcatenateToTheSameString() {
+        // GIVEN processors whose identifiers concatenate to the same string
+        let lhs = ImageProcessors.Composition([MockImageProcessor(id: "resize-"), MockImageProcessor(id: "largeblur")])
+        let rhs = ImageProcessors.Composition([MockImageProcessor(id: "resize-large"), MockImageProcessor(id: "blur")])
+
+        // THEN
+        #expect(lhs != rhs)
+        #expect(lhs.identifier != rhs.identifier)
+        #expect(lhs.hashableIdentifier != rhs.hashableIdentifier)
+    }
+
     @Test func identifiersEmptyProcessors() {
         // GIVEN empty processors
         let lhs = ImageProcessors.Composition([])


### PR DESCRIPTION
`ImageProcessors.Composition.identifier` and `makeDataCacheKey(for:)` concatenated identifiers with no separator, so requests like `["resize-", "largeblur"]` and `["resize-large", "blur"]` produced the same disk cache key and the second one was served the first one's processed bytes. The same applied to the `imageID`/`thumbnail`/processors boundaries. The memory cache didn't have this bug, so the two cache layers disagreed.

Both now join their components with a `+` separator (always emitted, so empty components can't alias either).

Note: this changes the on-disk cache key format, so existing disk cache entries become unreachable - they simply miss, get re-fetched, and are reclaimed by the normal `DataCache` sweep.