### PR TITLE
Merge the unpublished Nuke 13 WIP entries into Nuke 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,11 @@
 
 **Bug Fixes**
 
+- Fix a data race on `ImagePipeline/Configuration/isSignpostLoggingEnabled`, which the pipeline reads on every signpost while it can be written from any thread – https://github.com/kean/Nuke/pull/901
+- Fix progressive previews not being delivered on a resumed download – https://github.com/kean/Nuke/pull/903
 - Fix `ImageTask/events` producing an empty stream when the task finishes before the subscription lands, as it does on a memory cache hit. A new stream now replays the terminal event and starts with the current progress – https://github.com/kean/Nuke/pull/916
 
 # Nuke 13
-
-## WIP
-
-- Fix a data race on `ImagePipeline/Configuration/isSignpostLoggingEnabled`, which the pipeline reads on every signpost while it can be written from any thread – https://github.com/kean/Nuke/pull/901
-- Fix progressive previews not being delivered on a resumed download – https://github.com/kean/Nuke/pull/903
 
 ## Nuke 13.2.0
 


### PR DESCRIPTION
PRs #901 and #903 were listed under a `Nuke 13` / `WIP` heading that never shipped — 13.2.0 was cut without them. Their fixes are on `main` and will ship in 14.0, so the entries now live in the Nuke 14 `Bug Fixes` list, ordered by PR number.

## To test

1. Open `CHANGELOG.md`.
2. Confirm the Nuke 14 `Bug Fixes` section lists #901, #903, and #916.
3. Confirm `# Nuke 13` now starts at `## Nuke 13.2.0` with no `WIP` section.