### PR TITLE
Fix data race in TestExpectation's notification observer

### DIFF
--- a/Tests/Helpers/TestExpectation.swift
+++ b/Tests/Helpers/TestExpectation.swift
@@ -96,11 +96,12 @@ final class TestExpectation: @unchecked Sendable {
 extension TestExpectation {
     convenience init(notification name: Notification.Name, object: AnyObject? = nil) {
         self.init()
-        let ref = TokenRef()
-        ref.token = NotificationCenter.default.addObserver(forName: name, object: object, queue: nil) { [weak self] _ in
-            if let token = ref.token { NotificationCenter.default.removeObserver(token) }
+        let observer = NotificationObserver()
+        let token = NotificationCenter.default.addObserver(forName: name, object: object, queue: nil) { [weak self] _ in
+            observer.remove()
             self?.fulfill()
         }
+        observer.store(token)
     }
 
     /// Creates a test expectation that waits for a given number of operations
@@ -139,8 +140,31 @@ private final class TaskQueueOperationRecorder: @unchecked Sendable {
     }
 }
 
-private final class TokenRef: @unchecked Sendable {
-    var token: NSObjectProtocol?
+/// Owns the token returned by `NotificationCenter.addObserver`. The notification
+/// can be delivered on another thread before `addObserver` returns, so the token
+/// handoff has to be synchronized, and the observer has to be removed exactly
+/// once no matter which side wins the race.
+private final class NotificationObserver: @unchecked Sendable {
+    private let lock = NSLock()
+    private var token: NSObjectProtocol?
+    private var isRemoved = false
+
+    func store(_ token: NSObjectProtocol) {
+        let isRemoved = lock.withLock { () -> Bool in
+            if !self.isRemoved { self.token = token }
+            return self.isRemoved
+        }
+        if isRemoved { NotificationCenter.default.removeObserver(token) }
+    }
+
+    func remove() {
+        let token = lock.withLock { () -> NSObjectProtocol? in
+            isRemoved = true
+            defer { self.token = nil }
+            return self.token
+        }
+        if let token { NotificationCenter.default.removeObserver(token) }
+    }
 }
 
 func notification(_ name: Notification.Name, object: AnyObject? = nil, isolation: isolated (any Actor)? = #isolation, while action: () -> Void = {}) async {

--- a/Tests/NukeTests/TestExpectationTests.swift
+++ b/Tests/NukeTests/TestExpectationTests.swift
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+import Testing
+@testable import Nuke
+
+@Suite(.timeLimit(.minutes(5)))
+struct TestExpectationTests {
+    /// `NotificationCenter` can deliver the notification on another thread before
+    /// `addObserver` returns, so the expectation has to survive being fulfilled
+    /// while it is still being created.
+    @Test func notificationIsDeliveredWhileExpectationIsCreated() async {
+        let name = Notification.Name("com.github.kean.Nuke.Tests.TestExpectationTests.\(UUID().uuidString)")
+        let isPosting = Nuke.Mutex(value: true)
+        let thread = Thread {
+            while isPosting.value {
+                NotificationCenter.default.post(name: name, object: nil)
+            }
+        }
+        thread.start()
+        defer { isPosting.withLock { $0 = false } }
+
+        for _ in 0..<100 {
+            await notification(name)
+        }
+    }
+}


### PR DESCRIPTION
Two ImageTaskStateTests tests failed consistently on macOS because ThreadSanitizer flagged a data race in TestExpectation(notification:object:) and aborted the test process. NotificationCenter can deliver the notification on another thread before addObserver returns, so the observer block read the token while the initializing thread was still writing it, and when the notification won that race the observer was never removed and could fire again for a later test. The token handoff is now synchronized and the observer is removed exactly once regardless of which side wins.