### PR TITLE
Fix Color.hex ignoring the conversion failure and not clamping components

### DIFF
--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -396,24 +396,36 @@ typealias Color = UIColor
 #endif
 
 extension Color {
-    /// Returns a hex representation of the color, e.g. "#FFFFAA".
-    var hex: String {
+    /// Returns a hex representation of the color, e.g. "#FFFFAA", or `nil` if
+    /// the color has no sRGB representation, e.g. a pattern color.
+    ///
+    /// - note: The components are clamped to `0...1`. The colors in the
+    /// extended sRGB space – which is what a P3 color converts to – have
+    /// components outside of that range and would otherwise produce malformed
+    /// hex, e.g. `"117"` for `1.093`.
+    var hex: String? {
         var (r, g, b, a) = (CGFloat(0), CGFloat(0), CGFloat(0), CGFloat(0))
 #if os(macOS)
         // Unlike `UIColor`, `NSColor` doesn't convert the color on the fly and
         // raises an `NSInvalidArgumentException` if it's outside an RGB
         // colorspace – including the grays, e.g. `.black`, and the catalog
         // colors, e.g. `.labelColor`. `usingColorSpace(_:)` returns `nil` for
-        // the colors that can't be converted at all, e.g. pattern colors, which
-        // `UIColor` also reports zero components for.
-        usingColorSpace(.sRGB)?.getRed(&r, green: &g, blue: &b, alpha: &a)
+        // the colors that can't be converted at all, e.g. pattern colors.
+        guard let color = usingColorSpace(.sRGB) else {
+            return nil
+        }
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
 #else
-        getRed(&r, green: &g, blue: &b, alpha: &a)
+        // Returns `false` and leaves the components untouched for the colors
+        // with no RGB representation, e.g. pattern colors.
+        guard getRed(&r, green: &g, blue: &b, alpha: &a) else {
+            return nil
+        }
 #endif
         let components = [r, g, b, a < 1 ? a : nil]
         return "#" + components
             .compactMap { $0 }
-            .map { String(format: "%02lX", lroundf(Float($0) * 255)) }
+            .map { String(format: "%02lX", lroundf(Float(min(max($0, 0), 1)) * 255)) }
             .joined()
     }
 }

--- a/Sources/Nuke/Processing/ImageProcessingOptions.swift
+++ b/Sources/Nuke/Processing/ImageProcessingOptions.swift
@@ -65,7 +65,12 @@ public enum ImageProcessingOptions: Sendable {
 #endif
 
         public var description: String {
-            "Border(color: \(color.hex), width: \(width) pixels)"
+            // `hex` is `nil` for the colors with no sRGB representation, e.g.
+            // pattern colors. The description is part of the identifiers of the
+            // processors that draw borders, so the fallback has to stay
+            // distinct per color instead of collapsing every such color onto
+            // the same – and, in the case of "#00000000", already taken – value.
+            "Border(color: \(color.hex ?? String(describing: color)), width: \(width) pixels)"
         }
     }
 

--- a/Tests/NukeTests/ImageProcessingOptionsTests.swift
+++ b/Tests/NukeTests/ImageProcessingOptionsTests.swift
@@ -108,12 +108,42 @@ struct ImageProcessingOptionsTests {
     /// Catalog colors, e.g. `NSColor.labelColor`, are another color space that
     /// `getRed(_:green:blue:alpha:)` can't read. Their value depends on the
     /// current appearance, so only the format is verified.
-    @Test func hexForCatalogColor() {
-        let hex = Color.labelColor.hex
+    @Test func hexForCatalogColor() throws {
+        let hex = try #require(Color.labelColor.hex)
         #expect(hex.hasPrefix("#"))
         #expect(hex.count == 7 || hex.count == 9)
     }
 #endif
+
+    /// The components of a P3 color converted to (extended) sRGB fall outside
+    /// of `0...1`, which used to produce malformed hex, e.g. `"#1170000"`.
+    @Test func hexForWideGamutColorIsWellFormed() throws {
+        let hex = try #require(Color(displayP3Red: 1, green: 0, blue: 0, alpha: 1).hex)
+        #expect(hex == "#FF0000")
+    }
+
+    @Test func hexForWideGamutColorWithNegativeComponentsIsWellFormed() throws {
+        let hex = try #require(Color(displayP3Red: 0, green: 1, blue: 0, alpha: 1).hex)
+        #expect(hex.count == 7)
+        #expect(hex.dropFirst().filter(\.isHexDigit).count == 6)
+    }
+
+    /// Pattern colors have no sRGB representation. They used to report all-zero
+    /// components, which made every one of them – and `.clear` – hex to
+    /// `"#00000000"` and share an identifier.
+    @Test func hexForPatternColorIsNil() {
+        #expect(Color(patternImage: Test.image).hex == nil)
+        #expect(Color.clear.hex == "#00000000")
+    }
+
+    @Test func borderDescriptionsForPatternColorsDoNotCollide() {
+        let a = ImageProcessingOptions.Border(color: Color(patternImage: Test.image), width: 2, unit: .pixels)
+        let b = ImageProcessingOptions.Border(color: Color(patternImage: Test.image(named: "fixture-tiny", extension: "jpeg")), width: 2, unit: .pixels)
+        let clear = ImageProcessingOptions.Border(color: .clear, width: 2, unit: .pixels)
+
+        #expect(a.description != b.description)
+        #expect(a.description != clear.description)
+    }
 
     // MARK: - ContentMode
 


### PR DESCRIPTION
Two problems in `Color.hex`, which feeds `Border.description` and through it the identifiers of `Circle` and `RoundedCorners`:

1. The result of `getRed(_:green:blue:alpha:)` was discarded. It returns `false` for the colors with no RGB representation — pattern colors — leaving the zero-initialized components in place, so all of them hexed to `"#00000000"` and shared an identifier with `.clear` and with each other. Two distinct border colors could be served each other's processed bytes from the disk cache, while the memory cache, which hashes the color object, kept them apart.

2. The components were formatted unclamped. A P3 color converts to extended sRGB with components outside of `0...1`, so `String(format: "%02lX", lroundf(1.093 * 255))` produced `"117"` and the negative components produced `"FFFFFFFFFFFFFFC6"`. P3 red hexed to `"#117FFFFFFFFFFFFFFC6FFFFFFFFFFFFFFDA"` on iOS.

`hex` is now optional and returns `nil` when the color has no sRGB representation, and the components are clamped to `0...1`. `Border.description` falls back to the color's own description so that such colors stay distinct from one another instead of collapsing onto a single, already-taken value.