### PR TITLE
Replace the ImageTask state mirror with an isFinished flag

### DIFF
--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -153,7 +153,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     // Set once during creation, then read-only from `response` getter.
     nonisolated(unsafe) var _task: Task<ImageResponse, any Error>!
     @ImagePipelineActor var _continuation: UnsafeContinuation<ImageResponse, any Error>?
-    @ImagePipelineActor var _state: State = .running
+    @ImagePipelineActor var _isFinished = false
     @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
@@ -207,7 +207,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// Gets called when the task is cancelled either by the user or by an
     /// external event such as session invalidation.
     @ImagePipelineActor func _cancel() {
-        guard _setState(.cancelled) else { return }
+        guard _setFinished(.cancelled) else { return }
         _dispatch(.finished(.failure(.cancelled)))
     }
 
@@ -229,14 +229,15 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     }
 
     @ImagePipelineActor private func _finish(_ result: Result<ImageResponse, ImagePipeline.Error>) {
-        guard _setState(.completed) else { return }
+        guard _setFinished(.completed) else { return }
         _dispatch(.finished(result))
     }
 
-    // The state mirror needs to be eliminated.
-    @ImagePipelineActor func _setState(_ state: State) -> Bool {
-        guard _state == .running else { return false }
-        _state = state
+    /// Latches the task as finished and records the outcome. Returns `false`
+    /// if the terminal event was already sent.
+    @ImagePipelineActor private func _setFinished(_ state: State) -> Bool {
+        guard !_isFinished else { return false }
+        _isFinished = true
         withNonisolatedStateLock {
             guard $0.state == .running else { return }
             $0.state = state
@@ -300,7 +301,7 @@ extension ImageTask {
     private func makeStream() -> AsyncStream<Event> {
         AsyncStream { continuation in
             Task { @ImagePipelineActor in
-                guard self._state == .running else {
+                guard !self._isFinished else {
                     return continuation.finish()
                 }
                 self._streamContinuations.append(continuation)

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -186,7 +186,7 @@ public final class ImagePipeline: Sendable {
 
     // By this time, the task has `continuation` set and is fully wired.
     private func startImageTask(_ task: ImageTask, isDataTask: Bool) {
-        guard task._state != .cancelled else {
+        guard !task._isFinished else {
             // The task gets started asynchronously in a `Task` and cancellation
             // can happen before the pipeline reached `startImageTask`. In that
             // case, the `cancel` method does not send the task event.


### PR DESCRIPTION
`ImageTask` kept two copies of its state: the nonisolated `state`, guarded by the task's lock and read by the public getter, and `_state`, an `@ImagePipelineActor` mirror of the same enum. `_setState` wrote both and carried a `// The state mirror needs to be eliminated.` note.

The mirror never needed to be an enum. Every read of `_state` asked the same yes/no question — has the terminal event already been sent? — so it is now `_isFinished: Bool`, and `_setState` becomes `_setFinished`, which latches the flag and records the outcome in the nonisolated state as before.

The actor-isolated copy can't simply be dropped in favor of the nonisolated one: `cancel()` flips `state` to `.cancelled` synchronously, before the pipeline hops to the actor, so gating the terminal dispatch on the nonisolated state would make `_cancel()` a no-op and hang `await task.response`.

No public API changes. `state`, `State`, and the outcome recorded for each path are all unchanged, so there's no CHANGELOG entry.

## To test

1. `swift build`
2. Run the `NukeTests`, `NukeThreadSafetyTests`, and `NukeExtensionsTests` schemes.
