### PR TITLE
Return a dedicated AsyncStream from ImageTask.progress and previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Remove Combine support: `ImagePipeline.imagePublisher(with:)` and `FetchImage.load(_:)` that takes a publisher. Use the Async/Await APIs instead – https://github.com/kean/Nuke/pull/911
 - Remove `ImageTask/Event/started`, which `ImageTask/events` never yielded, and add `ImagePipeline/Delegate/imageTaskDidStart(_:pipeline:)` in its place – https://github.com/kean/Nuke/pull/914
 - `ImageTask` now conforms to `Identifiable` – https://github.com/kean/Nuke/pull/922
+- `ImageTask/progress` and `ImageTask/previews` now return an `AsyncStream` instead of leaking the sequence type they are built from. `progress` also keeps only the most recent update for a consumer that can't keep up with the download – https://github.com/kean/Nuke/pull/924
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -167,8 +167,13 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     /// The stream of progress updates.
     ///
     /// A convenience over ``events``: every access creates a new subscription.
-    public var progress: AsyncCompactMapSequence<AsyncStream<Event>, Progress> {
-        events.compactMap {
+    ///
+    /// - note: Unlike ``events``, the stream keeps only the most recent update.
+    /// Each value is a complete snapshot of the download, so a consumer that
+    /// can't keep up – a progress bar driven by the main actor – picks up where
+    /// the download is now instead of replaying the values it missed.
+    public var progress: AsyncStream<Progress> {
+        makeStream(bufferingPolicy: .bufferingNewest(1)) {
             if case .progress(let value) = $0 { return value }
             return nil
         }
@@ -180,8 +185,8 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     /// A convenience over ``events``: every access creates a new subscription.
     ///
     /// - seealso: ``ImagePipeline/Configuration-swift.struct/isProgressiveDecodingEnabled``
-    public var previews: AsyncCompactMapSequence<AsyncStream<Event>, ImageResponse> {
-        events.compactMap {
+    public var previews: AsyncStream<ImageResponse> {
+        makeStream {
             if case .preview(let value) = $0 { return value }
             return nil
         }
@@ -214,7 +219,7 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     ///
     /// - note: A stream buffers the events that the consumer hasn't picked up
     /// yet, so a slow consumer never misses one.
-    public var events: AsyncStream<Event> { makeStream() }
+    public var events: AsyncStream<Event> { makeStream { $0 } }
 
     /// An event produced during the runtime of the task.
     @frozen public enum Event: Sendable {
@@ -238,7 +243,7 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     nonisolated(unsafe) var _task: Task<Result<ImageResponse, ImagePipeline.Error>, Never>!
     @ImagePipelineActor var _continuation: UnsafeContinuation<Result<ImageResponse, ImagePipeline.Error>, Never>?
     @ImagePipelineActor var _isFinished = false
-    @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
+    @ImagePipelineActor var _observers = ContiguousArray<@Sendable (Event) -> Void>()
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
 
@@ -344,18 +349,12 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
         if case .finished(let result) = event {
             _status.withLock { $0.result = result }
         }
-        for continuation in _streamContinuations {
-            continuation.yield(event)
+        for observer in _observers {
+            observer(event)
         }
-        switch event {
-        case .finished(let result):
-            for continuation in _streamContinuations {
-                continuation.finish()
-            }
-            _streamContinuations.removeAll()
+        if case .finished(let result) = event {
+            _observers.removeAll()
             _continuation?.resume(returning: result)
-        default:
-            break
         }
 
         onEvent?(event, self)
@@ -396,28 +395,46 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
 // MARK: - ImageTask (Private)
 
 extension ImageTask {
-    /// Creates a new stream of events for this task.
+    /// Creates a new stream with the values that `transform` produces for the
+    /// events sent by the task, and finishes it when the task finishes.
+    ///
+    /// The events are transformed when they are sent, not when they are read,
+    /// so the values the stream isn't interested in never reach its buffer and
+    /// each stream can pick the buffering policy that suits it.
     ///
     /// A subscription reaches the pipeline actor asynchronously, so the task
     /// can finish before it is registered – a memory cache hit, for example,
     /// finishes the task while the pipeline is still starting it. To make sure
     /// no subscriber misses the outcome, a stream created after the task
     /// finished replays the terminal event recorded in ``Status/result``.
-    private func makeStream() -> AsyncStream<Event> {
-        AsyncStream { continuation in
+    private func makeStream<Value: Sendable>(
+        bufferingPolicy: AsyncStream<Value>.Continuation.BufferingPolicy = .unbounded,
+        transform: @escaping @Sendable (Event) -> Value?
+    ) -> AsyncStream<Value> {
+        AsyncStream(bufferingPolicy: bufferingPolicy) { continuation in
             Task { @ImagePipelineActor in
                 let status = self.status
                 if let result = status.result {
-                    continuation.yield(.finished(result))
+                    if let value = transform(.finished(result)) {
+                        continuation.yield(value)
+                    }
                     return continuation.finish()
                 }
                 // Prime the stream with the progress reported so far so that a
                 // progress bar attached mid-download doesn't sit at zero until
                 // the next chunk arrives.
-                if status.progress.completed > 0 || status.progress.total > 0 {
-                    continuation.yield(.progress(status.progress))
+                if status.progress.completed > 0 || status.progress.total > 0,
+                   let value = transform(.progress(status.progress)) {
+                    continuation.yield(value)
                 }
-                self._streamContinuations.append(continuation)
+                self._observers.append { event in
+                    if let value = transform(event) {
+                        continuation.yield(value)
+                    }
+                    if case .finished = event {
+                        continuation.finish()
+                    }
+                }
             }
         }
     }

--- a/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Helpers/TestHelpers.swift
@@ -33,6 +33,44 @@ func withSuspendedDataLoading<T>(
     return result
 }
 
+// MARK: - ImageTask
+
+extension ImageTask {
+    /// Waits until the given number of streams created for the task are
+    /// registered with the pipeline, which happens asynchronously.
+    @ImagePipelineActor func waitUntilObserved(count: Int = 1) async {
+        while _observers.count < count {
+            await Task.yield()
+        }
+    }
+}
+
+extension ImagePipeline {
+    /// Starts a task for the given request and records every progress update
+    /// that it reports.
+    ///
+    /// Data loading stays suspended until the recording stream is registered
+    /// with the pipeline, which happens asynchronously: a stream created after
+    /// the download starts misses the updates that preceded it.
+    ///
+    /// The updates are read from `events`, which buffers all of them, and not
+    /// from `progress`, which keeps only the most recent one when the consumer
+    /// can't keep up with the download.
+    func recordProgress(for request: ImageRequest) async -> (task: ImageTask, progress: [ImageTask.Progress]) {
+        let queue = configuration.dataLoadingQueue
+        queue.isSuspended = true
+        let task = imageTask(with: request)
+        async let progress = task.events.reduce(into: [ImageTask.Progress]()) { values, event in
+            if case .progress(let value) = event {
+                values.append(value)
+            }
+        }
+        await task.waitUntilObserved()
+        queue.isSuspended = false
+        return (task, await progress)
+    }
+}
+
 // MARK: - Image Comparison
 
 func isEqualImages(_ lhs: PlatformImage, _ rhs: PlatformImage) -> Bool {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -246,10 +246,8 @@ struct ImagePipelineAsyncAwaitTests {
         // WHEN
         var recordedProgress: [ImageTask.Progress] = []
         do {
-            let task = pipeline.imageTask(with: Test.url)
-            for await progress in task.progress {
-                recordedProgress.append(progress)
-            }
+            let (task, progress) = await pipeline.recordProgress(for: ImageRequest(url: Test.url))
+            recordedProgress = progress
             _ = try await task.image
         } catch {
             // Do nothing

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineCoalescingTests.swift
@@ -238,11 +238,7 @@ struct ImagePipelineCoalescingTests {
         )
 
         // When/Then
-        let task = pipeline.imageTask(with: Test.url)
-        var progressValues: [ImageTask.Progress] = []
-        for await progress in task.progress {
-            progressValues.append(progress)
-        }
+        let (task, progressValues) = await pipeline.recordProgress(for: ImageRequest(url: Test.url))
         _ = try? await task.response
 
         #expect(progressValues == [

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
@@ -42,11 +42,7 @@ struct ImagePipelineLoadDataTests {
         )
 
         // When
-        let task = pipeline.imageTask(with: Test.url)
-        var progressValues: [ImageTask.Progress] = []
-        for await progress in task.progress {
-            progressValues.append(progress)
-        }
+        let (task, progressValues) = await pipeline.recordProgress(for: ImageRequest(url: Test.url))
         _ = try? await task.response
 
         // Then

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineResumableDataTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineResumableDataTests.swift
@@ -26,10 +26,8 @@ struct ImagePipelineResumableDataTests {
         // Expect the progress for the first part of the download to be reported.
         var initialProgress: [ImageTask.Progress] = []
         do {
-            let task = pipeline.imageTask(with: Test.request)
-            for await progress in task.progress {
-                initialProgress.append(progress)
-            }
+            let (task, progress) = await pipeline.recordProgress(for: Test.request)
+            initialProgress = progress
             _ = try await task.response
         } catch {
             // Expected failure
@@ -43,11 +41,7 @@ struct ImagePipelineResumableDataTests {
 
         // Expect progress closure to continue reporting the progress of the
         // entire download
-        var remainingProgress: [ImageTask.Progress] = []
-        let task2 = pipeline.imageTask(with: Test.request)
-        for await progress in task2.progress {
-            remainingProgress.append(progress)
-        }
+        let (task2, remainingProgress) = await pipeline.recordProgress(for: Test.request)
         _ = try await task2.response
 
         #expect(remainingProgress == [

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -29,11 +29,7 @@ struct ImagePipelineTests {
         )
 
         // When
-        let task = pipeline.imageTask(with: Test.url)
-        var progressValues: [ImageTask.Progress] = []
-        for await progress in task.progress {
-            progressValues.append(progress)
-        }
+        let (task, progressValues) = await pipeline.recordProgress(for: ImageRequest(url: Test.url))
         _ = try? await task.response
 
         // Then

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -140,9 +140,7 @@ struct ImageTaskTests {
         async let first = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
         async let second = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
 
-        while await task._streamContinuations.count < 2 {
-            await Task.yield()
-        }
+        await task.waitUntilObserved(count: 2)
         dataLoader.isSuspended = false
 
         // Then both observe the terminal event
@@ -228,9 +226,7 @@ struct ImageTaskTests {
 
         // When the stream is created after the first chunk is delivered
         async let recorded = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
-        while await task._streamContinuations.isEmpty {
-            await Task.yield()
-        }
+        await task.waitUntilObserved()
         dataLoader.resumeServingChunks(dataLoader.chunks.count)
 
         // Then it starts with the progress reported before it was created
@@ -241,6 +237,48 @@ struct ImageTaskTests {
         }
         #expect(firstProgress == progress)
         #expect(events.contains { if case .finished(.success) = $0 { return true } else { return false } })
+    }
+
+    // MARK: - Progress Stream
+
+    @Test func progressStreamKeepsOnlyTheMostRecentUpdate() async throws {
+        // Given a task with a subscribed, but not yet read, progress stream
+        let dataLoader = MockProgressiveDataLoader()
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+        let task = pipeline.imageTask(with: Test.request)
+        let progress = task.progress
+        while task.status.progress.completed == 0 {
+            await Task.yield()
+        }
+        await task.waitUntilObserved()
+
+        // When the rest of the image is downloaded before the stream is read
+        dataLoader.resumeServingChunks(dataLoader.chunks.count)
+        _ = try await task.response
+
+        // Then the stream reports the current progress and not the values that
+        // the download passed through while nobody was reading it
+        var recorded: [ImageTask.Progress] = []
+        for await value in progress {
+            recorded.append(value)
+        }
+        #expect(recorded == [task.status.progress])
+    }
+
+    @Test func subscribingToProgressAfterTheTaskFinishesFinishesTheStream() async throws {
+        // Given
+        let task = pipeline.imageTask(with: Test.request)
+        _ = try await task.response
+
+        // When/Then the stream finishes without reporting any updates
+        var recorded: [ImageTask.Progress] = []
+        for await value in task.progress {
+            recorded.append(value)
+        }
+        #expect(recorded.isEmpty)
     }
 
     // MARK: - Status


### PR DESCRIPTION
`ImageTask.progress` and `previews` spelled out how they were built in their own signatures:

```swift
// Before
public var progress: AsyncCompactMapSequence<AsyncStream<Event>, Progress>
public var previews: AsyncCompactMapSequence<AsyncStream<Event>, ImageResponse>

// After
public var progress: AsyncStream<Progress>
public var previews: AsyncStream<ImageResponse>
```

`some AsyncSequence<Progress, Never>` isn't an option at an iOS 16 target – the `Failure` primary associated type needs iOS 18 – so both now return a dedicated `AsyncStream` built the same way `events` is. `makeStream` became generic over a transform that runs when the event is *sent*, not when it is read, so a stream never buffers the events it isn't interested in: a slow `progress` consumer used to pin every `preview` – decoded images and all – in the buffer of the `events` stream underneath it.

Filtering at yield time also means each stream can pick its own buffering policy, and `progress` now uses `.bufferingNewest(1)`. **This is a behavior change**: a consumer that falls behind the download no longer replays the updates it missed. Each `Progress` is a complete snapshot rather than a delta, so a progress bar driven by the main actor is better served by where the download is now. `events` and `previews` keep the unbounded buffer, so nothing is dropped there.

Storing the observers as `(Event) -> Void` closures instead of `AsyncStream<Event>.Continuation` lets one array serve all three streams; `_dispatch` yields and finishes in a single pass.

### Tests

Five tests asserted the exact sequence of progress values, which `progress` no longer guarantees. They read the updates from `events` now, so the coverage – every chunk is reported – is unchanged. They went through a new `recordProgress(for:)` helper that also closes a pre-existing race in them: the stream subscription reaches the pipeline actor asynchronously, so a fast mock download could finish before it landed and the recorded sequence came back empty. The helper keeps data loading suspended until the stream is registered.

Two new tests in `ImageTaskTests` cover the buffering policy and a subscription made after the task finished.

## To test

1. Run the `Nuke`, `NukeUI`, and `NukeExtensions` schemes on macOS – all pass.
2. `for await progress in task.progress` and `for await preview in task.previews` still compile unchanged; only code that named the sequence type breaks.
