### PR TITLE
Deliver ImageTask.Event.started through the events stream

### DIFF
--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -131,7 +131,9 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
 
     /// An event produced during the runtime of the task.
     @frozen public enum Event: Sendable {
-        /// The task was started by the pipeline.
+        /// The task was started by the pipeline. Always the first event in the
+        /// stream: it is replayed for the subscribers that are added after the
+        /// pipeline started the task.
         case started
         /// The download progress was updated.
         case progress(Progress)
@@ -154,6 +156,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     nonisolated(unsafe) var _task: Task<ImageResponse, any Error>!
     @ImagePipelineActor var _continuation: UnsafeContinuation<ImageResponse, any Error>?
     @ImagePipelineActor var _state: State = .running
+    @ImagePipelineActor var _didStart = false
     @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
@@ -265,6 +268,10 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
             continuation.yield(event)
         }
         switch event {
+        case .started:
+            // Recorded so that the streams created after the pipeline started
+            // the task still see it – see `makeStream()`.
+            _didStart = true
         case .finished(let result):
             for continuation in _streamContinuations {
                 continuation.finish()
@@ -310,6 +317,14 @@ extension ImageTask {
             Task { @ImagePipelineActor in
                 guard self._state == .running else {
                     return continuation.finish()
+                }
+                // The pipeline starts the task asynchronously, so there is no
+                // way for a subscriber to be registered before `.started` is
+                // sent. It is replayed to make it the first event of every
+                // stream regardless of the order in which the pipeline and the
+                // subscriber reach the actor.
+                if self._didStart {
+                    continuation.yield(.started)
                 }
                 self._streamContinuations.append(continuation)
             }

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -216,9 +216,7 @@ public final class ImagePipeline: Sendable {
         // `removeTask` to remove it, and already started for the events to be
         // delivered in the correct order.
         task._node = tasks.append(task)
-        if !isDataTask {
-            delegate.imageTask(task, didReceiveEvent: .started, pipeline: self)
-        }
+        task._dispatch(.started)
         onTaskStarted?(task)
         task._subscription = worker.subscribe(priority: task.priority.taskPriority, subscriber: task) { [weak task] in
             task?._process($0)

--- a/Tests/Helpers/NukeExtensions.swift
+++ b/Tests/Helpers/NukeExtensions.swift
@@ -29,6 +29,8 @@ extension ImagePipeline.Error: @retroactive Equatable {
 extension ImageTask.Event: @retroactive Equatable {
     public static func == (lhs: ImageTask.Event, rhs: ImageTask.Event) -> Bool {
         switch (lhs, rhs) {
+        case (.started, .started):
+            return true
         case let (.progress(lhs), .progress(rhs)):
             return lhs == rhs
         case let (.preview(lhs), .preview(rhs)):

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -517,6 +517,7 @@ struct ImagePipelineAsyncAwaitTests {
             }
             return true
         } == [
+            .started,
             .preview(recordedPreviews[0]),
             .preview(recordedPreviews[1]),
             .finished(result)

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -99,6 +99,84 @@ struct ImageTaskTests {
 
     // MARK: - Events
 
+    /// A stream created right after the task – the pipeline hasn't started it
+    /// yet, so `.started` is delivered when it is sent.
+    @Test func startedIsTheFirstEventInTheStream() async throws {
+        // Given
+        dataLoader.isSuspended = true
+        let task = pipeline.imageTask(with: Test.request)
+
+        // When
+        async let events = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
+        while await task._streamContinuations.isEmpty {
+            await Task.yield()
+        }
+        dataLoader.isSuspended = false
+
+        // Then
+        let received = await events
+        #expect(received.first.map(isStarted) == true)
+        #expect(received.count(where: isStarted) == 1)
+        #expect(received.last.map { if case .finished(.success) = $0 { true } else { false } } == true)
+    }
+
+    /// A stream created after the pipeline started the task still sees
+    /// `.started` – it is replayed.
+    @Test func startedIsReplayedForLateSubscribers() async throws {
+        // Given a task that the pipeline has already started
+        dataLoader.isSuspended = true
+        let didStart = TestExpectation()
+        pipeline.onTaskStarted = { _ in didStart.fulfill() }
+        let task = pipeline.imageTask(with: Test.request)
+        await didStart.wait()
+        pipeline.onTaskStarted = nil
+
+        // When
+        async let events = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
+        while await task._streamContinuations.isEmpty {
+            await Task.yield()
+        }
+        dataLoader.isSuspended = false
+
+        // Then
+        let received = await events
+        #expect(received.first.map(isStarted) == true)
+        #expect(received.count(where: isStarted) == 1)
+    }
+
+    @Test func startedIsDeliveredToTheEventClosure() async throws {
+        // Given
+        let recorder = EventRecorder()
+        let task = pipeline.makeStartedImageTask(with: Test.request) { event, _ in
+            recorder.append(event)
+        }
+
+        // When
+        _ = try await task.response
+
+        // Then
+        let received = recorder.events
+        #expect(received.first.map(isStarted) == true)
+        #expect(received.count(where: isStarted) == 1)
+    }
+
+    @Test func startedIsDeliveredForDataTasks() async throws {
+        // Given
+        dataLoader.isSuspended = true
+        let task = pipeline.makeStartedImageTask(with: Test.request, isDataTask: true)
+
+        // When
+        async let events = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
+        while await task._streamContinuations.isEmpty {
+            await Task.yield()
+        }
+        dataLoader.isSuspended = false
+
+        // Then
+        let received = await events
+        #expect(received.first.map(isStarted) == true)
+    }
+
     @Test func eventsAreDeliveredToMultipleIndependentStreams() async throws {
         // Given
         dataLoader.isSuspended = true
@@ -234,5 +312,26 @@ struct ImageTaskTests {
 
         // Then
         #expect(task.priority == .veryLow)
+    }
+}
+
+// MARK: - Helpers
+
+private func isStarted(_ event: ImageTask.Event) -> Bool {
+    if case .started = event { return true }
+    return false
+}
+
+/// Collects the events delivered to an `onEvent` closure.
+private final class EventRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [ImageTask.Event] = []
+
+    var events: [ImageTask.Event] {
+        lock.withLock { _events }
+    }
+
+    func append(_ event: ImageTask.Event) {
+        lock.withLock { _events.append(event) }
     }
 }


### PR DESCRIPTION
`startImageTask` sent `.started` straight to the pipeline delegate and never called `_dispatch`, which is the only feeder of the public `events` stream and of the `onEvent` closure. `for await event in task.events { if case .started … }` could therefore never fire, even though `.started` is a public case of the stream's element type and `events` is documented as "the events sent by the pipeline during the task execution". `Deprecated.swift`'s `case .started: break` was dead code.

The event now goes through `_dispatch` like every other one. The pipeline starts the task asynchronously, so a subscriber has no way to be registered before `.started` is sent — it is also replayed to the streams created afterwards, which makes it the first event of every stream.

`.started` is now also delivered on the `events` stream of the data tasks, matching `.progress` and `.finished`. The delegate callback is unchanged.