### PR TITLE
Replace ImageTask.Event.started with a dedicated delegate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Remove the soft-deprecated `userInfo` parameter from the `ImageRequest` initializers. It's still available as a property – https://github.com/kean/Nuke/pull/909
 - `ImageRequest.scale` and `ImageRequest.ThumbnailOptions.init(maxPixelSize:)` now use `CGFloat` – https://github.com/kean/Nuke/pull/910
 - Remove Combine support: `ImagePipeline.imagePublisher(with:)` and `FetchImage.load(_:)` that takes a publisher. Use the Async/Await APIs instead – https://github.com/kean/Nuke/pull/911
+- Remove `ImageTask/Event/started`, which `ImageTask/events` never yielded, and add `ImagePipeline/Delegate/imageTaskDidStart(_:pipeline:)` in its place – https://github.com/kean/Nuke/pull/914
 
 # Nuke 13
 

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -67,6 +67,25 @@ To observe progressively decoded previews, which the publisher used to emit as i
 
 `FetchImage` remains an `ObservableObject`, so observing it from SwiftUI is unchanged.
 
+## Removed `ImageTask.Event.started`
+
+`ImageTask.Event.started` is gone. It was never delivered to `ImageTask.events` – the pipeline reported it to the delegate directly – so it only ever existed for `ImagePipeline.Delegate`. The delegate now has a dedicated method instead.
+
+```swift
+// Nuke 13
+func imageTask(_ task: ImageTask, didReceiveEvent event: ImageTask.Event, pipeline: ImagePipeline) {
+    switch event {
+    case .started: handleStart(task)
+    case .progress, .preview, .finished: break
+    }
+}
+
+// Nuke 14
+func imageTaskDidStart(_ task: ImageTask, pipeline: ImagePipeline) {
+    handleStart(task)
+}
+```
+
 ## `Float` to `CGFloat`
 
 The public scale and size APIs now use `CGFloat`, matching the types you get from UIKit and SwiftUI.

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -132,8 +132,6 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
 
     /// An event produced during the runtime of the task.
     @frozen public enum Event: Sendable {
-        /// The task was started by the pipeline.
-        case started
         /// The download progress was updated.
         case progress(Progress)
         /// The pipeline generated a progressive scan of the image.

--- a/Sources/Nuke/Pipeline/Deprecated.swift
+++ b/Sources/Nuke/Pipeline/Deprecated.swift
@@ -36,7 +36,6 @@ extension ImagePipeline {
                 // events are called on the callback queue.
                 guard !task.isCancelled else { return }
                 switch event {
-                case .started: break
                 case .progress(let value): progress?(nil, value)
                 case .preview(let response): progress?(response, task.currentProgress)
                 case .finished(let result):

--- a/Sources/Nuke/Pipeline/ImagePipeline+Delegate.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Delegate.swift
@@ -101,6 +101,9 @@ extension ImagePipeline {
         /// immediately on the caller's queue.
         func imageTaskCreated(_ task: ImageTask, pipeline: ImagePipeline)
 
+        /// Gets called when the task is started by the pipeline.
+        func imageTaskDidStart(_ task: ImageTask, pipeline: ImagePipeline)
+
         /// Gets called when the task receives an event.
         func imageTask(_ task: ImageTask, didReceiveEvent event: ImageTask.Event, pipeline: ImagePipeline)
     }
@@ -159,6 +162,8 @@ extension ImagePipeline.Delegate {
     }
 
     public func imageTaskCreated(_ task: ImageTask, pipeline: ImagePipeline) {}
+
+    public func imageTaskDidStart(_ task: ImageTask, pipeline: ImagePipeline) {}
 
     public func imageTask(_ task: ImageTask, didReceiveEvent event: ImageTask.Event, pipeline: ImagePipeline) {}
 }

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -203,8 +203,8 @@ public final class ImagePipeline: Sendable {
         // `removeTask` to remove it, and already started for the events to be
         // delivered in the correct order.
         task._node = tasks.append(task)
-        if !isDataTask {
-            delegate.imageTask(task, didReceiveEvent: .started, pipeline: self)
+        if !isDataTask && !isDefaultDelegate {
+            delegate.imageTaskDidStart(task, pipeline: self)
         }
         onTaskStarted?(task)
         task._subscription = worker.subscribe(priority: task.priority.taskPriority, subscriber: task) { [weak task] in

--- a/Tests/Mocks/ImagePipelineObserver.swift
+++ b/Tests/Mocks/ImagePipelineObserver.swift
@@ -34,12 +34,14 @@ final class ImagePipelineObserver: ImagePipeline.Delegate, @unchecked Sendable {
         append(.created)
     }
 
+    func imageTaskDidStart(_ task: ImageTask, pipeline: ImagePipeline) {
+        startedTaskCount += 1
+        append(.started)
+        NotificationCenter.default.post(name: ImagePipelineObserver.didStartTask, object: self, userInfo: [ImagePipelineObserver.taskKey: task])
+    }
+
     func imageTask(_ task: ImageTask, didReceiveEvent event: ImageTask.Event, pipeline: ImagePipeline) {
         switch event {
-        case .started:
-            startedTaskCount += 1
-            append(.started)
-            NotificationCenter.default.post(name: ImagePipelineObserver.didStartTask, object: self, userInfo: [ImagePipelineObserver.taskKey: task])
         case .progress(let progress):
             append(.progressUpdated(completedUnitCount: progress.completed, totalUnitCount: progress.total))
         case .preview(let response):

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
@@ -37,6 +37,23 @@ struct ImagePipelineTaskDelegateTests {
         ])
     }
 
+    @Test func startIsReportedThroughTheDedicatedDelegateMethod() async throws {
+        // WHEN
+        let completed = TestExpectation(notification: ImagePipelineObserver.didCompleteTask, object: delegate)
+        let task = pipeline.imageTask(with: Test.request)
+        var events: [ImageTask.Event] = []
+        for await event in task.events {
+            events.append(event)
+        }
+        await completed.wait()
+
+        // THEN the start is reported to `imageTaskDidStart` before any of the
+        // events observed by the task stream
+        #expect(delegate.startedTaskCount == 1)
+        #expect(Array(delegate.events.prefix(2)) == [ImageTaskEvent.created, .started])
+        #expect(events.count == delegate.events.count - 2)
+    }
+
     @Test func progressUpdateEvents() async throws {
         let request = ImageRequest(url: Test.url)
         dataLoader.results[Test.url] = .success(


### PR DESCRIPTION
`ImageTask.Event.started` was public and documented as "The task was started by the pipeline", but the pipeline only ever passed it to `ImagePipeline.Delegate` directly, bypassing `ImageTask._dispatch`. `for await event in task.events` could never observe it.

Since the case only ever existed for the delegate, it's removed from the public `Event` and replaced with `imageTaskDidStart(_:pipeline:)`:

```swift
// Before
func imageTask(_ task: ImageTask, didReceiveEvent event: ImageTask.Event, pipeline: ImagePipeline) {
    switch event {
    case .started: handleStart(task)
    case .progress, .preview, .finished: break
    }
}

// After
func imageTaskDidStart(_ task: ImageTask, pipeline: ImagePipeline) {
    handleStart(task)
}
```

The new callback is skipped for the default delegate, matching how the other task events are reported.

## To test

1. Run the `NukeTests`, `NukeUITests`, `NukeExtensionsTests`, and `NukeThreadSafetyTests` schemes – all pass.
2. `ImagePipelineTaskDelegateTests.startIsReportedThroughTheDedicatedDelegateMethod` covers that the start is reported to the delegate before any event the task stream observes.