### PR TITLE
Move the DataCache access date update off the calling thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fix `ImageTask/priority` updates being applied out of order, leaving the running task at a stale priority – https://github.com/kean/Nuke/pull/918
 - Fix a data race on the `DataCache` configuration properties, which the sweep reads on a background thread while they can be written from any thread – https://github.com/kean/Nuke/pull/925
 - Fix `DataCache.init` reading and decoding its metadata file on the calling thread, which is typically the main thread during app launch – https://github.com/kean/Nuke/pull/925
+- Fix `DataCache` updating the entry access date on the calling thread on every disk cache hit, which can be the main thread. The update now joins the staged changes, so the reads that arrive within the same window are written in a single pass – https://github.com/kean/Nuke/pull/927
 - Fix a data race on `DataLoader/prefersIncrementalDelivery`, which the loader reads when it creates a task while it can be written from any thread – https://github.com/kean/Nuke/pull/928
 
 # Nuke 13

--- a/Sources/Nuke/Caching/DataCache.swift
+++ b/Sources/Nuke/Caching/DataCache.swift
@@ -96,11 +96,12 @@ public final class DataCache: DataCaching, Sendable {
     /// the few threads in the cooperative pool for the entire duration of a
     /// write. The queue is serial, so the disk operations never overlap.
     ///
-    /// - important: The queue has no QoS of its own. The automatic drain is
-    /// submitted at `.utility`, while ``flush()`` and ``sweep()`` are submitted
-    /// with no QoS class so that they run at the priority of the task awaiting
-    /// them. A QoS assigned to the queue overrides the one assigned to the
-    /// blocks and would flatten both cases into one.
+    /// - important: The queue has no QoS of its own. The automatic drain and
+    /// the access date updates are submitted at `.utility`, while ``flush()``
+    /// and ``sweep()`` are submitted with no QoS class so that they run at the
+    /// priority of the task awaiting them. A QoS assigned to the queue
+    /// overrides the one assigned to the blocks and would flatten both cases
+    /// into one.
     private let ioQueue = DispatchQueue(label: "com.github.kean.Nuke.DataCache.io")
 
     private struct State {
@@ -111,11 +112,20 @@ public final class DataCache: DataCaching, Sendable {
         var isFlushScheduled = false
         /// Prevents the automatic drain from running (testing only).
         var isIOSuspended = false
+        /// The keys whose access date is yet to reach the disk.
+        var pendingTouches = Set<String>()
+        /// The number of the access date updates written (testing only).
+        var accessDateUpdateCount = 0
         var sizeLimit = 1024 * 1024 * 150
         var sweepInterval: TimeInterval = 1800
         var flushInterval: DispatchTimeInterval = .seconds(1)
         var isSweepEnabled = true
         var trimRatio = 0.7
+
+        /// There is something for the drain to write.
+        var hasPendingWork: Bool {
+            !staging.isEmpty || !pendingTouches.isEmpty
+        }
     }
 
     private struct Metadata: Codable {
@@ -182,12 +192,10 @@ public final class DataCache: DataCaching, Sendable {
                 return nil
             }
         }
-        guard var url = url(for: key), let data = try? Data(contentsOf: url) else {
+        guard let url = url(for: key), let data = try? Data(contentsOf: url) else {
             return nil
         }
-        var values = URLResourceValues()
-        values.contentAccessDate = Date()
-        try? url.setResourceValues(values)
+        touchAccessDate(for: key)
         return data
     }
 
@@ -205,6 +213,24 @@ public final class DataCache: DataCaching, Sendable {
             return false
         }
         return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    /// Refreshes the access date that the LRU sweep ranks the entries by.
+    ///
+    /// The update is a syscall that can block like any other file operation,
+    /// so it joins the staged changes instead of running on the thread that
+    /// reads the data, which can be the main one. The reads that arrive within
+    /// the same window are written in a single pass.
+    private func touchAccessDate(for key: String) {
+        state.withLock {
+            $0.pendingTouches.insert(key)
+            scheduleNextFlush(&$0)
+        }
+    }
+
+    /// The number of the access date updates written (testing only).
+    var accessDateUpdateCount: Int {
+        state.withLock { $0.accessDateUpdateCount }
     }
 
     private func change(for key: String) -> Staging.ChangeType? {
@@ -297,7 +323,7 @@ public final class DataCache: DataCaching, Sendable {
     ///
     /// - important: Must be called with the lock held.
     private func scheduleNextFlush(_ state: inout State) {
-        guard !state.isFlushScheduled, !state.isIOSuspended, !state.staging.isEmpty else { return }
+        guard !state.isFlushScheduled, !state.isIOSuspended, state.hasPendingWork else { return }
         state.isFlushScheduled = true
         // `self` is captured strongly on purpose: the staged data has to reach
         // the disk even if the client releases the cache in the meantime.
@@ -311,17 +337,17 @@ public final class DataCache: DataCaching, Sendable {
         // Create a snapshot of the recently made changes. The drain is no
         // longer scheduled, so the changes staged from here on schedule the
         // next one instead of joining the snapshot.
-        let staging: Staging? = state.withLock {
+        let work: PendingWork? = state.withLock {
             $0.isFlushScheduled = false
             guard !$0.isIOSuspended else {
                 return nil // The changes are picked up by `resumeIO()`
             }
-            return $0.staging.isEmpty ? nil : $0.staging
+            return $0.hasPendingWork ? takePendingWork(&$0) : nil
         }
-        guard let staging else { return }
+        guard let work else { return }
 
         // Apply the snapshot to disk
-        performChanges(staging)
+        performChanges(work)
 
         // Drain whatever was staged while the snapshot was being written
         state.withLock { scheduleNextFlush(&$0) }
@@ -370,14 +396,27 @@ public final class DataCache: DataCaching, Sendable {
         }
     }
 
-    /// Writes the changes staged so far. Runs on ``ioQueue``.
-    private func performPendingChanges() {
-        let staging = state.withLock { $0.staging }
-        guard !staging.isEmpty else { return }
-        performChanges(staging)
+    /// The changes and the access dates that are yet to reach the disk.
+    private typealias PendingWork = (staging: Staging, touches: Set<String>)
+
+    /// - important: Must be called with the lock held.
+    private func takePendingWork(_ state: inout State) -> PendingWork {
+        let touches = state.pendingTouches
+        state.pendingTouches.removeAll()
+        return (state.staging, touches)
     }
 
-    private func performChanges(_ staging: Staging) {
+    /// Writes the changes staged so far. Runs on ``ioQueue``.
+    private func performPendingChanges() {
+        let work: PendingWork? = state.withLock {
+            $0.hasPendingWork ? takePendingWork(&$0) : nil
+        }
+        guard let work else { return }
+        performChanges(work)
+    }
+
+    private func performChanges(_ work: PendingWork) {
+        let staging = work.staging
         autoreleasepool {
             if staging.changeRemoveAll != nil {
                 performRemoveAll()
@@ -385,8 +424,20 @@ public final class DataCache: DataCaching, Sendable {
             for change in staging.changes.values {
                 perform(change)
             }
+            performTouches(work.touches)
         }
         state.withLock { $0.staging.flushed(staging) }
+    }
+
+    private func performTouches(_ keys: Set<String>) {
+        guard !keys.isEmpty else { return }
+        var values = URLResourceValues()
+        values.contentAccessDate = Date()
+        for key in keys {
+            guard var url = url(for: key) else { continue }
+            try? url.setResourceValues(values)
+        }
+        state.withLock { $0.accessDateUpdateCount += keys.count }
     }
 
     private func perform(_ change: Staging.Change) {

--- a/Tests/NukeTests/DataCacheTests.swift
+++ b/Tests/NukeTests/DataCacheTests.swift
@@ -334,6 +334,93 @@ final class DataCacheTests {
         #expect(data == blob)
     }
 
+    @Test func readingDataUpdatesTheAccessDate() async throws {
+        // GIVEN an entry with a stale access date
+        cache["key"] = blob
+        await cache.flush()
+        let past = Date().addingTimeInterval(-1000)
+        try setAccessDate(past, for: "key")
+
+        // WHEN
+        #expect(cache.cachedData(for: "key") == blob)
+        await cache.flush() // The update runs on the I/O queue
+
+        // THEN
+        #expect(cache.accessDateUpdateCount == 1)
+        #expect(try accessDate(for: "key") > past)
+    }
+
+    @Test func theAccessDateUpdatesWithinTheFlushIntervalAreCoalesced() async {
+        // GIVEN an entry on disk and an interval long enough that the drain
+        // can't run within it
+        cache["key"] = blob
+        await cache.flush()
+        cache.flushInterval = .seconds(20)
+
+        // WHEN it is read repeatedly
+        for _ in 0..<10 {
+            #expect(cache.cachedData(for: "key") == blob)
+        }
+        await cache.flush()
+
+        // THEN the reads perform a single update between them
+        #expect(cache.accessDateUpdateCount == 1)
+    }
+
+    @Test func theAccessDateIsUpdatedAgainByTheReadsThatFollowTheDrain() async {
+        // GIVEN an entry that was already read once
+        cache["key"] = blob
+        await cache.flush()
+        _ = cache.cachedData(for: "key")
+        await cache.flush()
+
+        // WHEN it is read again
+        _ = cache.cachedData(for: "key")
+        await cache.flush()
+
+        // THEN the date doesn't go stale for as long as the entry is in use
+        #expect(cache.accessDateUpdateCount == 2)
+    }
+
+    @Test func theAccessDateIsRefreshedWithoutAnExplicitFlush() async throws {
+        // GIVEN an entry on disk and an interval short enough to keep the test quick
+        cache["key"] = blob
+        await cache.flush()
+        cache.flushInterval = .milliseconds(10)
+
+        // WHEN the read is the only thing that needs to reach the disk
+        _ = cache.cachedData(for: "key")
+
+        // THEN the drain gets to it on its own
+        while cache.accessDateUpdateCount == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    @Test func readingDataFromStagingDoesNotUpdateTheAccessDate() async {
+        // GIVEN data that is only in the staging area
+        cache.withSuspendedIO {
+            cache["key"] = blob
+
+            // WHEN/THEN there is no file to update
+            #expect(cache.cachedData(for: "key") == blob)
+        }
+        await cache.flush()
+        #expect(cache.accessDateUpdateCount == 0)
+    }
+
+    private func setAccessDate(_ date: Date, for key: String) throws {
+        var url = try #require(cache.url(for: key))
+        var values = URLResourceValues()
+        values.contentAccessDate = date
+        try url.setResourceValues(values)
+    }
+
+    private func accessDate(for key: String) throws -> Date {
+        let url = try #require(cache.url(for: key))
+        return try #require(url.resourceValues(forKeys: [.contentAccessDateKey]).contentAccessDate)
+    }
+
     // MARK: Flush
 
     @Test func flush() async {


### PR DESCRIPTION
Every disk cache hit performed a `setattrlist` syscall to refresh the entry's access date, synchronously, on whatever thread read the data:

- `TaskLoadImage.start()` – the pipeline's serial queue, where one slow syscall stalls every other task behind it
- the public `ImagePipeline.Cache.cachedData(for:)` – callable from the main thread

It was the one blocking file operation left off `ioQueue`, and the doc comment on that queue argues precisely why it doesn't belong on the caller's thread.

A read now records the key under the lock it already takes and schedules the existing drain, so the dates are written on `ioQueue` in the same pass as the staged changes, inside the same `autoreleasepool`, within the same 1-second coalescing window – the repeat reads of a key collapse into one update. It also puts them in order with the sweep, which reads those dates from that queue: `performSweep` used to read them while the readers wrote them from arbitrary threads.

One thing worth recording: `contentAccessDate` is the file's atime and the kernel bumps it on every read, so `Data(contentsOf:)` in `cachedData` already refreshes the date on APFS. The explicit update is the guarantee for the case where it doesn't. It's also why the new tests assert through an internal counter instead of the file system – a filesystem assertion passes even with the update removed entirely.

## To test

1. Run the `NukeTests` scheme – 1009 tests pass, including all 62 `DataCacheTests` (5 new ones cover the access date).
2. Run the `NukeThreadSafetyTests` scheme – 7 tests pass.