### PR TITLE
Carry a Result through a non-throwing continuation in ImageTask

### DIFF
--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -92,17 +92,12 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     /// Throws ``ImagePipeline/Error/cancelled`` if the task is cancelled.
     public var response: ImageResponse {
         get async throws(ImagePipeline.Error) {
-            do {
-                return try await withTaskCancellationHandler {
-                    try await _task.value
-                } onCancel: {
-                    cancel()
-                }
-            } catch let error as ImagePipeline.Error {
-                throw error
-            } catch {
-                preconditionFailure("Unexpected error type: \(error)")
+            let result = await withTaskCancellationHandler {
+                await _task.value
+            } onCancel: {
+                cancel()
             }
+            return try result.get()
         }
     }
 
@@ -149,8 +144,8 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     private weak var pipeline: ImagePipeline?
 
     // Set once during creation, then read-only from `response` getter.
-    nonisolated(unsafe) var _task: Task<ImageResponse, any Error>!
-    @ImagePipelineActor var _continuation: UnsafeContinuation<ImageResponse, any Error>?
+    nonisolated(unsafe) var _task: Task<Result<ImageResponse, ImagePipeline.Error>, Never>!
+    @ImagePipelineActor var _continuation: UnsafeContinuation<Result<ImageResponse, ImagePipeline.Error>, Never>?
     @ImagePipelineActor var _isFinished = false
     @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
     @ImagePipelineActor var _subscription: TaskSubscription?
@@ -261,7 +256,7 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
                 continuation.finish()
             }
             _streamContinuations.removeAll()
-            _continuation?.resume(with: result)
+            _continuation?.resume(returning: result)
         default:
             break
         }

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -176,7 +176,7 @@ public final class ImagePipeline: Sendable {
             delegate.imageTaskCreated(task, pipeline: self)
         }
         task._task = Task { @ImagePipelineActor in
-            try await withUnsafeThrowingContinuation { continuation in
+            await withUnsafeContinuation { continuation in
                 task._continuation = continuation
                 self.startImageTask(task, isDataTask: isDataTask)
             }


### PR DESCRIPTION
`ImageTask._task` and `_continuation` were typed as `any Error` only because `withUnsafeThrowingContinuation` erases the error type. Everything the pipeline resumes them with is already an `ImagePipeline.Error`, so `response` had to re-case the error on the way out and trap on anything else:

```swift
// Before
public var response: ImageResponse {
    get async throws(ImagePipeline.Error) {
        do {
            return try await withTaskCancellationHandler {
                try await _task.value
            } onCancel: { cancel() }
        } catch let error as ImagePipeline.Error {
            throw error
        } catch {
            preconditionFailure("Unexpected error type: \(error)")
        }
    }
}

// After
public var response: ImageResponse {
    get async throws(ImagePipeline.Error) {
        let result = await withTaskCancellationHandler {
            await _task.value
        } onCancel: { cancel() }
        return try result.get()
    }
}
```

Carrying the `Result` through a non-throwing continuation (`withUnsafeContinuation`, resumed with `resume(returning:)`) makes the error type part of the task's type, so `Result.get()` supplies the typed throws and the unreachable branch goes away. No behavior change.

## To test

1. Run the `NukeTests`, `NukeUITests`, `NukeExtensionsTests`, and `NukeThreadSafetyTests` schemes – all pass.
2. `ImagePipelineAsyncAwaitTests` covers the success, failure, and cancellation paths through `task.response`, including that cancellation still throws `ImagePipeline.Error.cancelled`.