### PR TITLE
Replace ImageTask.State with an atomic Status snapshot

### DIFF
--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -28,14 +28,14 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// The priority of the task. The priority can be updated dynamically even
     /// for a task that is already running.
     public var priority: ImageRequest.Priority {
-        get { withNonisolatedStateLock { $0.priority } }
+        get { withStatusLock { $0.priority } }
         set { setPriority(newValue) }
     }
 
     /// Returns the current download progress. Returns zeros until the download
     /// starts and the total resource size is known.
     public var currentProgress: Progress {
-        withNonisolatedStateLock { $0.progress }
+        withStatusLock { $0.progress }
     }
 
     /// The download progress.
@@ -57,23 +57,51 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         }
     }
 
-    /// The current state of the task.
-    public var state: State {
-        withNonisolatedStateLock { $0.state }
+    /// Returns `true` if the task was cancelled from the outside: either by
+    /// calling ``cancel()``, or by cancelling the Swift concurrency task that
+    /// awaits ``response``.
+    ///
+    /// The flag is set synchronously, on the thread that requests the
+    /// cancellation, and never goes back to `false`.
+    ///
+    /// - note: Cancellation is a request, not an outcome. It is recorded before
+    /// the pipeline sends ``Event/finished(_:)``, and it can also be requested
+    /// after the task has already finished. Use ``Status/result`` to learn how
+    /// the task actually ended.
+    public var isCancelled: Bool {
+        withStatusLock { $0.isCancelled }
     }
 
-    var isCancelled: Bool {
-        withNonisolatedStateLock { $0.isCancelled }
+    /// Returns a snapshot of everything about the task that can change while
+    /// it runs.
+    ///
+    /// Reading the individual properties one by one acquires the task's lock
+    /// once per property, so the values can come from different points in time.
+    /// Read the status instead when you need them to agree with each other.
+    public var status: Status {
+        withStatusLock { $0 }
     }
 
-    /// The state of the image task.
-    @frozen public enum State {
-        /// The task is currently running.
-        case running
-        /// The task has received a cancel message.
-        case cancelled
-        /// The task has completed (without being canceled).
-        case completed
+    /// A snapshot of the task state, captured at a single point in time.
+    public struct Status: Sendable {
+        /// The result the task finished with, or `nil` if it is still running.
+        ///
+        /// The result is recorded immediately before the ``Event/finished(_:)``
+        /// event is sent, so it is guaranteed to be available to the observers
+        /// of that event and to anyone awaiting ``ImageTask/response``.
+        public internal(set) var result: Result<ImageResponse, ImagePipeline.Error>?
+
+        /// Returns `true` if the task was cancelled from the outside.
+        ///
+        /// - seealso: ``ImageTask/isCancelled``
+        public internal(set) var isCancelled = false
+
+        /// The priority of the task.
+        public internal(set) var priority: ImageRequest.Priority
+
+        /// The download progress. Contains zeros until the download starts and
+        /// the total resource size is known.
+        public internal(set) var progress = Progress(completed: 0, total: 0)
     }
 
     // MARK: - Async/Await
@@ -145,7 +173,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         case finished(Result<ImageResponse, ImagePipeline.Error>)
     }
 
-    private let nonisolatedState: OSAllocatedUnfairLock<NonisolatedState>
+    private let statusLock: OSAllocatedUnfairLock<Status>
     private let isDataTask: Bool
     private let onEvent: ((Event, ImageTask) -> Void)?
     private weak var pipeline: ImagePipeline?
@@ -161,7 +189,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, pipeline: ImagePipeline, onEvent: ((Event, ImageTask) -> Void)?) {
         self.taskId = taskId
         self.request = request
-        self.nonisolatedState = OSAllocatedUnfairLock(uncheckedState: NonisolatedState(priority: request.priority))
+        self.statusLock = OSAllocatedUnfairLock(uncheckedState: Status(priority: request.priority))
         self.isDataTask = isDataTask
         self.pipeline = pipeline
         self.onEvent = onEvent
@@ -172,11 +200,10 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// The pipeline will immediately cancel any work associated with a task
     /// unless there is an equivalent outstanding task running.
     public func cancel() {
-        let didChange: Bool = withNonisolatedStateLock {
+        let didChange: Bool = withStatusLock {
+            let didChange = !$0.isCancelled && $0.result == nil
             $0.isCancelled = true
-            guard $0.state == .running else { return false }
-            $0.state = .cancelled
-            return true
+            return didChange
         }
         guard didChange else { return } // Make sure it gets called once (expensive)
         Task { @ImagePipelineActor in
@@ -185,10 +212,10 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     }
 
     private func setPriority(_ newValue: ImageRequest.Priority) {
-        let didChange: Bool = withNonisolatedStateLock {
+        let didChange: Bool = withStatusLock {
             guard $0.priority != newValue else { return false }
             $0.priority = newValue
-            return $0.state == .running
+            return !$0.isCancelled && $0.result == nil
         }
         guard didChange else { return }
         Task { @ImagePipelineActor in
@@ -207,8 +234,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// Gets called when the task is cancelled either by the user or by an
     /// external event such as session invalidation.
     @ImagePipelineActor func _cancel() {
-        guard _setFinished(.cancelled) else { return }
-        _dispatch(.finished(.failure(.cancelled)))
+        _finish(.failure(.cancelled))
     }
 
     /// Gets called when the associated task sends a new event.
@@ -221,28 +247,18 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
                 _dispatch(.preview(response))
             }
         case let .progress(value):
-            withNonisolatedStateLock { $0.progress = value }
+            withStatusLock { $0.progress = value }
             _dispatch(.progress(value))
         case let .error(error):
             _finish(.failure(error))
         }
     }
 
+    /// Sends the terminal event, but only the first time it is called.
     @ImagePipelineActor private func _finish(_ result: Result<ImageResponse, ImagePipeline.Error>) {
-        guard _setFinished(.completed) else { return }
-        _dispatch(.finished(result))
-    }
-
-    /// Latches the task as finished and records the outcome. Returns `false`
-    /// if the terminal event was already sent.
-    @ImagePipelineActor private func _setFinished(_ state: State) -> Bool {
-        guard !_isFinished else { return false }
+        guard !_isFinished else { return }
         _isFinished = true
-        withNonisolatedStateLock {
-            guard $0.state == .running else { return }
-            $0.state = state
-        }
-        return true
+        _dispatch(.finished(result))
     }
 
     /// Dispatches the given event to the observers.
@@ -254,6 +270,11 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
             return // Task isn't fully wired yet
         }
 
+        // Record the result first so that it is already visible to everyone
+        // observing the terminal event.
+        if case .finished(let result) = event {
+            withStatusLock { $0.result = result }
+        }
         for continuation in _streamContinuations {
             continuation.yield(event)
         }
@@ -285,7 +306,13 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     // MARK: CustomStringConvertible
 
     public var description: String {
-        "ImageTask(id: \(taskId), priority: \(priority), progress: \(currentProgress.completed) / \(currentProgress.total), state: \(state))"
+        let status = self.status
+        let state: String = switch status.result {
+        case .none: status.isCancelled ? "cancelled" : "running"
+        case .success: "success"
+        case .failure(let error): "failure(\(error))"
+        }
+        return "ImageTask(id: \(taskId), priority: \(status.priority), progress: \(status.progress.completed) / \(status.progress.total), state: \(state))"
     }
 }
 
@@ -309,17 +336,9 @@ extension ImageTask {
         }
     }
 
-    private func withNonisolatedStateLock<T>(_ closure: (inout NonisolatedState) -> T) -> T {
-        nonisolatedState.withLockUnchecked(closure)
-    }
-
-    /// Contains the state synchronized using the internal lock.
-    ///
-    /// - warning: Must be accessed using `withNonisolatedState`.
-    private struct NonisolatedState {
-        var state: ImageTask.State = .running
-        var isCancelled = false
-        var priority: ImageRequest.Priority
-        var progress = Progress(completed: 0, total: 0)
+    /// Provides exclusive access to the ``Status`` shared between the callers
+    /// and the pipeline actor.
+    private func withStatusLock<T>(_ closure: (inout Status) -> T) -> T {
+        statusLock.withLockUnchecked(closure)
     }
 }

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -28,7 +28,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// The priority of the task. The priority can be updated dynamically even
     /// for a task that is already running.
     public var priority: ImageRequest.Priority {
-        get { statusLock.withLockUnchecked { $0.priority } }
+        get { _status.withLockUnchecked { $0.priority } }
         set { setPriority(newValue) }
     }
 
@@ -63,7 +63,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// after the task has already finished. Use ``Status/result`` to learn how
     /// the task actually ended.
     public var isCancelled: Bool {
-        statusLock.withLockUnchecked { $0.isCancelled }
+        _status.withLockUnchecked { $0.isCancelled }
     }
 
     /// Returns a snapshot of everything about the task that can change while
@@ -73,7 +73,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// once per property, so the values can come from different points in time.
     /// Read the status instead when you need them to agree with each other.
     public var status: Status {
-        statusLock.withLockUnchecked { $0 }
+        _status.withLockUnchecked { $0 }
     }
 
     /// A snapshot of the task state, captured at a single point in time.
@@ -167,7 +167,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         case finished(Result<ImageResponse, ImagePipeline.Error>)
     }
 
-    private let statusLock: OSAllocatedUnfairLock<Status>
+    private let _status: OSAllocatedUnfairLock<Status>
     private let isDataTask: Bool
     private let onEvent: ((Event, ImageTask) -> Void)?
     private weak var pipeline: ImagePipeline?
@@ -183,7 +183,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, pipeline: ImagePipeline, onEvent: ((Event, ImageTask) -> Void)?) {
         self.taskId = taskId
         self.request = request
-        self.statusLock = OSAllocatedUnfairLock(uncheckedState: Status(priority: request.priority))
+        self._status = OSAllocatedUnfairLock(uncheckedState: Status(priority: request.priority))
         self.isDataTask = isDataTask
         self.pipeline = pipeline
         self.onEvent = onEvent
@@ -194,7 +194,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// The pipeline will immediately cancel any work associated with a task
     /// unless there is an equivalent outstanding task running.
     public func cancel() {
-        let didChange: Bool = statusLock.withLockUnchecked {
+        let didChange: Bool = _status.withLockUnchecked {
             let didChange = !$0.isCancelled && $0.result == nil
             $0.isCancelled = true
             return didChange
@@ -206,7 +206,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     }
 
     private func setPriority(_ newValue: ImageRequest.Priority) {
-        let didChange: Bool = statusLock.withLockUnchecked {
+        let didChange: Bool = _status.withLockUnchecked {
             guard $0.priority != newValue else { return false }
             $0.priority = newValue
             return !$0.isCancelled && $0.result == nil
@@ -241,7 +241,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
                 _dispatch(.preview(response))
             }
         case let .progress(value):
-            statusLock.withLockUnchecked { $0.progress = value }
+            _status.withLockUnchecked { $0.progress = value }
             _dispatch(.progress(value))
         case let .error(error):
             _finish(.failure(error))
@@ -267,7 +267,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         // Record the result first so that it is already visible to everyone
         // observing the terminal event.
         if case .finished(let result) = event {
-            statusLock.withLockUnchecked { $0.result = result }
+            _status.withLockUnchecked { $0.result = result }
         }
         for continuation in _streamContinuations {
             continuation.yield(event)
@@ -340,7 +340,7 @@ extension ImageTask {
     /// - warning: Deprecated in Nuke 14.0. Use ``status`` instead.
     @available(*, deprecated, renamed: "status.progress", message: "Deprecated in Nuke 14.0. Use `status` to read the progress along with the rest of the task state captured at the same point in time.")
     public var currentProgress: Progress {
-        statusLock.withLockUnchecked { $0.progress }
+        _status.withLockUnchecked { $0.progress }
     }
 
     /// The current state of the task.

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -28,14 +28,15 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// The priority of the task. The priority can be updated dynamically even
     /// for a task that is already running.
     public var priority: ImageRequest.Priority {
-        get { withStatusLock { $0.priority } }
+        get { statusLock.withLockUnchecked { $0.priority } }
         set { setPriority(newValue) }
     }
 
     /// Returns the current download progress. Returns zeros until the download
     /// starts and the total resource size is known.
+    @available(*, deprecated, renamed: "status.progress", message: "Use `status` to read the progress along with the rest of the task state captured at the same point in time.")
     public var currentProgress: Progress {
-        withStatusLock { $0.progress }
+        statusLock.withLockUnchecked { $0.progress }
     }
 
     /// The download progress.
@@ -69,7 +70,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// after the task has already finished. Use ``Status/result`` to learn how
     /// the task actually ended.
     public var isCancelled: Bool {
-        withStatusLock { $0.isCancelled }
+        statusLock.withLockUnchecked { $0.isCancelled }
     }
 
     /// Returns a snapshot of everything about the task that can change while
@@ -79,7 +80,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// once per property, so the values can come from different points in time.
     /// Read the status instead when you need them to agree with each other.
     public var status: Status {
-        withStatusLock { $0 }
+        statusLock.withLockUnchecked { $0 }
     }
 
     /// A snapshot of the task state, captured at a single point in time.
@@ -200,7 +201,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// The pipeline will immediately cancel any work associated with a task
     /// unless there is an equivalent outstanding task running.
     public func cancel() {
-        let didChange: Bool = withStatusLock {
+        let didChange: Bool = statusLock.withLockUnchecked {
             let didChange = !$0.isCancelled && $0.result == nil
             $0.isCancelled = true
             return didChange
@@ -212,7 +213,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     }
 
     private func setPriority(_ newValue: ImageRequest.Priority) {
-        let didChange: Bool = withStatusLock {
+        let didChange: Bool = statusLock.withLockUnchecked {
             guard $0.priority != newValue else { return false }
             $0.priority = newValue
             return !$0.isCancelled && $0.result == nil
@@ -247,7 +248,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
                 _dispatch(.preview(response))
             }
         case let .progress(value):
-            withStatusLock { $0.progress = value }
+            statusLock.withLockUnchecked { $0.progress = value }
             _dispatch(.progress(value))
         case let .error(error):
             _finish(.failure(error))
@@ -273,7 +274,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         // Record the result first so that it is already visible to everyone
         // observing the terminal event.
         if case .finished(let result) = event {
-            withStatusLock { $0.result = result }
+            statusLock.withLockUnchecked { $0.result = result }
         }
         for continuation in _streamContinuations {
             continuation.yield(event)
@@ -334,11 +335,5 @@ extension ImageTask {
                 self._streamContinuations.append(continuation)
             }
         }
-    }
-
-    /// Provides exclusive access to the ``Status`` shared between the callers
-    /// and the pipeline actor.
-    private func withStatusLock<T>(_ closure: (inout Status) -> T) -> T {
-        statusLock.withLockUnchecked(closure)
     }
 }

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -32,13 +32,6 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         set { setPriority(newValue) }
     }
 
-    /// Returns the current download progress. Returns zeros until the download
-    /// starts and the total resource size is known.
-    @available(*, deprecated, renamed: "status.progress", message: "Use `status` to read the progress along with the rest of the task state captured at the same point in time.")
-    public var currentProgress: Progress {
-        statusLock.withLockUnchecked { $0.progress }
-    }
-
     /// The download progress.
     public struct Progress: Hashable, Sendable {
         /// The number of bytes that the task has received.
@@ -335,5 +328,48 @@ extension ImageTask {
                 self._streamContinuations.append(continuation)
             }
         }
+    }
+}
+
+// MARK: - ImageTask (Deprecated)
+
+extension ImageTask {
+    /// Returns the current download progress. Returns zeros until the download
+    /// starts and the total resource size is known.
+    ///
+    /// - warning: Deprecated in Nuke 14.0. Use ``status`` instead.
+    @available(*, deprecated, renamed: "status.progress", message: "Deprecated in Nuke 14.0. Use `status` to read the progress along with the rest of the task state captured at the same point in time.")
+    public var currentProgress: Progress {
+        statusLock.withLockUnchecked { $0.progress }
+    }
+
+    /// The current state of the task.
+    ///
+    /// - warning: Deprecated in Nuke 14.0. Use ``status`` instead. The state is
+    /// now derived from it: ``Status/isCancelled`` records the cancellation
+    /// request and ``Status/result`` records how the task actually ended.
+    @available(*, deprecated, message: "Deprecated in Nuke 14.0. Use `status` instead: `isCancelled` for the cancellation request and `result` for the outcome.")
+    public var state: State {
+        let status = self.status
+        guard let result = status.result else {
+            return status.isCancelled ? .cancelled : .running
+        }
+        if case .failure(.cancelled) = result {
+            return .cancelled
+        }
+        return .completed
+    }
+
+    /// The state of the image task.
+    ///
+    /// - warning: Deprecated in Nuke 14.0. Use ``ImageTask/Status`` instead.
+    @available(*, deprecated, message: "Deprecated in Nuke 14.0. Use `ImageTask.Status` instead.")
+    @frozen public enum State {
+        /// The task is currently running.
+        case running
+        /// The task has received a cancel message.
+        case cancelled
+        /// The task has completed (without being canceled).
+        case completed
     }
 }

--- a/Sources/Nuke/Pipeline/Deprecated.swift
+++ b/Sources/Nuke/Pipeline/Deprecated.swift
@@ -38,7 +38,7 @@ extension ImagePipeline {
                 switch event {
                 case .started: break
                 case .progress(let value): progress?(nil, value)
-                case .preview(let response): progress?(response, task.currentProgress)
+                case .preview(let response): progress?(response, task.status.progress)
                 case .finished(let result):
                     completion(result)
                 }

--- a/Tests/NukeTests/ImagePipelineTests/DeprecatedTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/DeprecatedTests.swift
@@ -36,16 +36,16 @@ struct DeprecationTests {
     @Test func loadImageWithRequest() async {
         dataLoader.isSuspended = true
         let taskRef = Ref<ImageTask?>(nil)
-        let stateInsideCallback = Ref<ImageTask.State>(.running)
+        let resultInsideCallback = Ref<Result<ImageResponse, ImagePipeline.Error>?>(nil)
         let result: Result<ImageResponse, ImagePipeline.Error> = await withCheckedContinuation { continuation in
             taskRef.value = pipeline.loadImage(with: Test.request) { result in
-                stateInsideCallback.value = taskRef.value!.state
+                resultInsideCallback.value = taskRef.value!.status.result
                 continuation.resume(returning: result)
             }
             dataLoader.isSuspended = false
         }
         #expect(result.isSuccess)
-        #expect(stateInsideCallback.value == .completed)
+        #expect(resultInsideCallback.value?.isSuccess == true)
     }
 
     @Test func loadImageCompletionOnMainThread() async {
@@ -93,7 +93,7 @@ struct DeprecationTests {
                 continuation.resume(returning: task)
             }
         }
-        #expect(task.state == .cancelled)
+        #expect(task.isCancelled)
     }
 
     @Test func loadImageCancellationCompletionNotCalled() async {
@@ -110,7 +110,7 @@ struct DeprecationTests {
         // Flush any DispatchQueue.main.async callbacks
         await MainActor.run {}
         #expect(!completionCalled.value)
-        #expect(task.state == .cancelled)
+        #expect(task.isCancelled)
     }
 
     // MARK: - loadData

--- a/Tests/NukeTests/ImagePipelineTests/DeprecatedTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/DeprecatedTests.swift
@@ -160,3 +160,87 @@ struct DeprecationTests {
         #expect(progressValues.value[1] == (20, 20))
     }
 }
+
+/// `ImageTask.state` is no longer stored – it is derived from `status`. These
+/// tests pin the mapping to what the stored property used to report.
+@Suite(.timeLimit(.minutes(5)))
+struct DeprecatedImageTaskStateTests {
+    private let pipeline: ImagePipeline
+    private let dataLoader: MockDataLoader
+
+    init() {
+        let dataLoader = MockDataLoader()
+        self.dataLoader = dataLoader
+        self.pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+    }
+
+    // The `state` reads are hoisted out of `#expect` on purpose: the macro
+    // re-expands its argument, which would report every deprecation twice.
+
+    @Test func stateIsRunningWhileInFlight() {
+        dataLoader.isSuspended = true
+        let task = pipeline.imageTask(with: Test.request)
+
+        let state = task.state
+        #expect(state == .running)
+        task.cancel()
+    }
+
+    @Test func stateIsCancelledAsSoonAsCancelIsCalled() {
+        dataLoader.isSuspended = true
+        let task = pipeline.imageTask(with: Test.request)
+
+        task.cancel()
+
+        // Reads as `.cancelled` whether or not the pipeline has processed the
+        // cancellation yet, matching the old stored state, which flipped
+        // synchronously inside `cancel()`.
+        let state = task.state
+        #expect(state == .cancelled)
+    }
+
+    @Test func stateIsCancelledAfterThePipelineProcessesTheCancellation() async throws {
+        dataLoader.isSuspended = true
+        let task = pipeline.imageTask(with: Test.request)
+        task.cancel()
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
+
+        let state = task.state
+        #expect(state == .cancelled)
+    }
+
+    @Test func stateIsCompletedAfterSuccess() async throws {
+        let task = pipeline.imageTask(with: Test.request)
+        _ = try await task.response
+
+        let state = task.state
+        #expect(state == .completed)
+    }
+
+    @Test func stateIsCompletedWhenTheTaskFails() async throws {
+        dataLoader.results[Test.url] = .failure(Foundation.URLError(.notConnectedToInternet) as NSError)
+        let task = pipeline.imageTask(with: Test.request)
+        _ = try? await task.response
+
+        let state = task.state
+        #expect(state == .completed)
+    }
+
+    @Test func stateStaysCompletedWhenAFinishedTaskIsCancelled() async throws {
+        let task = pipeline.imageTask(with: Test.request)
+        _ = try await task.response
+
+        // Cancelling after the fact records the request but must not rewrite
+        // the outcome, which is what the stored state used to guarantee.
+        task.cancel()
+
+        let state = task.state
+        #expect(task.isCancelled)
+        #expect(state == .completed)
+    }
+}

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -44,7 +44,7 @@ struct ImagePipelineAsyncAwaitTests {
 
         // THEN
         #expect(response.image.sizeInPixels == CGSize(width: 640, height: 480))
-        #expect(task.state == .completed)
+        #expect(task.status.result?.isSuccess == true)
     }
 
     @Test func taskBasedImage() async throws {
@@ -189,7 +189,7 @@ struct ImagePipelineAsyncAwaitTests {
             caughtError = error
         }
         #expect(caughtError == .cancelled)
-        #expect(task.state == .cancelled)
+        #expect(task.isCancelled)
         NotificationCenter.default.removeObserver(observer)
     }
 
@@ -527,7 +527,7 @@ struct ImagePipelineAsyncAwaitTests {
 // MARK: - ImageTask State
 
 @Suite(.timeLimit(.minutes(5)))
-struct ImageTaskStateTests {
+struct ImageTaskStatusTests {
     let dataLoader: MockDataLoader
     let pipeline: ImagePipeline
 
@@ -540,39 +540,42 @@ struct ImageTaskStateTests {
         }
     }
 
-    @Test func stateIsRunningWhileInFlight() async throws {
+    @Test func statusIsEmptyWhileInFlight() async throws {
         dataLoader.queue.isSuspended = true
         let task = pipeline.imageTask(with: Test.request)
         Task.detached { try? await task.response }
 
         await notification(MockDataLoader.DidStartTask, object: dataLoader) {}
 
-        #expect(task.state == .running)
+        #expect(task.status.result == nil)
+        #expect(!task.status.isCancelled)
         dataLoader.queue.isSuspended = false
         _ = try await task.response
     }
 
-    @Test func stateIsCompletedAfterSuccess() async throws {
+    @Test func statusRecordsTheSuccess() async throws {
         let task = pipeline.imageTask(with: Test.request)
         _ = try await task.response
-        #expect(task.state == .completed)
+        #expect(task.status.result?.isSuccess == true)
     }
 
-    @Test func stateIsCancelledAfterCancel() async throws {
+    @Test func statusRecordsTheCancellation() async throws {
         dataLoader.queue.isSuspended = true
         let task = pipeline.imageTask(with: Test.request)
         Task.detached { try? await task.response }
         await notification(MockDataLoader.DidStartTask, object: dataLoader) {}
         task.cancel()
         await notification(MockDataLoader.DidCancelTask, object: dataLoader) {}
-        #expect(task.state == .cancelled)
+        #expect(task.status.isCancelled)
+        #expect(task.status.result?.error == .cancelled)
     }
 
-    @Test func stateIsFailedWhenErrorOccurs() async throws {
+    @Test func statusRecordsTheFailure() async throws {
         dataLoader.results[Test.url] = .failure(Foundation.URLError(.notConnectedToInternet) as NSError)
         let task = pipeline.imageTask(with: Test.request)
         _ = try? await task.response
-        #expect(task.state == .completed)
+        #expect(task.status.result?.isSuccess == false)
+        #expect(!task.status.isCancelled)
     }
 }
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -566,6 +566,13 @@ struct ImageTaskStatusTests {
         await notification(MockDataLoader.DidStartTask, object: dataLoader) {}
         task.cancel()
         await notification(MockDataLoader.DidCancelTask, object: dataLoader) {}
+
+        // `DidCancelTask` is posted from the data loader queue while the
+        // pipeline is still on its way to recording the outcome, so wait for
+        // the task itself to finish before reading the result.
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
         #expect(task.status.isCancelled)
         #expect(task.status.result?.error == .cancelled)
     }

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -229,9 +229,11 @@ struct ImageTaskTests {
         task.cancel()
 
         // Then it is visible on the calling thread, without waiting for the
-        // pipeline actor to process the cancellation
+        // pipeline actor to process the cancellation.
+        //
+        // The result is deliberately not asserted here: it is written on the
+        // pipeline actor, so whether it is set yet is a race.
         #expect(task.isCancelled)
-        #expect(task.status.result == nil)
     }
 
     // MARK: - Priority

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -37,7 +37,7 @@ struct ImageTaskTests {
         #expect(ImageTask.Progress(completed: 200, total: 100).fraction == 1)
     }
 
-    @Test func currentProgressIsEmptyBeforeTheDownloadStarts() {
+    @Test func progressIsEmptyBeforeTheDownloadStarts() {
         // Given
         dataLoader.isSuspended = true
 
@@ -45,7 +45,7 @@ struct ImageTaskTests {
         let task = pipeline.imageTask(with: Test.request)
 
         // Then
-        #expect(task.currentProgress == ImageTask.Progress(completed: 0, total: 0))
+        #expect(task.status.progress == ImageTask.Progress(completed: 0, total: 0))
         task.cancel()
     }
 

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -97,6 +97,17 @@ struct ImageTaskTests {
         #expect(task.description.contains("state: cancelled"))
     }
 
+    @Test func descriptionReflectsTheFinishedState() async throws {
+        // Given
+        let task = pipeline.imageTask(with: Test.request)
+
+        // When
+        _ = try await task.response
+
+        // Then
+        #expect(task.description.contains("state: success"))
+    }
+
     // MARK: - Events
 
     @Test func eventsAreDeliveredToMultipleIndependentStreams() async throws {
@@ -157,9 +168,9 @@ struct ImageTaskTests {
         #expect(events.isEmpty)
     }
 
-    // MARK: - State
+    // MARK: - Status
 
-    @Test func stateIsCompletedWhenTheTaskFinishes() async throws {
+    @Test func statusResultIsSetWhenTheTaskFinishes() async throws {
         // Given
         let task = pipeline.imageTask(with: Test.request)
 
@@ -167,10 +178,23 @@ struct ImageTaskTests {
         _ = try await task.response
 
         // Then
-        #expect(task.state == .completed)
+        #expect(task.status.result?.isSuccess == true)
     }
 
-    @Test func cancellingAFinishedTaskDoesNotChangeItsState() async throws {
+    @Test func statusIsCapturedAtomically() async throws {
+        // Given
+        let task = pipeline.imageTask(with: Test.request)
+
+        // When
+        _ = try await task.response
+
+        // Then the result and the progress agree with each other
+        let status = task.status
+        #expect(status.result?.isSuccess == true)
+        #expect(status.progress.fraction == 1)
+    }
+
+    @Test func cancellingAFinishedTaskDoesNotChangeItsResult() async throws {
         // Given
         let task = pipeline.imageTask(with: Test.request)
         _ = try await task.response
@@ -178,8 +202,9 @@ struct ImageTaskTests {
         // When
         task.cancel()
 
-        // Then
-        #expect(task.state == .completed)
+        // Then the cancellation is recorded, but the outcome is not affected
+        #expect(task.isCancelled)
+        #expect(task.status.result?.isSuccess == true)
     }
 
     @Test func cancellingTwiceIsIdempotent() {
@@ -192,7 +217,21 @@ struct ImageTaskTests {
         task.cancel()
 
         // Then
-        #expect(task.state == .cancelled)
+        #expect(task.isCancelled)
+    }
+
+    @Test func isCancelledIsSetSynchronously() {
+        // Given
+        dataLoader.isSuspended = true
+        let task = pipeline.imageTask(with: Test.request)
+
+        // When
+        task.cancel()
+
+        // Then it is visible on the calling thread, without waiting for the
+        // pipeline actor to process the cancellation
+        #expect(task.isCancelled)
+        #expect(task.status.result == nil)
     }
 
     // MARK: - Priority


### PR DESCRIPTION
Stacked on #912 — review that one first, or read only the last three commits here.

`ImageTask.State` answered three different questions with one value, and two of them live on different clocks: *did I ask it to stop* is knowable synchronously on the calling thread, while *is it over* and *how did it end* are only knowable when the pipeline dispatches `.finished`. Conflating them is why `isCancelled` had to exist alongside `state`, and why the two could disagree.

`State` is now split along that seam. The struct the task already kept behind its lock becomes the public `Status`, so the snapshot is the same storage — no new allocation, no second lock:

```swift
public var status: Status { statusLock.withLockUnchecked { $0 } }

public struct Status: Sendable {
    public internal(set) var result: Result<ImageResponse, ImagePipeline.Error>?
    public internal(set) var isCancelled = false
    public internal(set) var priority: ImageRequest.Priority
    public internal(set) var progress = Progress(completed: 0, total: 0)
}
```

- `isCancelled` is now public. It records a cancellation *request*, is set synchronously on the thread that calls `cancel()`, and never goes back to `false`.
- `status.result` records the *outcome*, written immediately before `.finished` is sent, so it is guaranteed visible to anyone observing that event or returning from `await response`.
- The two can disagree in both directions, by design: cancelling an already-finished task leaves `isCancelled == true` with a `.success` result, and `invalidate()` produces a `.cancelled` result without ever setting `isCancelled`. The latter matters — setting `isCancelled` there would make the closure-based API silently drop completion handlers instead of completing with `.failure(.cancelled)`.
- The result is only reachable as `status.result`, deliberately. `ImageTask.result` stays free for a future non-throwing `{ get async }` accessor, which is what `Task.result` means in Swift concurrency.
- `description` now takes the lock once instead of three times, so its fields can no longer tear.

`state` and `currentProgress` are deprecated in Nuke 14.0 rather than removed. `state` is no longer stored — it is derived from `isCancelled` and `result`, reproducing what the stored property reported in every path: cancel-then-finish → `.cancelled`, finish-then-cancel → `.completed`, network failure → `.completed`, `invalidate()` → `.cancelled`. `DeprecatedImageTaskStateTests` pins each one. `currentProgress` uses `renamed:` so Xcode offers a fix-it to `status.progress`.

## Migration note

`task.state` was written synchronously inside `cancel()`; `status.result` is written on the pipeline actor. So this does not translate directly:

```swift
task.cancel()
if task.state == .cancelled { … }        // was synchronous
if task.status.result != nil { … }       // races the pipeline
```

`isCancelled` is the synchronous signal; the result requires awaiting the task. A test written the naive way here failed about one run in four before being fixed, so it is worth documenting in the migration guide.

## Known gap

`DeprecatedTests.swift` emits 6 deprecation warnings. Swift Testing rejects `@available(*, deprecated)` on `@Suite` and `@Test`, and there is no call-site suppression in Swift, so exercising deprecated API from tests cannot be warning-free. Reading `task.state` into a local before `#expect` halves the count — the macro re-expands its argument and would otherwise report each one twice.

## To test

1. `swift build`
2. Run the `NukeTests`, `NukeThreadSafetyTests`, and `NukeExtensionsTests` schemes. `NukeTests` was run 5x to confirm the cancellation tests are not flaky.
