### PR TITLE
Cancel the orphaned progressive operation when a dependency fails

### DIFF
--- a/Sources/Nuke/Tasks/AsyncTask.swift
+++ b/Sources/Nuke/Tasks/AsyncTask.swift
@@ -80,6 +80,10 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
         }
     }
 
+    /// The outstanding operation: either the one that runs the task itself
+    /// (data loading), or the work it awaits (decoding, processing). It's only
+    /// cancelled when the task is cancelled – cancelling it on completion would
+    /// cancel the very operation that reports the completion.
     var operation: TaskQueue.Operation? {
         didSet {
             guard priority != .normal else { return }
@@ -257,6 +261,11 @@ extension AsyncTask {
                 case let .progress(progress):
                     task.send(progress: progress)
                 case let .error(error):
+                    // Cancel the orphaned progressive work – unlike the
+                    // completed values, the errors bypass the call sites that
+                    // normally do it. Safe here: the task is terminated by its
+                    // dependency, so it isn't running inside this operation.
+                    task.operation?.cancel()
                     task.send(error: error)
                 }
             }

--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -106,10 +106,10 @@ final class TaskLoadImage: AsyncPipelineTask<ImageResponse> {
     // MARK: Decompression
 
     private func didReceiveImageResponse(_ response: ImageResponse, isCompleted: Bool) {
+        guard !isDisposed else { return }
         guard isDecompressionNeeded(for: response) else {
             return didReceiveDecompressedImage(response, isCompleted: isCompleted)
         }
-        guard !isDisposed else { return }
         if isCompleted {
             operation?.cancel() // Cancel any potential pending progressive decompression tasks
         } else if operation != nil {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -290,6 +290,50 @@ struct ImagePipelineProgressiveDecodingTests {
         #expect(!response.isPreview)
     }
 
+    // MARK: Failures
+
+    /// A pending progressive processing operation used to outlive the failed
+    /// task, holding on to the decoded preview until the queue drained past it.
+    @Test @ImagePipelineActor func pendingProcessingIsCancelledWhenTheTaskFails() async throws {
+        // Given a decoder that produces previews, but fails on the final image
+        final class FailingFinalImageDecoder: ImageDecoding, @unchecked Sendable {
+            private let decoder = ImageDecoders.Default()
+
+            func decode(_ data: Data) throws -> ImageContainer {
+                throw MockError(description: "decoder-failed")
+            }
+
+            func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer? {
+                decoder.decodePartiallyDownloadedData(data)
+            }
+        }
+        let pipeline = pipeline.reconfigured {
+            $0.makeImageDecoder = { _ in FailingFinalImageDecoder() }
+        }
+
+        // Given a suspended processing queue that keeps the preview processing pending
+        let queue = pipeline.configuration.imageProcessingQueue
+        queue.isSuspended = true
+
+        // When the first scan is decoded and scheduled for processing
+        let request = ImageRequest(url: Test.url, processors: [processorsFactory.make(id: "1")])
+        let task = pipeline.imageTask(with: request)
+        let operations = await queue.waitForOperations(count: 1) {}
+
+        // When the download completes and the final image fails to decode
+        dataLoader.resumeServingChunks(2)
+        await #expect(throws: ImagePipeline.Error.self) {
+            try await task.response
+        }
+
+        // Then the pending processing operation is cancelled and never runs
+        #expect(operations.first?.isCancelled == true)
+        queue.isSuspended = false
+        await queue.waitUntilAllOperationsAreFinished()
+        #expect(processorsFactory.numberOfProcessorsApplied == 0)
+        #expect(cache[request] == nil)
+    }
+
     // MARK: Memory Cache
 
     @Test func intermediateMemoryCachedResultsAreDelivered() async throws {

--- a/Tests/NukeTests/TaskTests.swift
+++ b/Tests/NukeTests/TaskTests.swift
@@ -460,6 +460,64 @@ struct TaskTests {
         #expect(isDisposeCalled)
         #expect(task.isDisposed)
     }
+
+    @Test func whenDependencyFailsOutstandingOperationIsCancelled() {
+        // Given a task waiting on an operation and on a dependency
+        let operation = TaskQueue.Operation()
+        let dependency = SimpleTask<Int, MyError>()
+        let task = SimpleTask<Int, MyError>(starter: {
+            $0.operation = operation
+            $0.dependency = dependency.publisher.subscribe($0) { _, _ in }
+        })
+        _ = task.subscribe { _ in }
+        #expect(!operation.isCancelled)
+
+        // When the dependency fails
+        dependency.send(error: .init(raw: "1"))
+
+        // Then the orphaned operation isn't left to occupy a queue slot
+        #expect(operation.isCancelled)
+    }
+
+    @Test func whenTaskFailsItsOwnOperationIsNotCancelled() {
+        // Given
+        let operation = TaskQueue.Operation()
+        let task = SimpleTask<Int, MyError>(starter: { $0.operation = operation })
+        _ = task.subscribe { _ in }
+
+        // When the task reports the error itself, which it does from inside
+        // the operation that runs it
+        task.send(error: .init(raw: "1"))
+
+        // Then
+        #expect(!operation.isCancelled)
+    }
+
+    @Test func whenTaskCompletesWithSuccessOperationIsNotCancelled() {
+        // Given
+        let operation = TaskQueue.Operation()
+        let task = SimpleTask<Int, MyError>(starter: { $0.operation = operation })
+        _ = task.subscribe { _ in }
+
+        // When
+        task.send(value: 1, isCompleted: true)
+
+        // Then
+        #expect(!operation.isCancelled)
+    }
+
+    @Test func whenTaskSendsIntermediateValueOperationIsNotCancelled() {
+        // Given
+        let operation = TaskQueue.Operation()
+        let task = SimpleTask<Int, MyError>(starter: { $0.operation = operation })
+        _ = task.subscribe { _ in }
+
+        // When
+        task.send(value: 1)
+
+        // Then
+        #expect(!operation.isCancelled)
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
A pending progressive decode, processing, or decompression operation is cancelled when the final value arrives — `TaskFetchOriginalImage.didReceiveData`, `TaskLoadImage.process`, and `TaskLoadImage.didReceiveImageResponse` all do it explicitly. The errors bypass those call sites entirely: they are forwarded generically by `AsyncTask.Publisher.subscribe(_:onValue:)`, so a task that failed left its operation in the queue, holding on to the decoded preview and the captured decoder until the queue drained past it.

The cancellation now happens in that forwarder. It deliberately isn't in `AsyncTask.terminate`: `operation` is either the work a task awaits (decoding, processing — cleared before the result is delivered) or the operation that runs the task itself (`TaskFetchOriginalData.loadData`, `loadAsyncData`, `TaskFetchOriginalImage.loadAsyncImage` — never cleared). For the latter, the terminal event is reported from inside the operation, and since `send` terminates before delivering the event, a blanket cancel would run the whole downstream delivery chain inside a just-cancelled `Task`.

`TaskLoadImage.didReceiveImageResponse` also checks `isDisposed` before the no-decompression early return, so a late response can't reach `storeImageInCaches` and write a stale preview to the memory cache after the task has ended.
