### PR TITLE
Apply the current priority when the update reaches the pipeline actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 **Bug Fixes**
 
 - Fix `ImageTask/events` producing an empty stream when the task finishes before the subscription lands, as it does on a memory cache hit. A new stream now replays the terminal event and starts with the current progress – https://github.com/kean/Nuke/pull/916
+- Fix `ImageTask/priority` updates being applied out of order, leaving the running task at a stale priority – https://github.com/kean/Nuke/pull/918
 
 # Nuke 13
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -212,7 +212,9 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         }
         guard didChange else { return }
         Task { @ImagePipelineActor in
-            self.pipeline?.imageTaskUpdatePriorityCalled(self, priority: newValue)
+            // Read the priority instead of capturing `newValue`: the hops are
+            // unordered, so a stale value could land last.
+            self.pipeline?.imageTaskUpdatePriorityCalled(self, priority: self.priority)
         }
     }
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -65,6 +65,37 @@ struct ImagePipelineTests {
         }
     }
 
+    /// Every update schedules its own hop to the pipeline actor, and the hops
+    /// carry no ordering guarantee between them. Each one has to apply the
+    /// priority that is current when it runs, otherwise a stale value can land
+    /// last and leave the operation out of sync with ``ImageTask/priority``.
+    @Test @ImagePipelineActor func priorityUpdatesNeverApplyAStaleValue() async throws {
+        // Given
+        let queue = pipeline.configuration.dataLoadingQueue
+        queue.isSuspended = true
+
+        let expectation = TestExpectation(queue: queue, count: 1)
+        let imageTask = pipeline.imageTask(with: Test.request)
+        Task.detached { try await imageTask.response }
+        await expectation.wait()
+
+        let operation = try #require(expectation.operations.first)
+        var recorded: [TaskPriority] = []
+        operation.onPriorityChanged = { recorded.append($0) }
+
+        // When two updates are made back to back. The test holds the actor
+        // until it suspends, so both hops are scheduled before either runs.
+        let didApplyUpdates = TestExpectation()
+        imageTask.priority = .veryHigh
+        imageTask.priority = .veryLow
+        Task { @ImagePipelineActor in didApplyUpdates.fulfill() }
+        await didApplyUpdates.wait()
+
+        // Then the operation only ever sees the final priority
+        #expect(recorded == [.veryLow])
+        #expect(imageTask.priority == .veryLow)
+    }
+
     @Test @ImagePipelineActor func decodingPriorityUpdated() async throws {
         // Given
         let pipeline = pipeline.reconfigured {


### PR DESCRIPTION
`ImageTask.setPriority` captures `newValue` and applies it from a fresh `Task { @ImagePipelineActor in ... }`. Two updates made in quick succession — even from the same thread — spawn two independent hops with no ordering guarantee between them, so the subscription can end up at the older priority while `status.priority` reports the newer one.

The fix is to not capture the value: the hop reads the current priority instead, which makes it idempotent and convergent no matter which order the hops run in. `cancel()` doesn't have this problem because it is one-shot and monotonic.

Added a test that holds the pipeline actor across both updates so the two hops are guaranteed to be scheduled before either runs, and records every priority the data loading operation is given. Before the fix it recorded `[.veryHigh, .veryLow]`; now it records `[.veryLow]`.