### PR TITLE
Fix GIF previews bypassing the preview policy

### DIFF
--- a/Sources/Nuke/Decoding/ImageDecoders+Default.swift
+++ b/Sources/Nuke/Decoding/ImageDecoders+Default.swift
@@ -89,9 +89,15 @@ extension ImageDecoders {
             lock.lock()
             defer { lock.unlock() }
 
+            guard previewPolicy != .disabled else {
+                return nil
+            }
+
             let assetType = AssetType(data)
 
-            // GIF preview is always allowed regardless of policy
+            // GIFs can't be decoded incrementally: Image I/O needs the complete
+            // frame data, so a single preview is generated from whatever has
+            // been downloaded so far regardless of the policy.
             if assetType == .gif {
                 if !isPreviewForGIFGenerated, let image = ImageDecoders.Default._decode(data, scale: scale) {
                     isPreviewForGIFGenerated = true
@@ -102,7 +108,7 @@ extension ImageDecoders {
 
             switch previewPolicy {
             case .disabled:
-                return nil
+                return nil // Already handled above
 
             case .thumbnail:
                 if numberOfScans > 0 { return nil } // Already generated

--- a/Tests/NukeTests/ImageDecoderTests.swift
+++ b/Tests/NukeTests/ImageDecoderTests.swift
@@ -283,6 +283,39 @@ struct ImageDecoderTests {
         #expect(decoder.decodePartiallyDownloadedData(chunk) == nil)
     }
 
+    @Test func decodingGIFPreviewWithDisabledPolicy() throws {
+        let data = Test.data(name: "cat", extension: "gif")
+        let chunk = data[...60000]
+
+        var context = ImageDecodingContext.mock(data: chunk)
+        context.previewPolicy = .disabled
+        let decoder = try #require(ImageDecoders.Default(context: context))
+
+        // No previews with the .disabled policy, GIFs included
+        #expect(decoder.decodePartiallyDownloadedData(chunk) == nil)
+        #expect(decoder.decodePartiallyDownloadedData(data[...120000]) == nil)
+        #expect(decoder.numberOfScans == 0)
+
+        // Full decode still works
+        let container = try decoder.decode(data)
+        #expect(container.type == .gif)
+        #expect(!container.isPreview)
+    }
+
+    @Test func decodingGIFPreviewWithThumbnailPolicy() throws {
+        let data = Test.data(name: "cat", extension: "gif")
+        let chunk = data[...60000]
+
+        var context = ImageDecodingContext.mock(data: chunk)
+        context.previewPolicy = .thumbnail
+        let decoder = try #require(ImageDecoders.Default(context: context))
+
+        // GIFs can't be decoded incrementally, so a single preview is still
+        // generated for any policy other than .disabled
+        #expect(decoder.decodePartiallyDownloadedData(chunk) != nil)
+        #expect(decoder.decodePartiallyDownloadedData(chunk) == nil)
+    }
+
     @Test func decodingPNGDataNotAttached() throws {
         let data = Test.data(name: "fixture", extension: "png")
         let container = try ImageDecoders.Default().decode(data)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
@@ -174,6 +174,61 @@ struct ImagePipelinePreviewPolicyTests {
         _ = try await task.image
     }
 
+    // MARK: - GIF
+
+    @Test func gifDeliversPreviewsByDefault() async throws {
+        // GIVEN a GIF served in chunks (default policy is .incremental for GIF)
+        let dataLoader = MockAutoDataLoader(
+            data: Test.data(name: "cat", extension: "gif"),
+            chunkCount: 8
+        )
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.isProgressiveDecodingEnabled = true
+            $0.progressiveDecodingInterval = 0
+            $0.imageCache = nil
+        }
+
+        // WHEN loading the image
+        let task = pipeline.imageTask(with: Test.url)
+        var previews: [ImageResponse] = []
+        for try await preview in task.previews {
+            previews.append(preview)
+        }
+
+        // THEN a single preview is delivered
+        #expect(previews.count == 1)
+        #expect(previews.allSatisfy { $0.container.isPreview })
+        _ = try await task.image
+    }
+
+    @Test func gifWithDisabledPolicyDeliversNoPreviews() async throws {
+        // GIVEN a delegate that disables previews and a GIF served in chunks
+        let delegate = PreviewPolicyDelegate(policy: .disabled)
+        let dataLoader = MockAutoDataLoader(
+            data: Test.data(name: "cat", extension: "gif"),
+            chunkCount: 8
+        )
+        let pipeline = ImagePipeline(delegate: delegate) {
+            $0.dataLoader = dataLoader
+            $0.isProgressiveDecodingEnabled = true
+            $0.progressiveDecodingInterval = 0
+            $0.imageCache = nil
+        }
+
+        // WHEN loading the image
+        let task = pipeline.imageTask(with: Test.url)
+        var previews: [ImageResponse] = []
+        for try await preview in task.previews {
+            previews.append(preview)
+        }
+
+        // THEN no previews are delivered
+        #expect(previews.isEmpty)
+        let response = try await task.response
+        #expect(response.container.type == .gif)
+    }
+
     // MARK: - Policy that only resolves to .incremental on later chunks
 
     @Test func policyIsReevaluatedWhenMoreDataArrives() async throws {


### PR DESCRIPTION
The GIF branch in `decodePartiallyDownloadedData` ran before the `previewPolicy` switch, so a delegate returning `.disabled` — documented as "No previews are generated for partially downloaded data" — still got a full `UIImage(data:)` decode and an emitted preview for every partially downloaded GIF.

`.disabled` is now checked first and applies to GIFs too. `.incremental` and `.thumbnail` keep the existing behaviour: GIFs can't be decoded incrementally, so a single preview is generated from whatever has been downloaded so far. The default policy for GIF data is `.incremental`, so nothing changes unless a delegate opts out.