### PR TITLE
Remove userInfo parameter from ImageRequest initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 **API Changes**
 
 - Remove previously deprecated APIs: `ImagePipelineDelegate` typealias, `ImageRequest.imageId`, `ImageRequest.UserInfoKey.imageIdKey`, `ImageRequest.UserInfoKey.scaleKey`, `ImageRequest.UserInfoKey.thumbnailKey`, `ImagePipeline.Configuration.maximumDecodedImageSize`, and `ImageDecodingContext.maximumDecodedImageSize` – https://github.com/kean/Nuke/pull/907
+- Remove the soft-deprecated `userInfo` parameter from the `ImageRequest` initializers. It's still available as a property – https://github.com/kean/Nuke/pull/909
 
 # Nuke 13
 

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -29,3 +29,16 @@ The APIs deprecated in Nuke 13 have been removed.
 | `ImageDecodingContext.maximumDecodedImageSize` | `ImageRequest.ThumbnailOptions` |
 
 The automatic downscaling implementation behind `maximumDecodedImageSize` was removed in Nuke 13, so setting it already had no effect. Use `ImageRequest.ThumbnailOptions` to control the decoded image size on a per-request basis instead.
+
+## Removed `userInfo` from `ImageRequest` Initializers
+
+The `userInfo` parameter, soft-deprecated in Nuke 13, is gone from the `ImageRequest` initializers. The options it used to carry now have dedicated type-safe properties, and `userInfo` itself remains available as a property for custom values.
+
+```swift
+// Before
+let request = ImageRequest(url: url, userInfo: ["key": "value"])
+
+// After
+var request = ImageRequest(url: url)
+request.userInfo = ["key": "value"]
+```

--- a/Documentation/Nuke.docc/Extensions/ImageRequest-Extension.md
+++ b/Documentation/Nuke.docc/Extensions/ImageRequest-Extension.md
@@ -26,9 +26,9 @@ let cachedRequest = ImageRequest(url: url, options: [.returnCacheDataDontLoad])
 
 ### Initializers
 
-- ``init(url:processors:priority:options:userInfo:)``
-- ``init(urlRequest:processors:priority:options:userInfo:)``
-- ``init(id:data:processors:priority:options:userInfo:)``
+- ``init(url:processors:priority:options:)``
+- ``init(urlRequest:processors:priority:options:)``
+- ``init(id:data:processors:priority:options:)``
 - ``init(stringLiteral:)``
 
 ### Options

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -144,7 +144,6 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     ///   - processors: Processors to be applied to the image. See <doc:image-processing> to learn more.
     ///   - priority: The priority of the request.
     ///   - options: Image loading options.
-    ///   - userInfo: Soft-deprecated in Nuke 13.0, but still available as a dedicated property.
     ///
     /// ```swift
     /// let request = ImageRequest(
@@ -157,16 +156,14 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
         url: URL?,
         processors: [any ImageProcessing] = [],
         priority: Priority = .normal,
-        options: Options = [],
-        userInfo: [UserInfoKey: any Sendable]? = nil
+        options: Options = []
     ) {
         self.ref = Container(
             resource: Resource.url(url),
             originalImageID: url?.absoluteString,
             processors: processors,
             priority: priority,
-            options: options,
-            userInfo: userInfo
+            options: options
         )
     }
 
@@ -177,7 +174,6 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     ///   - processors: Processors to be applied to the image. See <doc:image-processing> to learn more.
     ///   - priority: The priority of the request.
     ///   - options: Image loading options.
-    ///   - userInfo: Soft-deprecated in Nuke 13.0, but still available as a dedicated property.
     ///
     /// ```swift
     /// let request = ImageRequest(
@@ -190,16 +186,14 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
         urlRequest: URLRequest,
         processors: [any ImageProcessing] = [],
         priority: Priority = .normal,
-        options: Options = [],
-        userInfo: [UserInfoKey: any Sendable]? = nil
+        options: Options = []
     ) {
         self.ref = Container(
             resource: Resource.urlRequest(urlRequest),
             originalImageID: urlRequest.url?.absoluteString,
             processors: processors,
             priority: priority,
-            options: options,
-            userInfo: userInfo
+            options: options
         )
     }
 
@@ -228,22 +222,19 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     ///   - processors: Processors to be applied to the image. See <doc:image-processing> to learn more.
     ///   - priority: The priority of the request.
     ///   - options: Image loading options.
-    ///   - userInfo: Soft-deprecated in Nuke 13.0, but still available as a dedicated property.
     public init(
         id: String,
         data: @Sendable @escaping () async throws -> Data,
         processors: [any ImageProcessing] = [],
         priority: Priority = .normal,
-        options: Options = [],
-        userInfo: [UserInfoKey: any Sendable]? = nil
+        options: Options = []
     ) {
         self.ref = Container(
             resource: .data(fetch: data),
             originalImageID: id,
             processors: processors,
             priority: priority,
-            options: options,
-            userInfo: userInfo
+            options: options
         )
     }
 
@@ -253,7 +244,7 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     /// Use this initializer to process images already in memory or integrate
     /// with systems that provide pre-decoded images, such as the Photos framework.
     ///
-    /// - note: Unlike ``init(id:data:processors:priority:options:userInfo:)``, the image is never stored in the disk
+    /// - note: Unlike ``init(id:data:processors:priority:options:)``, the image is never stored in the disk
     /// cache because no raw data is available.
     ///
     /// - parameters:
@@ -262,22 +253,19 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     ///   - processors: Processors to be applied to the image. See <doc:image-processing> to learn more.
     ///   - priority: The priority of the request.
     ///   - options: Image loading options.
-    ///   - userInfo: Soft-deprecated in Nuke 13.0, but still available as a dedicated property.
     public init(
         id: String,
         image: @Sendable @escaping () async throws -> ImageContainer,
         processors: [any ImageProcessing] = [],
         priority: Priority = .normal,
-        options: Options = [],
-        userInfo: [UserInfoKey: any Sendable]? = nil
+        options: Options = []
     ) {
         self.ref = Container(
             resource: .image(fetch: image),
             originalImageID: id,
             processors: processors,
             priority: priority,
-            options: options,
-            userInfo: userInfo
+            options: options
         )
     }
 
@@ -518,13 +506,12 @@ extension ImageRequest {
         var userInfo: [UserInfoKey: any Sendable]?
         var thumbnail: ThumbnailOptions?
 
-        init(resource: Resource, originalImageID: String?, processors: [any ImageProcessing], priority: Priority, options: Options, userInfo: [UserInfoKey: any Sendable]?) {
+        init(resource: Resource, originalImageID: String?, processors: [any ImageProcessing], priority: Priority, options: Options) {
             self.resource = resource
             self.processors = processors
             self.priority = priority
             self.options = options
             self.originalImageID = originalImageID
-            self.userInfo = userInfo
         }
 
         /// Creates a copy.

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
@@ -38,11 +38,11 @@ struct ImagePipelineDelegateTests {
         )
 
         // GIVEN image is loaded from medium size URL and saved in cache using imageId "image-01-small"
-        let requestA = ImageRequest(
+        var requestA = ImageRequest(
             url: imageURLMedium,
-            processors: [.resize(width: 44)],
-            userInfo: ["imageId": "image-01-small"]
+            processors: [.resize(width: 44)]
         )
+        requestA.userInfo = ["imageId": "image-01-small"]
         _ = try await pipeline.image(for: requestA)
         await pipeline.configuration.imageEncodingQueue.waitUntilAllOperationsAreFinished()
 
@@ -51,10 +51,8 @@ struct ImagePipelineDelegateTests {
         #expect(image.sizeInPixels.width == 44 * Screen.scale)
 
         // GIVEN a request for a small image
-        let requestB = ImageRequest(
-            url: imageURLSmall,
-            userInfo: ["imageId": "image-01-small"]
-        )
+        var requestB = ImageRequest(url: imageURLSmall)
+        requestB.userInfo = ["imageId": "image-01-small"]
 
         // WHEN/THEN the image is returned from the disk cache
         let responseB = try await pipeline.imageTask(with: requestB).response

--- a/Tests/NukeTests/ImageRequestTests.swift
+++ b/Tests/NukeTests/ImageRequestTests.swift
@@ -56,7 +56,8 @@ struct ImageRequestTests {
 
     @Test func userInfoKey() {
         // WHEN
-        let request = ImageRequest(url: Test.url, userInfo: [.init("a"): 1])
+        var request = ImageRequest(url: Test.url)
+        request.userInfo = [.init("a"): 1]
 
         // THEN
         #expect(request.userInfo["a"] != nil)


### PR DESCRIPTION
The `userInfo` parameter was soft-deprecated in Nuke 13 when `imageID`, `scale`, and `thumbnail` got dedicated type-safe properties. What's left in the dictionary is rare enough that it doesn't need a slot in every initializer, so it's now a property-only API.

- Removed `userInfo` from all four `ImageRequest` initializers (`url:`, `urlRequest:`, `id:data:`, `id:image:`) and from the private `Container` init.
- `ImageRequest.userInfo` remains a settable property, so custom values are still supported.
- Updated the DocC topics, the Nuke 14 migration guide, and the CHANGELOG.

## To test

1. `swift build`
2. Run the `NukeTests`, `NukeThreadSafetyTests`, and `NukeUITests` schemes.