### PR TITLE
Synchronize access to isSignpostLoggingEnabled

### DIFF
--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -150,7 +150,12 @@ extension ImagePipeline {
         ///
         /// For more information, see the [Logging](https://developer.apple.com/documentation/os/logging)
         /// documentation and [WWDC 2018 Session 405](https://developer.apple.com/videos/play/wwdc2018/405/).
-        nonisolated(unsafe) public static var isSignpostLoggingEnabled = false
+        public static var isSignpostLoggingEnabled: Bool {
+            get { _isSignpostLoggingEnabled.value }
+            set { _isSignpostLoggingEnabled.withLock { $0 = newValue } }
+        }
+
+        private static let _isSignpostLoggingEnabled = Mutex(value: false)
 
         private var isCustomImageCacheProvided = false
 

--- a/Tests/NukeTests/SignpostLoggingTests.swift
+++ b/Tests/NukeTests/SignpostLoggingTests.swift
@@ -72,6 +72,39 @@ struct SignpostLoggingTests {
         }
     }
 
+    /// The pipeline reads `isSignpostLoggingEnabled` on every `signpost(...)`
+    /// call from its own threads, so writing it from another thread has to be
+    /// synchronized – otherwise the thread sanitizer aborts the test run.
+    @Test func signpostLoggingIsToggledWhileLoadingImages() async throws {
+        // Given
+        let initialValue = ImagePipeline.Configuration.isSignpostLoggingEnabled
+        defer { ImagePipeline.Configuration.isSignpostLoggingEnabled = initialValue }
+
+        let writer = Task.detached {
+            var isEnabled = true
+            while !Task.isCancelled {
+                isEnabled.toggle()
+                ImagePipeline.Configuration.isSignpostLoggingEnabled = isEnabled
+                await Task.yield()
+            }
+        }
+
+        // When loading images while the flag is being toggled
+        let pipeline = self.pipeline
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<50 {
+                group.addTask {
+                    let url = URL(string: "https://example.com/image-\(index).jpeg")!
+                    _ = try? await pipeline.image(for: ImageRequest(url: url))
+                }
+            }
+        }
+
+        // Then no data races are reported
+        writer.cancel()
+        await writer.value
+    }
+
     @Test func byteFormatter() {
         #expect(!Formatter.bytes(0).isEmpty)
         #expect(!Formatter.bytes(1024).isEmpty)


### PR DESCRIPTION
Toggling `ImagePipeline.Configuration.isSignpostLoggingEnabled` while a pipeline is loading images trips the thread sanitizer and aborts the test process, which is why `SignpostLoggingTests` fails intermittently on macOS. The flag was declared `nonisolated(unsafe)` with no synchronization at all, and the pipeline reads it on every `signpost(...)` call from its own data loading, decoding and processing threads, so any write from another thread races with those reads; it is now backed by the internal `Mutex`, leaving the public API unchanged.