### PR TITLE
Replay the terminal event to late ImageTask.events subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 - Remove Combine support: `ImagePipeline.imagePublisher(with:)` and `FetchImage.load(_:)` that takes a publisher. Use the Async/Await APIs instead – https://github.com/kean/Nuke/pull/911
 - Remove `ImageTask/Event/started`, which `ImageTask/events` never yielded, and add `ImagePipeline/Delegate/imageTaskDidStart(_:pipeline:)` in its place – https://github.com/kean/Nuke/pull/914
 
+**Bug Fixes**
+
+- Fix `ImageTask/events` producing an empty stream when the task finishes before the subscription lands, as it does on a memory cache hit. A new stream now replays the terminal event and starts with the current progress – https://github.com/kean/Nuke/pull/916
+
 # Nuke 13
 
 ## WIP

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -145,6 +145,12 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
     // MARK: - Events
 
     /// The events sent by the pipeline during the task execution.
+    ///
+    /// Each access creates an independent stream that ends with the terminal
+    /// ``Event/finished(_:)`` event. Subscribing is safe at any point in the
+    /// task lifetime: a stream created after the task has already finished
+    /// replays the terminal event, and a stream created mid-download starts
+    /// with the current ``Event/progress(_:)`` value, if any.
     public var events: AsyncStream<Event> { makeStream() }
 
     /// An event produced during the runtime of the task.
@@ -308,15 +314,24 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
 extension ImageTask {
     /// Creates a new stream of events for this task.
     ///
-    /// - note: Each call creates an independent stream. Subscribing after the
-    /// task has already finished or been cancelled produces an empty stream —
-    /// no `.finished` terminal event is replayed. Subscribe before the task
-    /// completes if you need to observe this event.
+    /// A subscription reaches the pipeline actor asynchronously, so the task
+    /// can finish before it is registered – a memory cache hit, for example,
+    /// finishes the task while the pipeline is still starting it. To make sure
+    /// no subscriber misses the outcome, a stream created after the task
+    /// finished replays the terminal event recorded in ``Status/result``.
     private func makeStream() -> AsyncStream<Event> {
         AsyncStream { continuation in
             Task { @ImagePipelineActor in
-                guard !self._isFinished else {
+                let status = self.status
+                if let result = status.result {
+                    continuation.yield(.finished(result))
                     return continuation.finish()
+                }
+                // Prime the stream with the progress reported so far so that a
+                // progress bar attached mid-download doesn't sit at zero until
+                // the next chunk arrives.
+                if status.progress.completed > 0 || status.progress.total > 0 {
+                    continuation.yield(.progress(status.progress))
                 }
                 self._streamContinuations.append(continuation)
             }

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -130,9 +130,7 @@ struct ImageTaskTests {
         #expect(rhs.contains { if case .finished(.success) = $0 { return true } else { return false } })
     }
 
-    /// Subscribing after the task is already finished produces an empty stream:
-    /// the terminal event is not replayed.
-    @Test func subscribingAfterTheTaskFinishesProducesAnEmptyStream() async throws {
+    @Test func subscribingAfterTheTaskFinishesReplaysTheTerminalEvent() async throws {
         // Given
         let task = pipeline.imageTask(with: Test.request)
         _ = try await task.response
@@ -144,10 +142,11 @@ struct ImageTaskTests {
         }
 
         // Then
-        #expect(events.isEmpty)
+        #expect(events.count == 1)
+        #expect(events.contains { if case .finished(.success) = $0 { return true } else { return false } })
     }
 
-    @Test func subscribingAfterTheTaskIsCancelledProducesAnEmptyStream() async throws {
+    @Test func subscribingAfterTheTaskIsCancelledReplaysTheTerminalEvent() async throws {
         // Given
         dataLoader.isSuspended = true
         let task = await withSuspendedDataLoading(for: pipeline, expectedCount: 1) {
@@ -165,7 +164,62 @@ struct ImageTaskTests {
         }
 
         // Then
-        #expect(events.isEmpty)
+        #expect(events.count == 1)
+        #expect(events.contains { if case .finished(.failure(.cancelled)) = $0 { return true } else { return false } })
+    }
+
+    /// A memory cache hit finishes the task synchronously, while the pipeline
+    /// is still starting it, so even a subscription made immediately after
+    /// creating the task can arrive late.
+    @Test func subscribingImmediatelyDeliversTheTerminalEventOnMemoryCacheHit() async throws {
+        // Given
+        let imageCache = MockImageCache()
+        imageCache[Test.request] = Test.container
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = imageCache
+        }
+
+        // When
+        let task = pipeline.imageTask(with: Test.request)
+        var events: [ImageTask.Event] = []
+        for await event in task.events {
+            events.append(event)
+        }
+
+        // Then
+        #expect(events.count == 1)
+        #expect(events.contains { if case .finished(.success) = $0 { return true } else { return false } })
+    }
+
+    @Test func subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress() async throws {
+        // Given a task that already received one chunk of the image
+        let dataLoader = MockProgressiveDataLoader()
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+        let task = pipeline.imageTask(with: Test.request)
+        while task.status.progress.completed == 0 {
+            await Task.yield()
+        }
+        let progress = task.status.progress
+
+        // When the stream is created after the first chunk is delivered
+        async let recorded = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
+        while await task._streamContinuations.isEmpty {
+            await Task.yield()
+        }
+        dataLoader.resumeServingChunks(dataLoader.chunks.count)
+
+        // Then it starts with the progress reported before it was created
+        let events = await recorded
+        var firstProgress: ImageTask.Progress?
+        if case .progress(let value) = try #require(events.first) {
+            firstProgress = value
+        }
+        #expect(firstProgress == progress)
+        #expect(events.contains { if case .finished(.success) = $0 { return true } else { return false } })
     }
 
     // MARK: - Status


### PR DESCRIPTION
`ImageTask.events` could hand a caller an empty stream. `makeStream` registers its continuation from an unstructured `Task { @ImagePipelineActor }`, and the task itself starts from another one in `makeStartedImageTask`. Job ordering between independent tasks isn't FIFO, and a memory cache hit finishes the task synchronously inside `startImageTask`, so this reasonable-looking code could observe nothing at all:

```swift
let task = pipeline.imageTask(with: url)
for await event in task.events { ... } // may never see .finished
```

The old doc note said to "subscribe before the task completes", but the caller has no way to do that — the race is internal to the pipeline.

`status.result` is already recorded immediately before the terminal event is sent, so a stream created after the task finished can replay it:

```swift
Task { @ImagePipelineActor in
    let status = self.status
    if let result = status.result {
        continuation.yield(.finished(result))
        return continuation.finish()
    }
    if status.progress.completed > 0 || status.progress.total > 0 {
        continuation.yield(.progress(status.progress))
    }
    self._streamContinuations.append(continuation)
}
```

Keying the replay off `status.result` instead of `_isFinished` also covers the window where the two disagree: a `cancel()` that lands before the task is wired sets `_isFinished` but returns early from `_dispatch` without recording a result. There the continuation is registered normally and receives the terminal event that `startImageTask` dispatches, so nothing is dropped either way.

New streams are also primed with the progress reported so far, so a progress bar attached mid-download doesn't sit at zero until the next chunk arrives.

## To test

1. Run the `NukeTests`, `NukeUITests`, and `NukeExtensionsTests` schemes – all pass.
2. `ImageTaskTests` covers the four cases: subscribing after success, after cancellation, immediately on a memory cache hit, and mid-download for the primed progress. All four fail without the change.
