### PR TITLE
Synchronize access to DataLoader.prefersIncrementalDelivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fix `ImageTask/priority` updates being applied out of order, leaving the running task at a stale priority – https://github.com/kean/Nuke/pull/918
 - Fix a data race on the `DataCache` configuration properties, which the sweep reads on a background thread while they can be written from any thread – https://github.com/kean/Nuke/pull/925
 - Fix `DataCache.init` reading and decoding its metadata file on the calling thread, which is typically the main thread during app launch – https://github.com/kean/Nuke/pull/925
+- Fix a data race on `DataLoader/prefersIncrementalDelivery`, which the loader reads when it creates a task while it can be written from any thread – https://github.com/kean/Nuke/pull/928
 
 # Nuke 13
 

--- a/Sources/Nuke/Loading/DataLoader.swift
+++ b/Sources/Nuke/Loading/DataLoader.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+import os
 
 /// Provides basic networking using `URLSession`.
 public final class DataLoader: DataLoading, @unchecked Sendable {
@@ -12,7 +13,15 @@ public final class DataLoader: DataLoading, @unchecked Sendable {
 
     /// Determines whether to deliver a partial response body in increments. By
     /// default, `false`.
-    public var prefersIncrementalDelivery = false
+    ///
+    /// - note: The value is read when each task is created, which can happen on
+    /// any thread, so the access is synchronized.
+    public var prefersIncrementalDelivery: Bool {
+        get { _prefersIncrementalDelivery.withLock { $0 } }
+        set { _prefersIncrementalDelivery.withLock { $0 = newValue } }
+    }
+
+    private let _prefersIncrementalDelivery = OSAllocatedUnfairLock(initialState: false)
 
     /// The delegate that gets called for the callbacks handled by the data loader.
     /// You can use it for observing the session events and modifying some of the

--- a/Tests/NukeTests/DataLoaderTests.swift
+++ b/Tests/NukeTests/DataLoaderTests.swift
@@ -270,6 +270,56 @@ struct DataLoaderTests {
         for try await _ in loader.loadData(with: URLRequest(url: url)) {}
     }
 
+    @Test func prefersIncrementalDeliveryIsUpdated() async throws {
+        let loader = makeDataLoader()
+
+        loader.prefersIncrementalDelivery = true
+        #expect(loader.prefersIncrementalDelivery == true)
+
+        loader.prefersIncrementalDelivery = false
+        #expect(loader.prefersIncrementalDelivery == false)
+    }
+
+    /// The loader reads `prefersIncrementalDelivery` when each task is created,
+    /// which happens on the thread that starts the request, so writing it from
+    /// another thread has to be synchronized – otherwise the thread sanitizer
+    /// aborts the test run.
+    @Test func prefersIncrementalDeliveryIsToggledWhileLoadingData() async throws {
+        // Given
+        let loader = makeDataLoader()
+        let urls = (0..<50).map { mockURL("incr-toggle-\($0)") }
+        for url in urls {
+            registerMock(url: url, chunks: [Data("x".utf8)])
+        }
+
+        let writer = Task.detached {
+            var isEnabled = true
+            while !Task.isCancelled {
+                isEnabled.toggle()
+                loader.prefersIncrementalDelivery = isEnabled
+                await Task.yield()
+            }
+        }
+
+        // When loading data while the flag is being toggled
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for url in urls {
+                group.addTask {
+                    var received = Data()
+                    for try await (chunk, _) in loader.loadData(with: URLRequest(url: url)) {
+                        received.append(chunk)
+                    }
+                    #expect(received == Data("x".utf8))
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        // Then no data races are reported
+        writer.cancel()
+        await writer.value
+    }
+
     // MARK: - Static Validation Helper
 
     @Test func staticValidateAccepts200() {


### PR DESCRIPTION
`DataLoader.prefersIncrementalDelivery` was a plain stored `var` on an `@unchecked Sendable` class, and it's read in `loadData(with:didReceiveData:completion:)` when each `URLSessionDataTask` is created – on whichever thread starts the request. Any write from another thread races with those reads, and the pipeline writes it: `ImagePipeline.init` is `nonisolated` and sets it from `configuration.isProgressiveDecodingEnabled`, so simply creating a second pipeline that shares a `DataLoader` with a running one is enough to trip the thread sanitizer.

The property is now backed by an `OSAllocatedUnfairLock`, same as `isSignpostLoggingEnabled` in #901. The public API is unchanged – it's still a settable `Bool`. The class stays `@unchecked Sendable` because of `delegate`.

## To test

1. Run the `NukeTests` scheme – 1006 tests pass, including the two new `DataLoaderTests`.
2. Run `NukeTests/DataLoaderTests` with the thread sanitizer enabled – `prefersIncrementalDeliveryIsToggledWhileLoadingData` reports a data race on `prefersIncrementalDelivery.setter` without the fix and passes with it.
