### PR TITLE
Fix progressive previews being dropped after a failed cached-data decode

### DIFF
--- a/Sources/Nuke/Tasks/AsyncPipelineTask.swift
+++ b/Sources/Nuke/Tasks/AsyncPipelineTask.swift
@@ -41,9 +41,14 @@ extension AsyncPipelineTask: ImageTaskSubscribers {
 extension AsyncPipelineTask {
     /// Decodes the data on the dedicated queue and calls the completion
     /// on the pipeline's internal queue.
+    ///
+    /// If the decoding is scheduled on the decoding queue, the operation is
+    /// stored in ``AsyncTask/operation`` – it also serves as a back-pressure
+    /// flag for the progressive decoding – and is cleared before the completion
+    /// is called, so the callers never see a stale handle.
     func decode(_ context: ImageDecodingContext, decoder: any ImageDecoding, _ completion: @escaping @ImagePipelineActor (Result<ImageResponse, ImagePipeline.Error>) -> Void) {
         if let decoder = decoder as? any AsyncImageDecoding {
-            operation = pipeline.configuration.imageDecodingQueue.add {
+            operation = pipeline.configuration.imageDecodingQueue.add { [weak self] in
                 let result: Result<ImageResponse, ImagePipeline.Error> = await signpost(context.isCompleted ? "DecodeImageData" : "DecodeProgressiveImageData") {
                     do {
                         return .success(try await decoder.decode(context))
@@ -51,6 +56,7 @@ extension AsyncPipelineTask {
                         return .failure(.decodingFailed(decoder: decoder, context: context, error: error))
                     }
                 }
+                self?.operation = nil
                 completion(result)
             }
             return
@@ -65,8 +71,10 @@ extension AsyncPipelineTask {
         guard decoder.isAsynchronous else {
             return completion(decode())
         }
-        operation = pipeline.configuration.imageDecodingQueue.add {
-            completion(await performInBackground(decode))
+        operation = pipeline.configuration.imageDecodingQueue.add { [weak self] in
+            let result = await performInBackground(decode)
+            self?.operation = nil
+            completion(result)
         }
     }
 }

--- a/Sources/Nuke/Tasks/TaskFetchOriginalImage.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalImage.swift
@@ -73,8 +73,6 @@ final class TaskFetchOriginalImage: AsyncPipelineTask<ImageResponse> {
     }
 
     private func didFinishDecoding(context: ImageDecodingContext, result: Result<ImageResponse, ImagePipeline.Error>) {
-        operation = nil
-
         switch result {
         case .success(let response):
             if !context.isCompleted {

--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -39,6 +39,11 @@ final class TaskLoadImage: AsyncPipelineTask<ImageResponse> {
     }
 
     private func didFinishDecoding(with response: ImageResponse?) {
+        // `decode` stores the decoding queue operation for the asynchronous
+        // decoders. It has to be cleared: the progressive back-pressure guards
+        // check `operation != nil` and would otherwise drop every preview the
+        // task receives after falling back to `fetchImage`.
+        operation = nil
         if let response {
             didReceiveImageResponse(response, isCompleted: true)
         } else {

--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -39,11 +39,6 @@ final class TaskLoadImage: AsyncPipelineTask<ImageResponse> {
     }
 
     private func didFinishDecoding(with response: ImageResponse?) {
-        // `decode` stores the decoding queue operation for the asynchronous
-        // decoders. It has to be cleared: the progressive back-pressure guards
-        // check `operation != nil` and would otherwise drop every preview the
-        // task receives after falling back to `fetchImage`.
-        operation = nil
         if let response {
             didReceiveImageResponse(response, isCompleted: true)
         } else {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -127,6 +127,47 @@ struct ImagePipelineProgressiveDecodingTests {
         #expect(!response.isPreview)
     }
 
+    /// The cached data decode runs on the decoding queue for the asynchronous
+    /// decoders, occupying the task's operation handle. When the decode fails
+    /// and the task falls back to loading the image, the stale handle used to
+    /// trip the progressive back-pressure guard and drop every preview.
+    @Test func previewsAreDeliveredWhenTheCachedDataFailsToDecode() async throws {
+        // Given a disk cache entry that the (asynchronous) decoder can't decode
+        let dataCache = MockDataCache()
+        let pipeline = pipeline.reconfigured {
+            $0.dataCache = dataCache
+            $0.makeImageDecoder = { _ in MockImageDecoder(name: "a") }
+        }
+        let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "_image_processor")])
+        dataCache.store[pipeline.cache.makeDataCacheKey(for: request)] = Data("not an image".utf8)
+
+        // When
+        let task = pipeline.imageTask(with: request)
+
+        let dataLoader = self.dataLoader
+        let progressEvents = task.progress
+        let previewEvents = task.previews
+
+        Task {
+            for await _ in progressEvents {
+                dataLoader.resume()
+            }
+        }
+
+        var recordedPreviews: [ImageResponse] = []
+        for try await preview in previewEvents {
+            recordedPreviews.append(preview)
+            dataLoader.resume()
+        }
+        let response = try await task.response
+
+        // Then the previews are still delivered and the final image arrives
+        #expect(!recordedPreviews.isEmpty)
+        #expect(recordedPreviews.allSatisfy { $0.image.nk_test_processorIDs == ["_image_processor"] })
+        #expect(!response.isPreview)
+        #expect(response.image.nk_test_processorIDs == ["_image_processor"])
+    }
+
     // MARK: - Image Processing
 
 #if !os(macOS)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -141,7 +141,7 @@ struct ImagePipelineProgressiveDecodingTests {
         let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "_image_processor")])
         dataCache.store[pipeline.cache.makeDataCacheKey(for: request)] = Data("not an image".utf8)
 
-        // When
+        // W
         let task = pipeline.imageTask(with: request)
 
         let dataLoader = self.dataLoader


### PR DESCRIPTION
`TaskLoadImage.decodeCachedData` goes through `AsyncPipelineTask.decode`, which stores the decoding-queue handle in `operation` whenever the decoder is asynchronous — any custom decoder, since the protocol default for `isAsynchronous` is `true`, or the default decoder with thumbnail options. `didFinishDecoding(with:)` never reset it, unlike `TaskFetchOriginalImage.didFinishDecoding`.

When the cached decode fails and the task falls back to `fetchImage()`, the stale non-nil handle trips the progressive back-pressure guards (`else if operation != nil { return }`), so every progressive preview is silently dropped for the rest of the task's lifetime. The final image still arrives.

`didFinishDecoding(with:)` now clears `operation` first.