### PR TITLE
Fix LazyImage.processors and .priority overriding the request's own values

### DIFF
--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -104,12 +104,22 @@ public struct LazyImage<Content: View>: View {
     /// Processors are only applied if the request does not already define its
     /// own processors. The request's processors always take priority.
     public consuming func processors(_ processors: [any ImageProcessing]?) -> Self {
-        map { $0.context?.request.processors = processors ?? [] }
+        map {
+            if let processors, !processors.isEmpty, $0.context?.request.processors.isEmpty == true {
+                $0.context?.request.processors = processors
+            }
+        }
     }
 
     /// Sets the priority of the requests.
+    ///
+    /// When `nil` (the default), the request's own priority is used.
     public consuming func priority(_ priority: ImageRequest.Priority?) -> Self {
-        map { $0.context?.request.priority = priority ?? .normal }
+        map {
+            if let priority {
+                $0.context?.request.priority = priority
+            }
+        }
     }
 
     /// Changes the underlying pipeline used for image loading.
@@ -205,7 +215,6 @@ private struct LazyImageContext: Equatable {
         return lhs.imageID == rhs.imageID &&
         lhs.priority == rhs.priority &&
         lhs.processors == rhs.processors &&
-        lhs.priority == rhs.priority &&
         lhs.options == rhs.options
     }
 }

--- a/Tests/NukeUITests/LazyImageTests.swift
+++ b/Tests/NukeUITests/LazyImageTests.swift
@@ -269,7 +269,7 @@ struct LazyImageTests {
         withExtendedLifetime(host) {}
     }
 
-    @Test func nilProcessorsClearRequestProcessors() async {
+    @Test func nilProcessorsKeepRequestProcessors() async {
         let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "p1")])
 
         let completed = TestExpectation()
@@ -286,7 +286,28 @@ struct LazyImageTests {
         }
         await completed.wait()
 
-        #expect(response.value?.image.nk_test_processorIDs == [])
+        #expect(response.value?.image.nk_test_processorIDs == ["p1"])
+        withExtendedLifetime(host) {}
+    }
+
+    @Test func processorsFromRequestTakePrecedenceOverViewProcessors() async {
+        let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "p2")])
+
+        let completed = TestExpectation()
+        let response = Ref<ImageResponse?>(nil)
+
+        let host = ViewHost(request) { request in
+            LazyImage(request: request)
+                .pipeline(pipeline)
+                .processors([MockImageProcessor(id: "p1")])
+                .onCompletion {
+                    response.value = $0.value
+                    completed.fulfill()
+                }
+        }
+        await completed.wait()
+
+        #expect(response.value?.image.nk_test_processorIDs == ["p2"])
         withExtendedLifetime(host) {}
     }
 
@@ -313,7 +334,7 @@ struct LazyImageTests {
         withExtendedLifetime(host) {}
     }
 
-    @Test func nilPriorityResetsRequestPriorityToNormal() async throws {
+    @Test func nilPriorityKeepsRequestPriority() async throws {
         dataLoader.isSuspended = true
 
         let started = TestExpectation()
@@ -331,7 +352,7 @@ struct LazyImageTests {
         }
         await started.wait()
 
-        #expect(try #require(task.value).priority == .normal)
+        #expect(try #require(task.value).priority == .high)
         withExtendedLifetime(host) {}
     }
 


### PR DESCRIPTION
`LazyImage.processors(_:)` and `LazyImage.priority(_:)` contradicted their own documentation: for a `LazyImage(request:)` built from a request that carries its own processors or priority, the modifiers would override them, and passing `nil` would reset them instead of leaving them alone. Both assigned unconditionally (`processors ?? []`, `priority ?? .normal`) rather than deferring to the request the way `LazyImageView` and `FetchImage` do. They now behave as documented:

- `.processors([...])` is only applied when the request has no processors of its own.
- `.processors(nil)` no longer wipes the request's processors.
- `.priority(nil)` no longer resets the request's priority to `.normal`.

Also drops a duplicated `priority` comparison in `LazyImageContext`'s `==`; the modifiers still restart the request whenever they actually change it.