### PR TITLE
Deliver ImageTask.Event.started to the task's event observers

### DIFF
--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -216,9 +216,7 @@ public final class ImagePipeline: Sendable {
         // `removeTask` to remove it, and already started for the events to be
         // delivered in the correct order.
         task._node = tasks.append(task)
-        if !isDataTask {
-            delegate.imageTask(task, didReceiveEvent: .started, pipeline: self)
-        }
+        task._dispatch(.started)
         onTaskStarted?(task)
         task._subscription = worker.subscribe(priority: task.priority.taskPriority, subscriber: task) { [weak task] in
             task?._process($0)

--- a/Tests/Helpers/NukeExtensions.swift
+++ b/Tests/Helpers/NukeExtensions.swift
@@ -29,6 +29,8 @@ extension ImagePipeline.Error: @retroactive Equatable {
 extension ImageTask.Event: @retroactive Equatable {
     public static func == (lhs: ImageTask.Event, rhs: ImageTask.Event) -> Bool {
         switch (lhs, rhs) {
+        case (.started, .started):
+            return true
         case let (.progress(lhs), .progress(rhs)):
             return lhs == rhs
         case let (.preview(lhs), .preview(rhs)):

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -99,6 +99,50 @@ struct ImageTaskTests {
 
     // MARK: - Events
 
+    @Test func startedIsTheFirstEventDeliveredToTheStream() async throws {
+        // Given a stream created before the pipeline starts the task
+        let observer = ImagePipelineObserver()
+        let pipeline = ImagePipeline(delegate: observer) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+        let stream = Nuke.Mutex<AsyncStream<ImageTask.Event>?>(value: nil)
+        observer.onTaskCreated = { task in
+            stream.withLock { $0 = task.events }
+        }
+
+        // When
+        _ = try await pipeline.imageTask(with: Test.request).response
+
+        // Then
+        var events: [ImageTask.Event] = []
+        for await event in try #require(stream.value) {
+            events.append(event)
+        }
+        #expect(events.first == .started)
+        #expect(events.filter { $0 == .started }.count == 1)
+
+        // Then the delegate receives it exactly once
+        await Task { @ImagePipelineActor in }.value
+        #expect(observer.startedTaskCount == 1)
+    }
+
+    @Test func startedIsTheFirstEventDeliveredToTheEventClosure() async throws {
+        // Given
+        let events = Nuke.Mutex<[ImageTask.Event]>(value: [])
+
+        // When
+        let task = pipeline.makeStartedImageTask(with: Test.request) { event, _ in
+            events.withLock { $0.append(event) }
+        }
+        _ = try await task.response
+
+        // Then
+        let recorded = events.value
+        #expect(recorded.first == .started)
+        #expect(recorded.filter { $0 == .started }.count == 1)
+    }
+
     @Test func eventsAreDeliveredToMultipleIndependentStreams() async throws {
         // Given
         dataLoader.isSuspended = true


### PR DESCRIPTION
`ImageTask.Event.started` was never delivered through `task.events` or the `onEvent` closure, so `for await event in task.events` could never observe it even though it is a public case of the stream's element type. `startImageTask` sent `.started` directly to the pipeline delegate instead of going through `_dispatch`, which is the only thing that feeds the stream continuations and the event closure; it now dispatches the event like every other one, so each observer — streams, closure, and delegate — receives exactly one `.started`, before the task subscribes to its worker.