### PR TITLE
Conform ImageTask to Identifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `ImageRequest.scale` and `ImageRequest.ThumbnailOptions.init(maxPixelSize:)` now use `CGFloat` – https://github.com/kean/Nuke/pull/910
 - Remove Combine support: `ImagePipeline.imagePublisher(with:)` and `FetchImage.load(_:)` that takes a publisher. Use the Async/Await APIs instead – https://github.com/kean/Nuke/pull/911
 - Remove `ImageTask/Event/started`, which `ImageTask/events` never yielded, and add `ImagePipeline/Delegate/imageTaskDidStart(_:pipeline:)` in its place – https://github.com/kean/Nuke/pull/914
+- `ImageTask` now conforms to `Identifiable` – https://github.com/kean/Nuke/pull/922
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -35,7 +35,7 @@ import AppKit
 /// The pipeline maintains a strong reference to the task until the request
 /// finishes or fails; you do not need to maintain a reference to the task unless
 /// it is useful for your app.
-public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Sendable {
+public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @unchecked Sendable {
     /// An identifier that uniquely identifies the task within a given pipeline.
     public let taskId: UInt64
 
@@ -350,6 +350,14 @@ public final class ImageTask: Hashable, CustomStringConvertible, @unchecked Send
         onEvent?(event, self)
         pipeline?.imageTask(self, didProcessEvent: event, isDataTask: isDataTask)
     }
+
+    // MARK: Identifiable
+
+    /// An identifier that uniquely identifies the task.
+    ///
+    /// Derived from the object identity, not from ``taskId``, which is only
+    /// unique within a single pipeline.
+    public var id: ObjectIdentifier { ObjectIdentifier(self) }
 
     // MARK: Hashable
 

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -67,6 +67,27 @@ struct ImageTaskTests {
         other.cancel()
     }
 
+    // MARK: - Identifiable
+
+    @Test func idIsStableAndUniqueAcrossPipelines() {
+        // Given two pipelines that both hand out the same `taskId`
+        dataLoader.isSuspended = true
+        let other = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+        let lhs = pipeline.imageTask(with: Test.request)
+        let rhs = other.imageTask(with: Test.request)
+
+        // Then the identifiers are still distinct
+        #expect(lhs.taskId == rhs.taskId)
+        #expect(lhs.id == lhs.id)
+        #expect(lhs.id != rhs.id)
+
+        lhs.cancel()
+        rhs.cancel()
+    }
+
     // MARK: - CustomStringConvertible
 
     @Test func description() {


### PR DESCRIPTION
`ImageTask` is a natural thing to put in a SwiftUI `ForEach` or `.id(_:)`, but it isn't `Identifiable`, so callers reach for `id: \.taskId` – which is subtly wrong. `taskId` is only unique within a single pipeline, so two tasks from two pipelines can share one and SwiftUI will treat them as the same view.

The identity is derived from the object instead, matching the existing `hash(into:)` and `==`:

```swift
public var id: ObjectIdentifier { ObjectIdentifier(self) }
```

That is also what the stdlib's `Identifiable where Self: AnyObject` default provides; it's spelled out so it shows up in the documentation.

## To test

1. Run the `NukeTests` scheme – all pass.
2. `ImageTaskTests` covers two pipelines handing out the same `taskId` while the tasks still get distinct `id`s.