### PR TITLE
Add a public initializer to ImageTask.Status

### DIFF
--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -108,11 +108,22 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
         public internal(set) var isCancelled = false
 
         /// The priority of the task.
-        public internal(set) var priority: ImageRequest.Priority
+        public internal(set) var priority: ImageRequest.Priority = .normal
 
         /// The download progress. Contains zeros until the download starts and
         /// the total resource size is known.
         public internal(set) var progress = Progress(completed: 0, total: 0)
+
+        /// Initializes the status describing a task that has just started.
+        ///
+        /// The pipeline creates the status for you – use this initializer to
+        /// construct one for tests and SwiftUI previews of the code that
+        /// consumes it.
+        public init() {}
+
+        init(priority: ImageRequest.Priority) {
+            self.priority = priority
+        }
     }
 
     // MARK: - Async/Await

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -245,6 +245,17 @@ struct ImageTaskTests {
 
     // MARK: - Status
 
+    @Test func statusCanBeCreatedByClients() {
+        // Given a status built without a pipeline
+        let status = ImageTask.Status()
+
+        // Then
+        #expect(status.result == nil)
+        #expect(!status.isCancelled)
+        #expect(status.priority == .normal)
+        #expect(status.progress == ImageTask.Progress(completed: 0, total: 0))
+    }
+
     @Test func statusResultIsSetWhenTheTaskFinishes() async throws {
         // Given
         let task = pipeline.imageTask(with: Test.request)


### PR DESCRIPTION
`ImageTask.Status` exposes its properties as `public internal(set)`, so the synthesized memberwise initializer is internal. Clients can read a status but can't build one, which makes anything that consumes it awkward to test or preview:

```swift
StatusView(status: /* no way to make one */)
```

This adds a parameterless initializer that creates a status describing a task that has just started:

```swift
StatusView(status: ImageTask.Status())
```

The setters stay internal – only the pipeline changes a status once it exists.

## To test

1. Run the `NukeTests` scheme – all pass.
2. `ImageTaskTests` covers the initializer.
