### PR TITLE
Remove the APIs deprecated in Nuke 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 **API Changes**
 
-- Remove previously deprecated APIs: `ImagePipelineDelegate` typealias, `ImageRequest.imageId`, `ImageRequest.UserInfoKey.imageIdKey`, `ImageRequest.UserInfoKey.scaleKey`, `ImageRequest.UserInfoKey.thumbnailKey`, `ImagePipeline.Configuration.maximumDecodedImageSize`, and `ImageDecodingContext.maximumDecodedImageSize`
+- Remove previously deprecated APIs: `ImagePipelineDelegate` typealias, `ImageRequest.imageId`, `ImageRequest.UserInfoKey.imageIdKey`, `ImageRequest.UserInfoKey.scaleKey`, `ImageRequest.UserInfoKey.thumbnailKey`, `ImagePipeline.Configuration.maximumDecodedImageSize`, and `ImageDecodingContext.maximumDecodedImageSize` – https://github.com/kean/Nuke/pull/907
 
 # Nuke 13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 - Minimum required platforms: iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, visionOS 1.0 – https://github.com/kean/Nuke/pull/904
 
+**API Changes**
+
+- Remove previously deprecated APIs: `ImagePipelineDelegate` typealias, `ImageRequest.imageId`, `ImageRequest.UserInfoKey.imageIdKey`, `ImageRequest.UserInfoKey.scaleKey`, `ImageRequest.UserInfoKey.thumbnailKey`, `ImagePipeline.Configuration.maximumDecodedImageSize`, and `ImageDecodingContext.maximumDecodedImageSize`
+
 # Nuke 13
 
 ## WIP

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -13,3 +13,19 @@ The minimum supported platforms have been raised.
 - Swift 6.2
 
 Apps that need to support earlier OS versions can stay on Nuke 13.x, which continues to receive fixes.
+
+## Removed Deprecated APIs
+
+The APIs deprecated in Nuke 13 have been removed.
+
+| Removed | Replacement |
+|---|---|
+| `ImagePipelineDelegate` | `ImagePipeline.Delegate` |
+| `ImageRequest.imageId` | `ImageRequest.imageID` |
+| `ImageRequest.UserInfoKey.imageIdKey` | `ImageRequest.imageID` |
+| `ImageRequest.UserInfoKey.scaleKey` | `ImageRequest.scale` |
+| `ImageRequest.UserInfoKey.thumbnailKey` | `ImageRequest.thumbnail` |
+| `ImagePipeline.Configuration.maximumDecodedImageSize` | `ImageRequest.ThumbnailOptions` |
+| `ImageDecodingContext.maximumDecodedImageSize` | `ImageRequest.ThumbnailOptions` |
+
+The automatic downscaling implementation behind `maximumDecodedImageSize` was removed in Nuke 13, so setting it already had no effect. Use `ImageRequest.ThumbnailOptions` to control the decoded image size on a per-request basis instead.

--- a/Sources/Nuke/Decoding/ImageDecoderRegistry.swift
+++ b/Sources/Nuke/Decoding/ImageDecoderRegistry.swift
@@ -91,14 +91,6 @@ public struct ImageDecodingContext: Sendable {
     /// The preview policy for progressive decoding. Set by the pipeline
     /// delegate for partial data; defaults to `.incremental`.
     public var previewPolicy: ImagePipeline.PreviewPolicy = .incremental
-    /// - warning: Deprecated. The automatic downscaling implementation has
-    /// been removed. Setting this value has no effect.
-    @available(*, deprecated, message: "Automatic decoded image size limiting has been removed. Setting this value has no effect.")
-    public var maximumDecodedImageSize: Int? {
-        get { _maximumDecodedImageSize }
-        set { _maximumDecodedImageSize = newValue }
-    }
-    private var _maximumDecodedImageSize: Int?
 
     public init(request: ImageRequest, data: Data, isCompleted: Bool = true, urlResponse: URLResponse? = nil, cacheType: ImageResponse.CacheType? = nil) {
         self.request = request

--- a/Sources/Nuke/Pipeline/Deprecated.swift
+++ b/Sources/Nuke/Pipeline/Deprecated.swift
@@ -4,33 +4,6 @@
 
 import Foundation
 
-/// - warning: Renamed to ``ImagePipeline/Delegate``.
-@available(*, deprecated, renamed: "ImagePipeline.Delegate")
-public typealias ImagePipelineDelegate = ImagePipeline.Delegate
-
-extension ImageRequest {
-    /// - warning: Renamed to ``imageID``. The new property uses idiomatic Swift naming (uppercase "ID") and is writable.
-    @available(*, deprecated, renamed: "imageID")
-    public var imageId: String? {
-        get { imageID }
-        set { imageID = newValue }
-    }
-}
-
-extension ImageRequest.UserInfoKey {
-    /// - warning: Use ``ImageRequest/imageID`` instead.
-    @available(*, deprecated, message: "Use the imageID property on ImageRequest instead")
-    public static let imageIdKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/imageId"
-
-    /// - warning: Use ``ImageRequest/scale`` instead.
-    @available(*, deprecated, message: "Use the scale property on ImageRequest instead")
-    public static let scaleKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/scale"
-
-    /// - warning: Use ``ImageRequest/thumbnail`` instead.
-    @available(*, deprecated, message: "Use the thumbnail property on ImageRequest instead")
-    public static let thumbnailKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/thumbnail"
-}
-
 extension ImagePipeline {
     // MARK: - Loading Images (Closures)
 

--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -121,16 +121,6 @@ extension ImagePipeline {
         /// `data` schemes) inline without using the data loader. By default, `true`.
         public var isLocalResourcesSupportEnabled = true
 
-        /// - warning: Deprecated. The automatic downscaling implementation has
-        /// been removed. Use ``ImageRequest/ThumbnailOptions`` to control the
-        /// decoded image size on a per-request basis instead.
-        @available(*, deprecated, message: "Automatic decoded image size limiting has been removed. Use ImageRequest.ThumbnailOptions to control decoded image size per request.")
-        public var maximumDecodedImageSize: Int? {
-            get { _maximumDecodedImageSize }
-            set { _maximumDecodedImageSize = newValue }
-        }
-        private var _maximumDecodedImageSize: Int?
-
         /// The maximum response data size in bytes allowed before the download
         /// is automatically cancelled. Downloads that exceed this limit fail
         /// with ``ImagePipeline/Error/dataDownloadExceededMaximumSize``. `nil`


### PR DESCRIPTION
Removes the APIs marked `@available(*, deprecated)` in Nuke 13: the `ImagePipelineDelegate` typealias, `ImageRequest.imageId`, the `imageIdKey`/`scaleKey`/`thumbnailKey` user info keys, and `maximumDecodedImageSize` on both `ImagePipeline.Configuration` and `ImageDecodingContext`. Each has a direct replacement — `ImagePipeline.Delegate`, `imageID`, the type-safe `imageID`/`scale`/`thumbnail` properties, and `ImageRequest.ThumbnailOptions` — and the automatic downscaling behind `maximumDecodedImageSize` was already removed in 13, so setting it had no effect.

The soft-deprecated APIs are untouched: the closure-based `loadImage`/`loadData` methods and the `userInfo` parameter in the `ImageRequest` initializers stay for now.

Nothing in the framework, the tests, or the documentation catalogs referenced the removed symbols. The migration guide gets a table mapping each removed API to its replacement.