### PR TITLE
Build Mutex on OSAllocatedUnfairLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 - Minimum required platforms: iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, visionOS 1.0 – https://github.com/kean/Nuke/pull/904
 
+**Concurrency & Data Race Safety**
+
+- Fix a crash in `_os_unfair_lock_corruption_abort` on Intel Macs by building the internal locks on `OSAllocatedUnfairLock`, which owns the lock's storage, instead of an `os_unfair_lock` the compiler is free to copy – https://github.com/kean/Nuke/pull/905
+
 # Nuke 13
 
 ## WIP

--- a/Sources/Nuke/Caching/Cache.swift
+++ b/Sources/Nuke/Caching/Cache.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+import os
 
 #if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit.UIApplication
@@ -36,13 +37,13 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 
     var conf: Configuration {
         get {
-            os_unfair_lock_lock(lock)
-            defer { os_unfair_lock_unlock(lock) }
+            lock.lock()
+            defer { lock.unlock() }
             return _conf
         }
         set {
-            os_unfair_lock_lock(lock)
-            defer { os_unfair_lock_unlock(lock) }
+            lock.lock()
+            defer { lock.unlock() }
             _conf = newValue
         }
     }
@@ -52,28 +53,26 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     var totalCost: Int {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         return _totalCost
     }
 
     var totalCount: Int {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         return map.count
     }
 
     private var _totalCost = 0
     private var map = [Key: LinkedList<Entry>.Node]()
     private let list = LinkedList<Entry>()
-    private let lock: os_unfair_lock_t
+    private let lock = OSAllocatedUnfairLock()
     private let memoryPressure: DispatchSourceMemoryPressure
     private var notificationObserver: AnyObject?
 
     init(costLimit: Int, countLimit: Int) {
         self._conf = Configuration(costLimit: costLimit, countLimit: countLimit, ttl: nil, entryCostLimit: 0.1)
-        self.lock = .allocate(capacity: 1)
-        self.lock.initialize(to: os_unfair_lock())
 
         self.memoryPressure = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)
         self.memoryPressure.setEventHandler { [weak self] in
@@ -90,8 +89,6 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 
     deinit {
         memoryPressure.cancel()
-        lock.deinitialize(count: 1)
-        lock.deallocate()
     }
 
 #if os(iOS) || os(tvOS) || os(visionOS)
@@ -103,8 +100,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 #endif
 
     func value(forKey key: Key) -> Value? {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         guard let node = map[key] else {
             return nil
@@ -126,8 +123,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func set(_ value: Value, forKey key: Key, cost: Int = 0, ttl: TimeInterval? = nil) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         guard cost < _conf.entryMaxCost else {
             return
@@ -142,8 +139,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 
     @discardableResult
     func removeValue(forKey key: Key) -> Value? {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         guard let node = map[key] else {
             return nil
@@ -172,8 +169,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func removeAllCachedValues() {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         map.removeAll()
         list.removeAllElements()
@@ -185,8 +182,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
         // This behavior is similar to `NSCache` (which removes all
         // items). This feature is not documented and may be subject
         // to change in future Nuke versions.
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         _trim(toCost: Int(Double(_conf.costLimit) * 0.1))
         _trim(toCount: Int(Double(_conf.countLimit) * 0.1))
@@ -201,8 +198,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func trim(toCost limit: Int) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         _trim(toCost: limit)
     }
 
@@ -211,8 +208,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func trim(toCount limit: Int) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         _trim(toCount: limit)
     }
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -144,10 +144,9 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         case finished(Result<ImageResponse, ImagePipeline.Error>)
     }
 
-    private var nonisolatedState: NonisolatedState
+    private let nonisolatedState: Mutex<NonisolatedState>
     private let isDataTask: Bool
     private let onEvent: ((Event, ImageTask) -> Void)?
-    private let lock: os_unfair_lock_t
     private weak var pipeline: ImagePipeline?
 
     // Set once during creation, then read-only from `response` getter.
@@ -158,21 +157,13 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
 
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
-    }
-
     init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, pipeline: ImagePipeline, onEvent: ((Event, ImageTask) -> Void)?) {
         self.taskId = taskId
         self.request = request
-        self.nonisolatedState = NonisolatedState(priority: request.priority)
+        self.nonisolatedState = Mutex(value: NonisolatedState(priority: request.priority))
         self.isDataTask = isDataTask
         self.pipeline = pipeline
         self.onEvent = onEvent
-
-        lock = .allocate(capacity: 1)
-        lock.initialize(to: os_unfair_lock())
     }
 
     /// Marks task as being cancelled.
@@ -317,9 +308,7 @@ extension ImageTask {
     }
 
     private func withNonisolatedStateLock<T>(_ closure: (inout NonisolatedState) -> T) -> T {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return closure(&nonisolatedState)
+        nonisolatedState.withLock(closure)
     }
 
     /// Contains the state synchronized using the internal lock.

--- a/Sources/Nuke/Internal/Mutex.swift
+++ b/Sources/Nuke/Internal/Mutex.swift
@@ -2,33 +2,41 @@
 //
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
-import Foundation
+import os
 
-final class Mutex<T>: @unchecked Sendable {
-    private var _value: T
-    private let lock: os_unfair_lock_t
+/// A mutual exclusion lock that guards a value.
+///
+/// Backed by `OSAllocatedUnfairLock`, which owns the lock's storage. An
+/// `os_unfair_lock` must never be copied or moved, and storing one in a Swift
+/// property gives the compiler license to do exactly that, which aborts the
+/// process with `_os_unfair_lock_corruption_abort` – https://github.com/kean/Nuke/issues/841.
+///
+/// The value is constrained to `Sendable` to keep the critical section from
+/// handing out state that isn't safe to use outside it. That's the same
+/// discipline the standard library's `Synchronization.Mutex` enforces, which
+/// this type can be swapped for once the deployment target reaches iOS 18.
+struct Mutex<T: Sendable>: Sendable {
+    private let lock: OSAllocatedUnfairLock<T>
 
     init(value: T) {
-        self._value = value
-        self.lock = .allocate(capacity: 1)
-        self.lock.initialize(to: os_unfair_lock())
-    }
-
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
+        lock = OSAllocatedUnfairLock(initialState: value)
     }
 
     var value: T {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return _value
+        lock.withLockUnchecked { $0 }
     }
 
-    func withLock<U>(_ closure: (inout T) -> U) -> U {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return closure(&_value)
+    /// Calls the closure with exclusive access to the value.
+    ///
+    /// - warning: The closure must never call back into anything that acquires
+    /// the same lock: `os_unfair_lock` is not recursive and re-entering it
+    /// traps.
+    func withLock<U>(_ closure: (inout T) throws -> U) rethrows -> U {
+        // `withLockUnchecked` rather than `withLock`: the latter requires a
+        // `@Sendable` closure and a `Sendable` result, which the call sites
+        // don't need. The closure is scoped and synchronous, and `T` is already
+        // `Sendable`.
+        try lock.withLockUnchecked(closure)
     }
 }
 

--- a/Tests/Helpers/Helpers.swift
+++ b/Tests/Helpers/Helpers.swift
@@ -5,6 +5,7 @@
 import Nuke
 import Foundation
 import CoreGraphics
+import os
 
 #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import UIKit
@@ -221,44 +222,22 @@ extension Result {
 }
 
 @propertyWrapper final class Mutex<T> {
-    private var value: T
-    private let lock: os_unfair_lock_t
+    private let lock: OSAllocatedUnfairLock<T>
 
     init(wrappedValue value: T) {
-        self.value = value
-        self.lock = .allocate(capacity: 1)
-        self.lock.initialize(to: os_unfair_lock())
-    }
-
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
+        lock = OSAllocatedUnfairLock(uncheckedState: value)
     }
 
     var wrappedValue: T {
-        get { getValue() }
-        set { setValue(newValue) }
+        get { lock.withLockUnchecked { $0 } }
+        set { lock.withLockUnchecked { $0 = newValue } }
     }
 
     var projectedValue: Mutex<T> {
         self
     }
 
-    func withLock<U>(_ closure: (inout T) -> U) -> U {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return closure(&value)
-    }
-
-    private func getValue() -> T {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return value
-    }
-
-    private func setValue(_ newValue: T) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        value = newValue
+    func withLock<U>(_ closure: (inout T) throws -> U) rethrows -> U {
+        try lock.withLockUnchecked(closure)
     }
 }

--- a/Tests/NukeTests/MutexTests.swift
+++ b/Tests/NukeTests/MutexTests.swift
@@ -1,0 +1,109 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import Foundation
+@testable import Nuke
+
+@Suite(.timeLimit(.minutes(5)))
+struct MutexTests {
+    @Test func valueReturnsTheInitialValue() {
+        let mutex = Nuke.Mutex(value: 7)
+
+        #expect(mutex.value == 7)
+    }
+
+    @Test func withLockMutatesTheValueInPlace() {
+        let mutex = Nuke.Mutex(value: 7)
+
+        mutex.withLock { $0 += 1 }
+
+        #expect(mutex.value == 8)
+    }
+
+    @Test func withLockReturnsTheClosureResult() {
+        let mutex = Nuke.Mutex(value: "a")
+
+        let previous = mutex.withLock { value -> String in
+            let previous = value
+            value = "b"
+            return previous
+        }
+
+        #expect(previous == "a")
+        #expect(mutex.value == "b")
+    }
+
+    @Test func withLockRethrowsTheClosureError() {
+        struct Failure: Error {}
+        let mutex = Nuke.Mutex(value: 0)
+
+        #expect(throws: Failure.self) {
+            try mutex.withLock { _ in throw Failure() }
+        }
+
+        // The lock is released, so it can still be acquired.
+        mutex.withLock { $0 = 1 }
+        #expect(mutex.value == 1)
+    }
+
+    @Test func testAndSetChangesTheValueWhenItDiffers() {
+        let mutex = Nuke.Mutex(value: 1)
+
+        #expect(mutex.testAndSet(2) == true)
+        #expect(mutex.value == 2)
+    }
+
+    @Test func testAndSetDoesNothingWhenTheValueMatches() {
+        let mutex = Nuke.Mutex(value: 1)
+
+        #expect(mutex.testAndSet(1) == false)
+        #expect(mutex.value == 1)
+    }
+
+    /// A copy shares the storage with the original: the lock and the value it
+    /// guards live in the allocation owned by `OSAllocatedUnfairLock`, not in
+    /// the `Mutex` value itself.
+    @Test func copiesShareTheUnderlyingStorage() {
+        let mutex = Nuke.Mutex(value: 0)
+        let copy = mutex
+
+        copy.withLock { $0 = 42 }
+
+        #expect(mutex.value == 42)
+    }
+
+    /// Regression coverage for https://github.com/kean/Nuke/issues/841: an
+    /// `os_unfair_lock` stored inline in a Swift value can be copied by the
+    /// compiler, and locking a copy aborts the process. Passing the mutex
+    /// across concurrent tasks is exactly the shape that used to trip it.
+    @Test func concurrentIncrementsDoNotLoseUpdates() async {
+        let iterations = 1_000
+        let mutex = Nuke.Mutex(value: 0)
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<iterations {
+                group.addTask {
+                    mutex.withLock { $0 += 1 }
+                }
+            }
+        }
+
+        #expect(mutex.value == iterations)
+    }
+
+    @Test func concurrentTestAndSetReportsExactlyOneChange() async {
+        let mutex = Nuke.Mutex(value: 0)
+
+        let changes = await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<1_000 {
+                group.addTask { mutex.testAndSet(1) }
+            }
+            return await group.reduce(into: 0) { $0 += $1 ? 1 : 0 }
+        }
+
+        #expect(changes == 1)
+        #expect(mutex.value == 1)
+    }
+}


### PR DESCRIPTION
Fixes #841.

An `os_unfair_lock` must never be copied or moved. Nuke kept its locks in place by hand — `UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)`, `initialize(to:)`, and a matching `deinit` — repeated in four separate types. That's the shape that trips `_os_unfair_lock_corruption_abort` on Intel Macs, and it's easy to get wrong in a new type.

`OSAllocatedUnfairLock` (iOS 16+, now the deployment floor after #904) owns the lock's storage, so it can be held in a plain `let`.

**Changes**

- `Mutex` is now a `struct` wrapping `OSAllocatedUnfairLock<T>`, constrained to `T: Sendable`. The constraint makes it a fully checked `Sendable` instead of `@unchecked`, and matches what `Synchronization.Mutex` will require when the floor reaches iOS 18 — swapping the backing store then is a one-file change. `withLock` also picks up `rethrows`.
- `ImageTask` drops its lock pointer and `deinit`; `NonisolatedState` moves into a `Mutex`, which is exactly what that struct was already emulating.
- `Cache` uses `OSAllocatedUnfairLock` directly rather than `Mutex`: it guards linked-list nodes, which aren't `Sendable`, so it needs a bare lock rather than a value-guarding one.
- The test helpers' `@propertyWrapper Mutex` had a copy of the same pointer code; it's now backed by `OSAllocatedUnfairLock` too (unconstrained, since tests store non-`Sendable` values in it).

No `os_unfair_lock` pointer code is left in `Sources/` or `Tests/`.

**Testing**

New `MutexTests` covers the value/`withLock`/`testAndSet` contract, `rethrows` releasing the lock, shared storage across copies, and two concurrent-mutation tests for the crash shape. Full suite green on macOS: 948 `NukeTests`, 131 `NukeUITests`, 33 `NukeExtensionsTests`, 7 `NukeThreadSafetyTests`.
