### PR TITLE
Use CGFloat for the public scale and size APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Remove previously deprecated APIs: `ImagePipelineDelegate` typealias, `ImageRequest.imageId`, `ImageRequest.UserInfoKey.imageIdKey`, `ImageRequest.UserInfoKey.scaleKey`, `ImageRequest.UserInfoKey.thumbnailKey`, `ImagePipeline.Configuration.maximumDecodedImageSize`, and `ImageDecodingContext.maximumDecodedImageSize` – https://github.com/kean/Nuke/pull/907
 - Remove the soft-deprecated `userInfo` parameter from the `ImageRequest` initializers. It's still available as a property – https://github.com/kean/Nuke/pull/909
+- `ImageRequest.scale` and `ImageRequest.ThumbnailOptions.init(maxPixelSize:)` now use `CGFloat` – https://github.com/kean/Nuke/pull/910
 
 # Nuke 13
 

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -42,3 +42,22 @@ let request = ImageRequest(url: url, userInfo: ["key": "value"])
 var request = ImageRequest(url: url)
 request.userInfo = ["key": "value"]
 ```
+
+## `Float` to `CGFloat`
+
+The public scale and size APIs now use `CGFloat`, matching the types you get from UIKit and SwiftUI.
+
+| API | Nuke 13 | Nuke 14 |
+|---|---|---|
+| `ImageRequest.scale` | `Float` | `CGFloat` |
+| `ImageRequest.ThumbnailOptions.init(maxPixelSize:)` | `Float` | `CGFloat` |
+
+Literals continue to work as is. Remove the conversions if you had any:
+
+```swift
+// Nuke 13
+request.scale = Float(traitCollection.displayScale)
+
+// Nuke 14
+request.scale = traitCollection.displayScale
+```

--- a/Sources/Nuke/Decoding/ImageDecoders+Default.swift
+++ b/Sources/Nuke/Decoding/ImageDecoders+Default.swift
@@ -55,7 +55,7 @@ extension ImageDecoders {
         /// Initializes the decoder from the given decoding context, reading the
         /// request's scale, thumbnail options, and preview policy.
         public init?(context: ImageDecodingContext) {
-            self.scale = CGFloat(context.request.scale)
+            self.scale = context.request.scale
             self.thumbnail = context.request.thumbnail
             self.previewPolicy = context.previewPolicy
         }

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -109,9 +109,9 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     }
 
     /// The display scale of the image. By default, `1`.
-    public var scale: Float {
-        get { ref.scale }
-        set { mutate { $0.scale = newValue } }
+    public var scale: CGFloat {
+        get { CGFloat(ref.scale) }
+        set { mutate { $0.scale = Float(newValue) } }
     }
 
     /// Thumbnail options. When set, the pipeline generates a thumbnail instead
@@ -397,7 +397,7 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
         ///
         /// This option performs slightly faster than ``ImageRequest/ThumbnailOptions/init(size:unit:contentMode:)``
         /// because it doesn't need to read the image size.
-        public init(maxPixelSize: Float) {
+        public init(maxPixelSize: CGFloat) {
             self.size = ImageTargetSize(maxPixelSize: maxPixelSize)
         }
 

--- a/Sources/Nuke/Internal/ImageRequestKeys.swift
+++ b/Sources/Nuke/Internal/ImageRequestKeys.swift
@@ -9,7 +9,7 @@ final class MemoryCacheKey: Hashable, Sendable {
     // Using a reference type turned out to be significantly faster
     private let customKey: String?
     private let imageId: String?
-    private let scale: Float
+    private let scale: CGFloat
     private let thumbnail: ImageRequest.ThumbnailOptions?
     private let processors: [any ImageProcessing]
     private let _hashValue: Int
@@ -78,7 +78,7 @@ final class TaskLoadImageKey: Hashable, Sendable {
 /// Uniquely identifies a task of retrieving the original image.
 struct TaskFetchOriginalImageKey: Hashable {
     private let dataLoadKey: TaskFetchOriginalDataKey
-    private let scale: Float
+    private let scale: CGFloat
     private let thumbnail: ImageRequest.ThumbnailOptions?
 
     init(_ request: ImageRequest) {

--- a/Sources/Nuke/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Resize.swift
@@ -80,8 +80,8 @@ struct ImageTargetSize: Hashable {
 
     var cgSize: CGSize { CGSize(width: Double(width), height: Double(height)) }
 
-    init(maxPixelSize: Float) {
-        (width, height) = (maxPixelSize, 0)
+    init(maxPixelSize: CGFloat) {
+        (width, height) = (Float(maxPixelSize), 0)
     }
 
     /// Creates the size in pixels by scaling to the input size to the screen scale


### PR DESCRIPTION
Every realistic source of a display scale is already a `CGFloat` (`traitCollection.displayScale`, `UIScreen.main.scale`, `@Environment(\.displayScale)`), so callers had to write `Float(displayScale)` only for the default decoder to convert it straight back. `ImageRequest.scale` is now `CGFloat`, and so is `ImageRequest.ThumbnailOptions.init(maxPixelSize:)` for the same reason.

The storage stays `Float`: `ImageRequest.Container` keeps its field packing, and `ImageTargetSize` keeps its smaller memory footprint.

Migration (literals are unaffected):

```swift
// Before
request.scale = Float(traitCollection.displayScale)

// After
request.scale = traitCollection.displayScale
```
