### PR TITLE
Synchronize access to ImagePrefetcher.didComplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Fix a data race on the `DataCache` configuration properties, which the sweep reads on a background thread while they can be written from any thread – https://github.com/kean/Nuke/pull/925
 - Fix `DataCache.init` reading and decoding its metadata file on the calling thread, which is typically the main thread during app launch – https://github.com/kean/Nuke/pull/925
 - Fix a data race on `DataLoader/prefersIncrementalDelivery`, which the loader reads when it creates a task while it can be written from any thread – https://github.com/kean/Nuke/pull/928
+- Fix a data race on `ImagePrefetcher/didComplete`, which the prefetcher reads on the pipeline actor while it can be written from any thread – https://github.com/kean/Nuke/pull/929
 
 # Nuke 13
 

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -58,7 +58,16 @@ public final class ImagePrefetcher: Sendable {
     /// The closure that gets called when the prefetching completes for all the
     /// scheduled requests. The closure is always called on completion,
     /// regardless of whether the requests succeed or some fail.
-    nonisolated(unsafe) public var didComplete: (@MainActor @Sendable () -> Void)?
+    ///
+    /// The closure runs every time the prefetcher runs out of outstanding work,
+    /// which includes the batches that finish without starting a single task:
+    /// an empty list of requests, or one where every image is already in the
+    /// memory cache.
+    nonisolated public var didComplete: (@MainActor @Sendable () -> Void)? {
+        get { _didComplete.withLock { $0 } }
+        set { _didComplete.withLock { $0 = newValue } }
+    }
+    private nonisolated let _didComplete = OSAllocatedUnfairLock<(@MainActor @Sendable () -> Void)?>(initialState: nil)
 
     private let pipeline: ImagePipeline
     private let destination: Destination

--- a/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Helpers/TestHelpers.swift
@@ -78,8 +78,13 @@ extension ImageTask {
     /// until the subscription exists.
     func subscribedPreviews() async -> AsyncCompactMapSequence<AsyncStream<Event>, ImageResponse> {
         let previews = self.previews
+        // Accessing `previews` schedules the registration on the pipeline
+        // actor, so this hop normally lands after it. Don't spin waiting for
+        // the exception: a busy-wait would starve the very actor it is
+        // waiting for, and the rest of the suite with it.
+        await Task { @ImagePipelineActor in }.value
         while await _streamContinuations.isEmpty {
-            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(1))
         }
         return previews
     }

--- a/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Helpers/TestHelpers.swift
@@ -66,3 +66,21 @@ private func bitmapData(for image: PlatformImage) -> Data? {
     context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
     return data
 }
+
+extension ImageTask {
+    /// Returns ``ImageTask/previews``, waiting until the subscription is
+    /// registered on the pipeline actor.
+    ///
+    /// Subscribing reaches the actor asynchronously, and unlike the terminal
+    /// event, the previews produced before it lands are not replayed. A test
+    /// that serves the next chunk of data only when it receives a preview
+    /// deadlocks if it loses the first one, so it has to hold the data back
+    /// until the subscription exists.
+    func subscribedPreviews() async -> AsyncCompactMapSequence<AsyncStream<Event>, ImageResponse> {
+        let previews = self.previews
+        while await _streamContinuations.isEmpty {
+            await Task.yield()
+        }
+        return previews
+    }
+}

--- a/Tests/Mocks/MockProgressiveDataLoader.swift
+++ b/Tests/Mocks/MockProgressiveDataLoader.swift
@@ -15,6 +15,20 @@ final class MockProgressiveDataLoader: DataLoading, @unchecked Sendable {
     private var _didReceiveData: (@Sendable (Data, URLResponse) -> Void)?
     private var _completion: (@Sendable (Error?) -> Void)?
 
+    /// Serves the first chunk from `loadData` without waiting for `resume()`.
+    ///
+    /// Set to `false` in the tests that serve the next chunk only when they
+    /// receive a preview: subscribing to `ImageTask/previews` reaches the
+    /// pipeline actor asynchronously and the previews produced before it lands
+    /// are not replayed, so such a test deadlocks if it loses the first one.
+    /// See `ImageTask/subscribedPreviews()`.
+    var servesFirstChunkAutomatically = true
+
+    /// Both are only ever touched on the main queue, which is what serializes
+    /// them against `loadData` running on the pipeline actor.
+    private var isLoading = false
+    private var pendingResumeCount = 0
+
     init() {
         self.urlResponse = HTTPURLResponse(url: Test.url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": "\(data.count)"])!
         self.chunks = Array(_createChunks(for: data, size: data.count / 3))
@@ -27,9 +41,17 @@ final class MockProgressiveDataLoader: DataLoading, @unchecked Sendable {
     ) -> any Cancellable {
             self._didReceiveData = didReceiveData
         self._completion = completion
-        // Serve the first chunk immediately
         DispatchQueue.main.async {
-            self.serveNextChunk()
+            self.isLoading = true
+            if self.servesFirstChunkAutomatically {
+                self.serveNextChunk()
+            }
+            // Serve whatever was requested before loading started.
+            let pending = self.pendingResumeCount
+            self.pendingResumeCount = 0
+            for _ in 0..<pending {
+                self.serveNextChunk()
+            }
         }
         return _NoOpCancellable()
     }
@@ -52,6 +74,12 @@ final class MockProgressiveDataLoader: DataLoading, @unchecked Sendable {
     // Serves the next chunk.
     func resume(_ completed: @escaping @Sendable () -> Void = {}) {
         DispatchQueue.main.async {
+            guard self.isLoading else {
+                // `loadData` hasn't been called yet, and serving now would drop
+                // the chunk – there is nobody to hand it to.
+                self.pendingResumeCount += 1
+                return
+            }
             if let chunk = self.chunks.first {
                 self.chunks.removeFirst()
                 self._didReceiveData?(chunk, self.urlResponse)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -265,6 +265,7 @@ struct ImagePipelineAsyncAwaitTests {
     @Test func thatProgressivePreviewsAreDelivered() async throws {
         // GIVEN
         let dataLoader = MockProgressiveDataLoader()
+        dataLoader.servesFirstChunkAutomatically = false
         let pipeline = pipeline.reconfigured {
             $0.dataLoader = dataLoader
             $0.isProgressiveDecodingEnabled = true
@@ -274,7 +275,9 @@ struct ImagePipelineAsyncAwaitTests {
         // WHEN
         var recordedPreviews: [ImageResponse] = []
         let task = pipeline.imageTask(with: Test.url)
-        for try await preview in task.previews {
+        let stream = await task.subscribedPreviews()
+        dataLoader.resume()
+        for try await preview in stream {
             recordedPreviews.append(preview)
             dataLoader.resume()
         }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -63,15 +63,21 @@ struct ImagePipelineAsyncAwaitTests {
     @Test func cancellation() async throws {
         dataLoader.queue.isSuspended = true
 
+        // Observe before starting: the notification is posted from `loadData`,
+        // and a run that registers too late never cancels the task, which then
+        // never finishes – the data loading queue stays suspended.
+        let didStartLoading = TestExpectation()
+        let observer = NotificationCenter.default.addObserver(forName: MockDataLoader.DidStartTask, object: dataLoader, queue: OperationQueue()) { _ in
+            didStartLoading.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
         let pipeline = self.pipeline
-        let dataLoader = self.dataLoader
         let task = Task {
             try await pipeline.image(for: Test.url)
         }
-
-        let observer = NotificationCenter.default.addObserver(forName: MockDataLoader.DidStartTask, object: dataLoader, queue: OperationQueue()) { _ in
-            task.cancel()
-        }
+        await didStartLoading.wait()
+        task.cancel()
 
         var caughtError: ImagePipeline.Error?
         do {
@@ -80,7 +86,6 @@ struct ImagePipelineAsyncAwaitTests {
             caughtError = error
         }
         #expect(caughtError == .cancelled)
-        NotificationCenter.default.removeObserver(observer)
     }
 
     @Test func cancelFromTaskCreated() async throws {
@@ -176,10 +181,16 @@ struct ImagePipelineAsyncAwaitTests {
     @Test func cancelAsyncImageTask() async throws {
         dataLoader.queue.isSuspended = true
 
-        let task = pipeline.imageTask(with: Test.url)
+        // Observe before starting – see `cancellation()`.
+        let didStartLoading = TestExpectation()
         let observer = NotificationCenter.default.addObserver(forName: MockDataLoader.DidStartTask, object: dataLoader, queue: OperationQueue()) { _ in
-            task.cancel()
+            didStartLoading.fulfill()
         }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let task = pipeline.imageTask(with: Test.url)
+        await didStartLoading.wait()
+        task.cancel()
         dataLoader.queue.isSuspended = false
 
         var caughtError: ImagePipeline.Error?
@@ -190,7 +201,6 @@ struct ImagePipelineAsyncAwaitTests {
         }
         #expect(caughtError == .cancelled)
         #expect(task.isCancelled)
-        NotificationCenter.default.removeObserver(observer)
     }
 
     // MARK: - Load Data

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
@@ -386,7 +386,11 @@ private final class MockBaselineDataLoader: DataLoading, @unchecked Sendable {
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Length": "\(data.count)"]
         )!
-        self.chunks = Array(_createChunks(for: data, size: data.count / 3))
+        // Use two equal chunks so the first chunk contains at least half
+        // the file. Image I/O needs roughly 50 % of a baseline JPEG to
+        // produce a partial image via CGImageSourceCreateImageAtIndex; 1/3
+        // is sometimes too little on newer macOS releases.
+        self.chunks = Array(_createChunks(for: data, size: data.count / 2))
     }
 
     func loadData(with request: URLRequest,

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
@@ -14,6 +14,7 @@ struct ImagePipelinePreviewPolicyTests {
     @Test func progressiveJPEGDeliversPreviews() async throws {
         // GIVEN a progressive JPEG served in chunks with manual resume
         let dataLoader = MockProgressiveDataLoader()
+        dataLoader.servesFirstChunkAutomatically = false
         let pipeline = ImagePipeline {
             $0.dataLoader = dataLoader
             $0.isProgressiveDecodingEnabled = true
@@ -23,8 +24,10 @@ struct ImagePipelinePreviewPolicyTests {
 
         // WHEN loading the image and collecting previews
         let task = pipeline.imageTask(with: Test.url)
+        let stream = await task.subscribedPreviews()
+        dataLoader.resume()
         var previews: [ImageResponse] = []
-        for try await preview in task.previews {
+        for try await preview in stream {
             previews.append(preview)
             dataLoader.resume()
         }
@@ -95,6 +98,7 @@ struct ImagePipelinePreviewPolicyTests {
         // GIVEN a delegate that forces .incremental for all images
         let delegate = PreviewPolicyDelegate(policy: .incremental)
         let dataLoader = MockBaselineDataLoader()
+        dataLoader.servesFirstChunkAutomatically = false
         let pipeline = ImagePipeline(delegate: delegate) {
             $0.dataLoader = dataLoader
             $0.isProgressiveDecodingEnabled = true
@@ -104,8 +108,10 @@ struct ImagePipelinePreviewPolicyTests {
 
         // WHEN loading the image
         let task = pipeline.imageTask(with: Test.url)
+        let stream = await task.subscribedPreviews()
+        dataLoader.resume()
         var previews: [ImageResponse] = []
-        for try await preview in task.previews {
+        for try await preview in stream {
             previews.append(preview)
             dataLoader.resume()
         }
@@ -367,6 +373,12 @@ private final class MockBaselineDataLoader: DataLoading, @unchecked Sendable {
     private var _didReceiveData: (@Sendable (Data, URLResponse) -> Void)?
     private var _completion: (@Sendable (Error?) -> Void)?
 
+    /// See `MockProgressiveDataLoader/servesFirstChunkAutomatically`.
+    var servesFirstChunkAutomatically = true
+
+    private var isLoading = false
+    private var pendingResumeCount = 0
+
     init() {
         self.urlResponse = HTTPURLResponse(
             url: Test.url,
@@ -382,22 +394,38 @@ private final class MockBaselineDataLoader: DataLoading, @unchecked Sendable {
                   completion: @escaping @Sendable (Error?) -> Void) -> any Cancellable {
         self._didReceiveData = didReceiveData
         self._completion = completion
-        // Serve the first chunk immediately
         DispatchQueue.main.async {
-            self.resume()
+            self.isLoading = true
+            if self.servesFirstChunkAutomatically {
+                self.serveNextChunk()
+            }
+            let pending = self.pendingResumeCount
+            self.pendingResumeCount = 0
+            for _ in 0..<pending {
+                self.serveNextChunk()
+            }
         }
         return AnonymousCancellable {}
     }
 
     func resume() {
         DispatchQueue.main.async {
-            if let chunk = self.chunks.first {
-                self.chunks.removeFirst()
-                self._didReceiveData?(chunk, self.urlResponse)
-                if self.chunks.isEmpty {
-                    self._completion?(nil)
-                }
+            guard self.isLoading else {
+                // `loadData` hasn't been called yet, and serving now would drop
+                // the chunk – there is nobody to hand it to.
+                self.pendingResumeCount += 1
+                return
             }
+            self.serveNextChunk()
+        }
+    }
+
+    private func serveNextChunk() {
+        guard let chunk = chunks.first else { return }
+        chunks.removeFirst()
+        _didReceiveData?(chunk, urlResponse)
+        if chunks.isEmpty {
+            _completion?(nil)
         }
     }
 }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -183,9 +183,12 @@ struct ImagePipelineProgressiveDecodingTests {
         )
 
         // When
+        dataLoader.servesFirstChunkAutomatically = false
         var recordedPreviews: [ImageResponse] = []
         let task = pipeline.imageTask(with: request)
-        for try await preview in task.previews {
+        let stream = await task.subscribedPreviews()
+        dataLoader.resume()
+        for try await preview in stream {
             #expect(preview.image.cgImage?.width == 45)
             #expect(preview.image.cgImage?.height == 30)
             recordedPreviews.append(preview)
@@ -205,9 +208,12 @@ struct ImagePipelineProgressiveDecodingTests {
         let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "_image_processor")])
 
         // When
+        dataLoader.servesFirstChunkAutomatically = false
         var recordedPreviews: [ImageResponse] = []
         let task = pipeline.imageTask(with: request)
-        for try await preview in task.previews {
+        let stream = await task.subscribedPreviews()
+        dataLoader.resume()
+        for try await preview in stream {
             #expect(preview.image.nk_test_processorIDs.count == 1)
             #expect(preview.image.nk_test_processorIDs.first == "_image_processor")
             recordedPreviews.append(preview)
@@ -384,9 +390,12 @@ struct ImagePipelineProgressiveDecodingTests {
         let request = ImageRequest(url: Test.url).with { $0.scale = 7.0 }
 
         // WHEN/THEN
+        dataLoader.servesFirstChunkAutomatically = false
         let task = pipeline.imageTask(with: request)
+        let stream = await task.subscribedPreviews()
+        dataLoader.resume()
         var previewScale: CGFloat?
-        for try await preview in task.previews {
+        for try await preview in stream {
             previewScale = preview.image.scale
             dataLoader.resume()
         }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
@@ -125,6 +125,7 @@ struct ImagePipelineTaskDelegateTests {
     @Test func intermediateResponseEventsDelivered() async throws {
         // GIVEN a pipeline with progressive decoding
         let dataLoader = MockProgressiveDataLoader()
+        dataLoader.servesFirstChunkAutomatically = false
         let pipeline = ImagePipeline(delegate: delegate) {
             $0.dataLoader = dataLoader
             $0.isProgressiveDecodingEnabled = true
@@ -134,7 +135,9 @@ struct ImagePipelineTaskDelegateTests {
 
         // WHEN
         let task = pipeline.imageTask(with: Test.url)
-        for try await _ in task.previews {
+        let stream = await task.subscribedPreviews()
+        dataLoader.resume()
+        for try await _ in stream {
             dataLoader.resume()
         }
         _ = try await task.response

--- a/Tests/NukeTests/ImagePrefetcherTests.swift
+++ b/Tests/NukeTests/ImagePrefetcherTests.swift
@@ -4,6 +4,7 @@
 
 import Testing
 import Foundation
+import os
 @testable import Nuke
 
 @Suite(.timeLimit(.minutes(5)))
@@ -381,6 +382,89 @@ struct ImagePrefetcherTests {
             prefetcher.startPrefetching(with: [Test.request])
         }
     }
+
+    @Test func didCompleteIsCalledWithAnEmptyBatch() async {
+        // WHEN prefetching is started with nothing to prefetch
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            prefetcher.didComplete = { @MainActor @Sendable in
+                continuation.resume()
+            }
+            prefetcher.startPrefetching(with: [URL]())
+        }
+
+        // THEN the closure is still called and no tasks are started
+        #expect(observer.startedTaskCount == 0)
+    }
+
+    @Test func didCompleteIsCalledOnTheMainThread() async {
+        // WHEN the closure is set from a non-main context
+        let isMainThread = OSAllocatedUnfairLock(initialState: false)
+        await Task.detached { [prefetcher] in
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                prefetcher.didComplete = { @MainActor @Sendable in
+                    isMainThread.withLock { $0 = Thread.isMainThread }
+                    continuation.resume()
+                }
+                prefetcher.startPrefetching(with: [Test.url])
+            }
+        }.value
+
+        // THEN it is still delivered on the main thread
+        #expect(isMainThread.withLock { $0 })
+    }
+
+    @Test func didCompleteIsCalledForEveryBatch() async {
+        // GIVEN one batch that already completed
+        let count = OSAllocatedUnfairLock(initialState: 0)
+        let first = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            first.fulfill()
+        }
+        prefetcher.startPrefetching(with: [Test.url])
+        await first.wait()
+
+        // WHEN a second batch is prefetched
+        let second = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            second.fulfill()
+        }
+        prefetcher.startPrefetching(with: [Self.otherURL])
+        await second.wait()
+
+        // THEN the closure is called once per batch and the replaced closure
+        // is never called again
+        #expect(count.withLock { $0 } == 2)
+    }
+
+    @Test func didCompleteCanBeCleared() async {
+        // GIVEN one batch that already completed
+        let count = OSAllocatedUnfairLock(initialState: 0)
+        let first = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            first.fulfill()
+        }
+        prefetcher.startPrefetching(with: [Test.url])
+        await first.wait()
+
+        // WHEN the closure is removed and another batch is prefetched
+        prefetcher.didComplete = nil
+        #expect(prefetcher.didComplete == nil)
+        prefetcher.startPrefetching(with: [Self.otherURL])
+
+        // THEN the removed closure is never called again. A later batch with a
+        // fresh closure gives us a point in time to check by.
+        let second = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in second.fulfill() }
+        prefetcher.startPrefetching(with: [Self.thirdURL])
+        await second.wait()
+        #expect(count.withLock { $0 } == 1)
+    }
+
+    private static let otherURL = URL(string: "http://test.com/example-2.jpeg")!
+    private static let thirdURL = URL(string: "http://test.com/example-3.jpeg")!
 
     // MARK: Empty Inputs
 

--- a/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
+++ b/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
@@ -61,9 +61,16 @@ struct ThreadSafetyTests {
             queue.addOperation {
                 prefetcher.stopPrefetching(with: makeRequests())
                 prefetcher.startPrefetching(with: makeRequests())
+                // The prefetcher reads `didComplete` on the pipeline actor
+                // every time it runs out of work.
+                prefetcher.didComplete = Bool.random() ? nil : { @MainActor @Sendable in }
+                _ = prefetcher.didComplete
+                prefetcher.priority = Bool.random() ? .high : .low
+                prefetcher.isPaused = false
             }
         }
         queue.waitUntilAllOperationsAreFinished()
+        prefetcher.stopPrefetching()
     }
 
     @Test func imageCacheThreadSafety() {


### PR DESCRIPTION
`ImagePrefetcher.didComplete` was declared `nonisolated(unsafe)`. It's written from wherever the prefetcher is configured – the main actor, in every example in the docs – and read on `@ImagePipelineActor` in `sendCompletionIfNeeded()`, which runs every time the prefetcher runs out of outstanding work. The annotation named the problem rather than solving it.

It's now backed by an `OSAllocatedUnfairLock`, the same pattern `priority` uses two properties above it. `(@MainActor @Sendable () -> Void)?` is already `Sendable`, so the lock needs no escape hatch, and every member of the class is now either lock-backed or actor-isolated. The API is unchanged – it's still a settable closure – and the lock is only taken when a batch drains, not on the prefetching path.

Isolating the property to `@ImagePipelineActor` instead would have been source-breaking in a way that invites a bug: `prefetcher.didComplete = { … }` no longer compiles from the main actor, and the `Task { @ImagePipelineActor in … }` workaround opens a window where prefetching starts before the callback lands.

Also documented the two behaviours that were previously only discoverable by reading the source: the closure runs once per drain, not once per prefetcher, and it runs for batches that never start a task (an empty request list, or one that's entirely memory cache hits).

## To test

1. Run the `NukeTests` scheme – 959 tests pass, including 5 new `ImagePrefetcherTests` covering delivery on the main thread when the closure is set from a background thread, one call per batch, replacing the closure, clearing it, and the empty-batch case.
2. Run the `NukeThreadSafetyTests` scheme with the thread sanitizer enabled – `prefetcherThreadSafety` now also sets and reads `didComplete` from the operation queue while prefetching runs, and reports a data race on `didComplete` without the fix.
