### PR TITLE
Preserve image opacity in GaussianBlur

### DIFF
--- a/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+GaussianBlur.swift
@@ -61,9 +61,12 @@ private extension CGImage {
         let size = self.size
         // vImageBoxConvolve_ARGB8888 needs a 32-bit ARGB layout. A grayscale
         // source yields a 16-bit gray+alpha context (half the row stride vImage
-        // expects), so force RGB for the scratch contexts.
-        guard let inputCtx = CGContext.make(self, size: size, alphaInfo: .premultipliedLast, colorSpace: CGColorSpaceCreateDeviceRGB()),
-              let outputCtx = CGContext.make(self, size: size, alphaInfo: .premultipliedLast, colorSpace: CGColorSpaceCreateDeviceRGB()) else {
+        // expects), so force RGB for the scratch contexts. `.noneSkipLast` keeps
+        // the same 32-bit layout for opaque images without tagging the output
+        // with alpha, which would make `ImageEncoders.Default` pick PNG.
+        let alphaInfo: CGImageAlphaInfo = isOpaque ? .noneSkipLast : .premultipliedLast
+        guard let inputCtx = CGContext.make(self, size: size, alphaInfo: alphaInfo, colorSpace: CGColorSpaceCreateDeviceRGB()),
+              let outputCtx = CGContext.make(self, size: size, alphaInfo: alphaInfo, colorSpace: CGColorSpaceCreateDeviceRGB()) else {
             return nil
         }
         inputCtx.draw(self, in: CGRect(origin: .zero, size: size))

--- a/Tests/NukeTests/ImageEncoderTests.swift
+++ b/Tests/NukeTests/ImageEncoderTests.swift
@@ -64,7 +64,7 @@ struct ImageEncoderTests {
 
 #if os(iOS) || os(tvOS) || os(visionOS)
 
-    @Test func encodeCoreImageBackedImage() throws {
+    @Test func encodeBlurredImage() throws {
         // Given
         let image = try ImageProcessors.GaussianBlur().processThrowing(Test.image)
         let encoder = ImageEncoders.Default()
@@ -72,9 +72,9 @@ struct ImageEncoderTests {
         // When
         let data = try #require(encoder.encode(image))
 
-        // Then encoded as PNG because GaussianBlur produces
-        // images with alpha channel
-        #expect(AssetType(data) == .png)
+        // Then encoded as JPEG because GaussianBlur preserves the opacity
+        // of the input image
+        #expect(AssetType(data) == .jpeg)
     }
 
 #endif

--- a/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/GaussianBlurTests.swift
@@ -34,9 +34,24 @@ struct ImageProcessorsGaussianBlurTests {
         #expect(processor.process(image) != nil)
     }
 
-    @Test func applyBlurProducesTransparentImages() throws {
-        // Given
+    @Test func applyBlurPreservesOpacityOfOpaqueImages() throws {
+        // Given an opaque image
         let image = Test.image
+        #expect(image.cgImage?.isOpaque == true)
+        let processor = ImageProcessors.GaussianBlur()
+
+        // When
+        let processed = try #require(processor.process(image))
+
+        // Then the output isn't tagged with an alpha channel: it would make
+        // `ImageEncoders.Default` encode it as PNG instead of JPEG/HEIC
+        #expect(processed.cgImage?.isOpaque == true)
+    }
+
+    @Test func applyBlurPreservesAlphaChannelOfTransparentImages() throws {
+        // Given an image with an alpha channel
+        let image = Test.image(named: "swift", extension: "png")
+        #expect(image.cgImage?.isOpaque == false)
         let processor = ImageProcessors.GaussianBlur()
 
         // When
@@ -44,6 +59,22 @@ struct ImageProcessorsGaussianBlurTests {
 
         // Then
         #expect(processed.cgImage?.isOpaque == false)
+    }
+
+    @Test func blurSpreadsAlphaOfTransparentImages() throws {
+        // GIVEN an opaque square in the middle of a transparent canvas
+        let image = imageWithOpaqueSquare(size: 64, square: 16)
+        let outsideTheSquare = 32 * 64 + 20 // (x: 20, y: 32)
+        #expect(try alphaChannel(of: image)[outsideTheSquare] == 0)
+
+        // WHEN
+        let output = try #require(ImageProcessors.GaussianBlur(radius: 8).process(image))
+
+        // THEN the alpha channel is blurred too: it bleeds outside of the
+        // square and the solid core softens
+        let alpha = try alphaChannel(of: output)
+        #expect(alpha[outsideTheSquare] > 0)
+        #expect(alpha.max() ?? 0 < 255)
     }
 
     @Test func imagesWithSameRadiusHasSameIdentifiers() {
@@ -194,6 +225,29 @@ private func pixels(of image: PlatformImage) throws -> Data {
     }
     #expect(success)
     return Data(bytes)
+}
+
+/// Returns the alpha component of every pixel of the image, row by row.
+private func alphaChannel(of image: PlatformImage) throws -> [UInt8] {
+    let pixels = try pixels(of: image)
+    return stride(from: 3, to: pixels.count, by: 4).map { pixels[$0] }
+}
+
+/// Returns a transparent image with an opaque square in the middle.
+private func imageWithOpaqueSquare(size: Int, square: Int) -> PlatformImage {
+    let context = CGContext(
+        data: nil,
+        width: size,
+        height: size,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )!
+    context.setFillColor(CGColor(red: 0, green: 0, blue: 1, alpha: 1))
+    let origin = (size - square) / 2
+    context.fill(CGRect(x: origin, y: origin, width: square, height: square))
+    return PlatformImage(cgImage: context.makeImage()!)
 }
 
 #endif


### PR DESCRIPTION
Blurring an opaque photo used to produce an image tagged with an alpha channel, which made `ImageEncoders.Default` encode it as PNG instead of JPEG/HEIC and silently bypass `isHEIFPreferred`, so cached entries under `.storeEncodedImages` were multiple times larger than they needed to be. The scratch contexts `vImageBoxConvolve_ARGB8888` renders into were always created with `.premultipliedLast`; they now use `.noneSkipLast` for opaque sources, keeping the 32-bit layout vImage requires while images with an actual alpha channel keep being blurred as before.