### PR TITLE
Add AssetType.avif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Remove Combine support: `ImagePipeline.imagePublisher(with:)` and `FetchImage.load(_:)` that takes a publisher. Use the Async/Await APIs instead – https://github.com/kean/Nuke/pull/911
 - Remove `ImageTask/Event/started`, which `ImageTask/events` never yielded, and add `ImagePipeline/Delegate/imageTaskDidStart(_:pipeline:)` in its place – https://github.com/kean/Nuke/pull/914
 - `ImageTask` now conforms to `Identifiable` – https://github.com/kean/Nuke/pull/922
+- Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
 
 **Bug Fixes**
 

--- a/Documentation/Nuke.docc/Customization/ImageFormats/supported-image-formats.md
+++ b/Documentation/Nuke.docc/Customization/ImageFormats/supported-image-formats.md
@@ -19,7 +19,7 @@ Nuke can also drive progressive decoding, animated image rendering, drawing vect
 | GIF | ``AssetType/gif`` | ✅ | ✅ | Automatic (single preview) | ✅ (data attached) |
 | HEIC | ``AssetType/heic`` | ✅ | ✅ | Opt-in | First frame only |
 | WebP | ``AssetType/webp`` | ✅ | ❌ | Opt-in | First frame only |
-| AVIF | – | ✅ | ✅ recent OS only | Opt-in | First frame only |
+| AVIF | ``AssetType/avif`` | ✅ | ✅ recent OS only | Opt-in | First frame only |
 | JPEG XL | ``AssetType/jxl`` | ✅ iOS 17, macOS 14 | ❌ | Opt-in | – |
 | JPEG 2000 | ``AssetType/jpeg2000`` | ✅ | ✅ | Opt-in | – |
 | TIFF | ``AssetType/tiff`` | ✅ | ✅ | Opt-in | – |
@@ -51,7 +51,7 @@ AssetType.png.utType?.preferredMIMEType // "image/png"
 
 The sniffer returns one of the types declared on ``AssetType`` and nothing else. A few consequences are worth knowing:
 
-- **AVIF, HEIF (`mif1`), and CUR decode but sniff as `nil`.** ISO base media files are matched by their major brand, and the AVIF and bare-HEIF brands aren't in the table. CUR starts with `00 00 02 00`, one byte away from the ICO signature. The images load; ``ImageContainer/type`` is just empty.
+- **HEIF (`mif1`) and CUR decode but sniff as `nil`.** ISO base media files are matched by their major brand, and the bare-HEIF brand isn't in the table. CUR starts with `00 00 02 00`, one byte away from the ICO signature. The images load; ``ImageContainer/type`` is just empty.
 - **A sniffed type describes the bytes, not the semantics.** Most camera RAW formats – DNG, CR2, NEF, ARW – are TIFF containers, so they sniff as ``AssetType/tiff``.
 - **A `nil` type is not an error.** Only two places in the pipeline read the type: GIF detection in ``ImageDecoders/Default``, and `AssetType.isVideo` in `NukeVideo`.
 - **Video types are recognized without `NukeVideo`.** ``AssetType/mp4``, ``AssetType/m4v``, and ``AssetType/mov`` are always sniffable, but only `ImageDecoders.Video` can decode them, and you have to register it yourself.
@@ -106,20 +106,17 @@ Image I/O has no WebP encoder. ``ImageEncoders/ImageIO/isSupported(type:)`` retu
 
 ## AVIF
 
-[AVIF](https://en.wikipedia.org/wiki/AVIF) decodes natively on every OS Nuke supports.
-
-``AssetType`` doesn't sniff AVIF: the format is an ISO base media container with an `avif` major brand, which isn't one of the recognized brands. Images decode normally, but ``ImageContainer/type`` is `nil`.
+[AVIF](https://en.wikipedia.org/wiki/AVIF) decodes natively on every OS Nuke supports. Files with the `avif` and `avis` major brands sniff as ``AssetType/avif``.
 
 AVIF encoding arrived later than decoding and is only available on recent OS versions, so check before using it:
 
 ```swift
-let avif: AssetType = "public.avif"
-if ImageEncoders.ImageIO.isSupported(type: avif) {
-    let data = ImageEncoders.ImageIO(type: avif).encode(image)
+if ImageEncoders.ImageIO.isSupported(type: .avif) {
+    let data = ImageEncoders.ImageIO(type: .avif).encode(image)
 }
 ```
 
-> Note: There is no ``AssetType`` constant for AVIF, and `UTType` doesn't declare one either, so the identifier has to be spelled out.
+> Note: `UTType` declares no `avif` constant of its own, but the system does register the `public.avif` identifier, so ``AssetType/utType`` still bridges.
 
 ## JPEG XL
 

--- a/Sources/Nuke/Decoding/AssetType.swift
+++ b/Sources/Nuke/Decoding/AssetType.swift
@@ -62,6 +62,12 @@ public struct AssetType: ExpressibleByStringLiteral, Hashable, Sendable {
     /// Native decoding support only available on the following platforms: macOS 14,
     /// iOS 17, watchOS 10, tvOS 17.
     public static let jxl: AssetType = "public.jpeg-xl"
+
+    /// AVIF (AV1 Image File Format).
+    ///
+    /// Image I/O decodes AVIF on every platform Nuke supports. Encoding arrived
+    /// later – check ``ImageEncoders/ImageIO/isSupported(type:)`` before using it.
+    public static let avif: AssetType = "public.avif"
 }
 
 extension AssetType {
@@ -160,13 +166,15 @@ extension AssetType {
 
     /// Returns the type of an ISO base media file with the given major brand,
     /// or `nil` if the brand is unknown or belongs to an unsupported format,
-    /// such as HEIF (`mif1`), AVIF (`avif`), or MPEG-4 audio (`M4A `).
+    /// such as HEIF (`mif1`) or MPEG-4 audio (`M4A `).
     ///
     /// The brands are registered at https://mp4ra.org/registered-types/brands.
     private static func _makeISOBaseMedia(majorBrand: String?) -> AssetType? {
         switch majorBrand {
         case "heic", "heix", "heim", "heis", "hevc", "hevx", "hevm", "hevs":
             return .heic
+        case "avif", "avis":
+            return .avif
         case "isom", "iso2", "iso4", "iso5", "iso6", "mp41", "mp42", "mmp4", "avc1", "dash":
             return .mp4
         case "M4V ", "M4VH", "M4VP":

--- a/Tests/NukeTests/AssetTypeTests.swift
+++ b/Tests/NukeTests/AssetTypeTests.swift
@@ -216,6 +216,21 @@ struct AssetTypeTests {
         #expect(AssetType(makeISOBaseMedia(brand: brand)) == .heic)
     }
 
+    // MARK: AVIF
+
+    @Test func detectAVIF() {
+        let data = makeISOBaseMedia(brand: "avif")
+        #expect(AssetType(data[0..<11]) == nil)
+        #expect(AssetType(data[0..<12]) == .avif)
+        #expect(AssetType(data) == .avif)
+    }
+
+    @Test(arguments: ["avif", "avis"])
+    func detectAVIFBrands(brand: String) {
+        // `avis` is the brand an AVIF image sequence uses.
+        #expect(AssetType(makeISOBaseMedia(brand: brand)) == .avif)
+    }
+
     // MARK: Edge Cases
 
     @Test func detectEmptyData() {
@@ -228,9 +243,9 @@ struct AssetTypeTests {
         #expect(AssetType(data) == nil)
     }
 
-    @Test(arguments: ["mif1", "msf1", "avif", "avis", "M4A ", "3gp4"])
+    @Test(arguments: ["mif1", "msf1", "M4A ", "3gp4"])
     func detectUnsupportedISOBaseMediaBrands(brand: String) {
-        // HEIF, AVIF, MPEG-4 audio, and 3GPP aren't formats the decoders
+        // Bare HEIF, MPEG-4 audio, and 3GPP aren't formats the decoders
         // support, so the brands they use are not recognized.
         #expect(AssetType(makeISOBaseMedia(brand: brand)) == nil)
     }
@@ -247,6 +262,7 @@ struct AssetTypeTests {
         #expect(AssetType.tiff.utType == .tiff)
         #expect(AssetType.jpeg2000.utType == UTType("public.jpeg-2000"))
         #expect(AssetType.jxl.utType == UTType("public.jpeg-xl"))
+        #expect(AssetType.avif.utType == UTType("public.avif"))
         #expect(AssetType.webp.utType == .webP)
         #expect(AssetType.mp4.utType == .mpeg4Movie)
         #expect(AssetType.m4v.utType == UTType("com.apple.m4v-video"))
@@ -256,7 +272,7 @@ struct AssetTypeTests {
     @Test func builtInTypesUseTheIdentifiersTheSystemDeclares() {
         // A type the system doesn't declare can't be bridged, so every built-in
         // type has to use the identifier the system registers for the format.
-        let types: [AssetType] = [.png, .jpeg, .gif, .heic, .ico, .bmp, .tiff, .jpeg2000, .jxl, .webp, .mp4, .m4v, .mov]
+        let types: [AssetType] = [.png, .jpeg, .gif, .heic, .ico, .bmp, .tiff, .jpeg2000, .jxl, .avif, .webp, .mp4, .m4v, .mov]
         for type in types {
             #expect(type.utType?.identifier == type.rawValue)
         }
@@ -280,7 +296,7 @@ struct AssetTypeTests {
         for type in [AssetType.mp4, .m4v, .mov] {
             #expect(type.utType?.conforms(to: .movie) == true)
         }
-        for type in [AssetType.png, .jpeg, .gif, .heic, .ico, .bmp, .tiff, .jpeg2000, .jxl, .webp] {
+        for type in [AssetType.png, .jpeg, .gif, .heic, .ico, .bmp, .tiff, .jpeg2000, .jxl, .avif, .webp] {
             #expect(type.utType?.conforms(to: .image) == true)
             #expect(type.utType?.conforms(to: .movie) == false)
         }
@@ -326,7 +342,7 @@ struct AssetTypeTests {
     /// the headers the system itself writes, and to make sure the decoder
     /// reports a type for every format it decodes. There is no JPEG XL encoder,
     /// so that format is covered by the unit tests only.
-    @Test(arguments: [AssetType.png, .jpeg, .gif, .heic, .bmp, .tiff, .jpeg2000])
+    @Test(arguments: [AssetType.png, .jpeg, .gif, .heic, .bmp, .tiff, .jpeg2000, .avif])
     func detectDataProducedByImageIO(type: AssetType) throws {
         guard let data = encode(Test.data(name: "fixture", extension: "png"), as: type) else {
             return // The platform has no encoder for this format


### PR DESCRIPTION
Follow-up to the 13.2 sniffing work, which added `bmp`, `tiff`, `jpeg2000`, and `jxl` but left AVIF out. Image I/O decodes AVIF on every OS Nuke 14 supports, so an AVIF response loaded fine while `ImageContainer/type` came back `nil`.

```swift
public static let avif: AssetType = "public.avif"
```

The sniffer already matches ISO base media files by the major brand in the `ftyp` box, so recognizing the format is two more entries in the same table:

```swift
case "avif", "avis":
    return .avif
```

`avif` is the brand for a still image, `avis` for an image sequence; both decode to a single frame with the built-in decoder, and `public.avif` covers both. Bare HEIF (`mif1`) is still unrecognized — it's ambiguous between HEIC and AVIF, and the major brand alone can't tell them apart.

`UTType` declares no `avif` constant, but the system does register the `public.avif` identifier, so `AssetType.avif.utType` bridges like every other built-in type — that's what `builtInTypesUseTheIdentifiersTheSystemDeclares` asserts.

The docs claimed AVIF sniffs as `nil` in three places (the support matrix, the format-detection caveats, and the AVIF section); all three are updated, and the encoding example no longer has to spell the identifier out by hand.

## To test

1. Run the `NukeTests` scheme on macOS — 943 tests pass, 38 of them in `AssetTypeTests`.
2. `detectDataProducedByImageIO` now covers `.avif`: it re-encodes the PNG fixture through `CGImageDestination` and checks the sniffing against the header the system itself writes. Image I/O produces `00 00 00 20 66 74 79 70 61 76 69 66` — `ftypavif` — and the round-trip through `ImageDecoders.Default` reports `.avif`. On a platform without an AVIF encoder the case skips, as it already does for the other formats.
3. Two brand tests (`detectAVIF`, `detectAVIFBrands`) cover the synthetic headers, and `avif`/`avis` are removed from `detectUnsupportedISOBaseMediaBrands`.
