### PR TITLE
Replace the remaining os_unfair_lock usages with OSAllocatedUnfairLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 **Requirements**
 
-- Minimum required platforms: iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, visionOS 1.0 – https://github.com/kean/Nuke/pull/904
+- Minimum required platforms: iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, visionOS 1.0 – https://github.com/kean/Nuke/pull/904. The internal locks now use `OSAllocatedUnfairLock` instead of the hand-rolled `os_unfair_lock_t` allocations – https://github.com/kean/Nuke/pull/908
 
 # Nuke 13
 

--- a/Sources/Nuke/Caching/Cache.swift
+++ b/Sources/Nuke/Caching/Cache.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+import os
 
 #if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit.UIApplication
@@ -36,13 +37,13 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 
     var conf: Configuration {
         get {
-            os_unfair_lock_lock(lock)
-            defer { os_unfair_lock_unlock(lock) }
+            lock.lock()
+            defer { lock.unlock() }
             return _conf
         }
         set {
-            os_unfair_lock_lock(lock)
-            defer { os_unfair_lock_unlock(lock) }
+            lock.lock()
+            defer { lock.unlock() }
             _conf = newValue
         }
     }
@@ -52,28 +53,26 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     var totalCost: Int {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         return _totalCost
     }
 
     var totalCount: Int {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         return map.count
     }
 
     private var _totalCost = 0
     private var map = [Key: LinkedList<Entry>.Node]()
     private let list = LinkedList<Entry>()
-    private let lock: os_unfair_lock_t
+    private let lock = OSAllocatedUnfairLock()
     private let memoryPressure: DispatchSourceMemoryPressure
     private var notificationObserver: AnyObject?
 
     init(costLimit: Int, countLimit: Int) {
         self._conf = Configuration(costLimit: costLimit, countLimit: countLimit, ttl: nil, entryCostLimit: 0.1)
-        self.lock = .allocate(capacity: 1)
-        self.lock.initialize(to: os_unfair_lock())
 
         self.memoryPressure = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)
         self.memoryPressure.setEventHandler { [weak self] in
@@ -90,8 +89,6 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 
     deinit {
         memoryPressure.cancel()
-        lock.deinitialize(count: 1)
-        lock.deallocate()
     }
 
 #if os(iOS) || os(tvOS) || os(visionOS)
@@ -103,8 +100,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 #endif
 
     func value(forKey key: Key) -> Value? {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         guard let node = map[key] else {
             return nil
@@ -126,8 +123,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func set(_ value: Value, forKey key: Key, cost: Int = 0, ttl: TimeInterval? = nil) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         guard cost < _conf.entryMaxCost else {
             return
@@ -142,8 +139,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
 
     @discardableResult
     func removeValue(forKey key: Key) -> Value? {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         guard let node = map[key] else {
             return nil
@@ -172,8 +169,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func removeAllCachedValues() {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         map.removeAll()
         list.removeAllElements()
@@ -185,8 +182,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
         // This behavior is similar to `NSCache` (which removes all
         // items). This feature is not documented and may be subject
         // to change in future Nuke versions.
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
 
         _trim(toCost: Int(Double(_conf.costLimit) * 0.1))
         _trim(toCount: Int(Double(_conf.countLimit) * 0.1))
@@ -201,8 +198,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func trim(toCost limit: Int) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         _trim(toCost: limit)
     }
 
@@ -211,8 +208,8 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
     }
 
     func trim(toCount limit: Int) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
+        lock.lock()
+        defer { lock.unlock() }
         _trim(toCount: limit)
     }
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+import os
 
 #if canImport(UIKit)
 import UIKit
@@ -144,10 +145,9 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         case finished(Result<ImageResponse, ImagePipeline.Error>)
     }
 
-    private var nonisolatedState: NonisolatedState
+    private let nonisolatedState: OSAllocatedUnfairLock<NonisolatedState>
     private let isDataTask: Bool
     private let onEvent: ((Event, ImageTask) -> Void)?
-    private let lock: os_unfair_lock_t
     private weak var pipeline: ImagePipeline?
 
     // Set once during creation, then read-only from `response` getter.
@@ -158,21 +158,13 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
 
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
-    }
-
     init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, pipeline: ImagePipeline, onEvent: ((Event, ImageTask) -> Void)?) {
         self.taskId = taskId
         self.request = request
-        self.nonisolatedState = NonisolatedState(priority: request.priority)
+        self.nonisolatedState = OSAllocatedUnfairLock(uncheckedState: NonisolatedState(priority: request.priority))
         self.isDataTask = isDataTask
         self.pipeline = pipeline
         self.onEvent = onEvent
-
-        lock = .allocate(capacity: 1)
-        lock.initialize(to: os_unfair_lock())
     }
 
     /// Marks task as being cancelled.
@@ -317,9 +309,7 @@ extension ImageTask {
     }
 
     private func withNonisolatedStateLock<T>(_ closure: (inout NonisolatedState) -> T) -> T {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return closure(&nonisolatedState)
+        nonisolatedState.withLockUnchecked(closure)
     }
 
     /// Contains the state synchronized using the internal lock.

--- a/Sources/Nuke/Internal/Mutex.swift
+++ b/Sources/Nuke/Internal/Mutex.swift
@@ -3,32 +3,21 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+import os
 
 final class Mutex<T>: @unchecked Sendable {
-    private var _value: T
-    private let lock: os_unfair_lock_t
+    private let lock: OSAllocatedUnfairLock<T>
 
     init(value: T) {
-        self._value = value
-        self.lock = .allocate(capacity: 1)
-        self.lock.initialize(to: os_unfair_lock())
-    }
-
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
+        self.lock = OSAllocatedUnfairLock(uncheckedState: value)
     }
 
     var value: T {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return _value
+        lock.withLockUnchecked { $0 }
     }
 
     func withLock<U>(_ closure: (inout T) -> U) -> U {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return closure(&_value)
+        lock.withLockUnchecked(closure)
     }
 }
 

--- a/Tests/Helpers/Helpers.swift
+++ b/Tests/Helpers/Helpers.swift
@@ -5,6 +5,7 @@
 import Nuke
 import Foundation
 import CoreGraphics
+import os
 
 #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import UIKit
@@ -221,23 +222,15 @@ extension Result {
 }
 
 @propertyWrapper final class Mutex<T> {
-    private var value: T
-    private let lock: os_unfair_lock_t
+    private let lock: OSAllocatedUnfairLock<T>
 
     init(wrappedValue value: T) {
-        self.value = value
-        self.lock = .allocate(capacity: 1)
-        self.lock.initialize(to: os_unfair_lock())
-    }
-
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
+        self.lock = OSAllocatedUnfairLock(uncheckedState: value)
     }
 
     var wrappedValue: T {
-        get { getValue() }
-        set { setValue(newValue) }
+        get { withLock { $0 } }
+        set { withLock { $0 = newValue } }
     }
 
     var projectedValue: Mutex<T> {
@@ -245,20 +238,6 @@ extension Result {
     }
 
     func withLock<U>(_ closure: (inout T) -> U) -> U {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return closure(&value)
-    }
-
-    private func getValue() -> T {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return value
-    }
-
-    private func setValue(_ newValue: T) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        value = newValue
+        lock.withLockUnchecked(closure)
     }
 }


### PR DESCRIPTION
Follow-up to #904. Now that iOS 16.0 / tvOS 16.0 / watchOS 9.0 / macOS 13.0 is the floor, `OSAllocatedUnfairLock` is available unconditionally, so the hand-rolled `os_unfair_lock_t` allocations are gone.

- `Mutex` is now backed by `OSAllocatedUnfairLock<T>`, which holds the value as the lock state. The manual `allocate`/`initialize`/`deinit` triple and the separate `_value` storage are gone.
- `ImageTask` merges `nonisolatedState` and its lock into a single `OSAllocatedUnfairLock<NonisolatedState>`, so the state can no longer be read or written without holding the lock. `withNonisolatedStateLock` forwards to `withLockUnchecked` and the `deinit` is no longer needed.
- `Cache` keeps the stateless form (`lock()`/`unlock()`) because its state lives across a dozen separate stored properties, but it no longer allocates or deallocates the lock by hand.
- The `Mutex` property wrapper in the test helpers gets the same treatment.

The unchecked variants (`init(uncheckedState:)`, `withLockUnchecked`) are used where the generic parameter isn't constrained to `Sendable`, which preserves the existing semantics of these `@unchecked Sendable` types.

## To test

1. `swift build`
2. Run the `NukeTests`, `NukeThreadSafetyTests`, and `NukeUITests` schemes.