### PR TITLE
Forward didCreateTask to the delegate on macOS and Mac Catalyst

### DIFF
--- a/Sources/Nuke/Loading/DataLoader.swift
+++ b/Sources/Nuke/Loading/DataLoader.swift
@@ -144,7 +144,6 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate, @unchecked Se
 
     // MARK: URLSessionDelegate
 
-#if !os(macOS) && !targetEnvironment(macCatalyst)
     func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             (delegate as? URLSessionTaskDelegate)?.urlSession?(session, didCreateTask: task)
@@ -152,7 +151,6 @@ private final class _DataLoader: NSObject, URLSessionDataDelegate, @unchecked Se
             // Doesn't exist on earlier versions
         }
     }
-#endif
 
     func urlSession(_ session: URLSession,
                     dataTask: URLSessionDataTask,

--- a/Tests/NukeTests/DataLoaderTests.swift
+++ b/Tests/NukeTests/DataLoaderTests.swift
@@ -391,6 +391,25 @@ struct DataLoaderTests {
         #expect(spy.didFinishMetricsCount > 0)
     }
 
+    @Test func delegateReceivesDidCreateTaskCallback() async throws {
+        let url = mockURL("delegate-did-create-task")
+        registerMock(url: url, chunks: [Data("data".utf8)])
+
+        let loader = makeDataLoader()
+        let spy = SpyURLSessionDelegate()
+        loader.delegate = spy
+
+        for try await _ in loader.loadData(with: URLRequest(url: url)) {}
+
+        await withCheckedContinuation { continuation in
+            loader.session.delegateQueue.addBarrierBlock {
+                continuation.resume()
+            }
+        }
+
+        #expect(spy.didCreateTaskCount == 1)
+    }
+
     // MARK: - Default Validation
 
     @Test func initWithDefaultValidation() async throws {
@@ -511,8 +530,13 @@ private final class SpyURLSessionDelegate: NSObject, URLSessionDataDelegate, @un
     @Mutex var didReceiveDataCount = 0
     @Mutex var didCompleteCount = 0
     @Mutex var didFinishMetricsCount = 0
+    @Mutex var didCreateTaskCount = 0
 
     let didCompleteWithError = TestExpectation()
+
+    func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {
+        didCreateTaskCount += 1
+    }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         didReceiveResponseCount += 1


### PR DESCRIPTION
`DataLoader.delegate` never received `urlSession(_:didCreateTask:)` on macOS or Mac Catalyst, so proxy delegates like Pulse's `URLSessionProxyDelegate` saw every other callback but no task-creation events there. The forwarding method was wrapped in `#if !os(macOS) && !targetEnvironment(macCatalyst)`, added years ago when the macOS SDK didn't declare the delegate method; it has existed since macOS 13, and the method's own runtime `#available` check already covers the macOS 12 deployment target.