### PR TITLE
Fix GaussianBlur(radius: 0) blurring instead of being an identity transform

### DIFF
--- a/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
@@ -23,13 +23,16 @@ extension ImageProcessors {
 
         /// Initializes the receiver with a blur radius.
         ///
-        /// - parameter radius: `8` by default.
+        /// - parameter radius: `8` by default. A radius of `0` – or any negative
+        /// value, which is clamped to `0` – makes the processor an identity
+        /// transform that returns the image unchanged.
         public init(radius: Int = 8) {
-            self.radius = radius
+            self.radius = max(0, radius)
         }
 
         /// Applies a Gaussian blur to the image.
         public func process(_ image: PlatformImage) -> PlatformImage? {
+            guard radius > 0 else { return image }
             guard let cgImage = image.cgImage else { return nil }
             guard let output = cgImage.blurred(radius: radius) else { return nil }
             return PlatformImage.make(cgImage: output, source: image)
@@ -47,8 +50,10 @@ extension ImageProcessors {
 
 private extension CGImage {
     /// Applies a Gaussian blur approximation using three box-blur passes (SVG spec).
+    ///
+    /// - parameter radius: Must be greater than `0`.
     func blurred(radius: Int) -> CGImage? {
-        let inputRadius = max(Double(radius), 2.0)
+        let inputRadius = Double(radius)
         let pi2 = 2.0 * Double.pi
         var kernelSize = UInt32(floor(inputRadius * 3.0 * sqrt(pi2) / 4.0 + 0.5))
         if kernelSize % 2 == 0 { kernelSize += 1 }

--- a/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
@@ -4,6 +4,7 @@
 
 import Testing
 import Foundation
+import CoreGraphics
 @testable import Nuke
 
 #if !os(macOS)
@@ -114,6 +115,85 @@ struct ImageProcessorsGaussianBlurTests {
             ImageProcessors.GaussianBlur(radius: 16).description
         )
     }
+
+    // MARK: - Zero and Negative Radius
+
+    @Test func zeroRadiusReturnsTheImageUnchanged() throws {
+        // GIVEN
+        let image = Test.image
+        let processor = ImageProcessors.GaussianBlur(radius: 0)
+
+        // WHEN
+        let output = try #require(processor.process(image))
+
+        // THEN the processor is an identity transform
+        #expect(output === image)
+    }
+
+    @Test func negativeRadiusIsClampedToZero() throws {
+        // GIVEN
+        let image = Test.image
+        let processor = ImageProcessors.GaussianBlur(radius: -8)
+
+        // WHEN
+        let output = try #require(processor.process(image))
+
+        // THEN the image is returned unchanged and the processor is
+        // indistinguishable from the one with a radius of `0`
+        #expect(output === image)
+        #expect(processor.identifier == ImageProcessors.GaussianBlur(radius: 0).identifier)
+        #expect(processor.hashableIdentifier == ImageProcessors.GaussianBlur(radius: 0).hashableIdentifier)
+        #expect(processor == ImageProcessors.GaussianBlur(radius: 0))
+    }
+
+    @Test func zeroRadiusIsDistinctFromTheSmallestBlur() throws {
+        // GIVEN
+        let image = Test.image
+
+        // WHEN
+        let identity = try #require(ImageProcessors.GaussianBlur(radius: 0).process(image))
+        let blurred = try #require(ImageProcessors.GaussianBlur(radius: 1).process(image))
+
+        // THEN a radius of `1` does blur the image
+        #expect(try pixels(of: identity) != pixels(of: blurred))
+    }
+
+    @Test func smallRadiiProduceDifferentOutput() throws {
+        // GIVEN - processors with distinct identifiers, so they must not
+        // produce byte-identical output and populate the cache with duplicates
+        let image = Test.image
+
+        // WHEN
+        let outputs = try (1...3).map {
+            try pixels(of: #require(ImageProcessors.GaussianBlur(radius: $0).process(image)))
+        }
+
+        // THEN
+        #expect(outputs[0] != outputs[1])
+        #expect(outputs[1] != outputs[2])
+    }
+}
+
+/// Renders the image into a known ARGB context and returns the raw bytes.
+private func pixels(of image: PlatformImage) throws -> Data {
+    let cgImage = try #require(image.cgImage)
+    let bytesPerRow = cgImage.width * 4
+    var bytes = [UInt8](repeating: 0, count: bytesPerRow * cgImage.height)
+    let success = bytes.withUnsafeMutableBytes { buffer -> Bool in
+        guard let context = CGContext(
+            data: buffer.baseAddress,
+            width: cgImage.width,
+            height: cgImage.height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return false }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: cgImage.width, height: cgImage.height))
+        return true
+    }
+    #expect(success)
+    return Data(bytes)
 }
 
 #endif


### PR DESCRIPTION
`blurred(radius:)` clamped the radius with `max(Double(radius), 2.0)`, so `GaussianBlur(radius: 0)` produced a kernel of 5 across three box passes — a clearly visible blur — instead of returning the image unchanged. Negative radii behaved the same way.

The clamp also made every radius in `0...2` render identically while `identifier` and `Hashable` treated them as distinct processors, so they populated the caches with duplicate entries holding the same bytes.

- `radius` is clamped to `0` at the low end, so `GaussianBlur(radius: -8)` and `GaussianBlur(radius: 0)` are the same processor.
- A radius of `0` returns the image unchanged.
- The kernel is now derived from the radius as given, so `1`, `2`, and `3` produce different output, matching their different identifiers.