### PR TITLE
Make the DataCache LRU sweep periodic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Fix `DataCache.init` reading and decoding its metadata file on the calling thread, which is typically the main thread during app launch – https://github.com/kean/Nuke/pull/925
 - Fix `DataCache` updating the entry access date on the calling thread on every disk cache hit, which can be the main thread. The update now joins the staged changes, so the reads that arrive within the same window are written in a single pass – https://github.com/kean/Nuke/pull/927
 - Fix a data race on `DataLoader/prefersIncrementalDelivery`, which the loader reads when it creates a task while it can be written from any thread – https://github.com/kean/Nuke/pull/928
+- Fix `DataCache` sweeping only once per launch instead of every `DataCache/sweepInterval`, letting a long-running app grow the cache past its `DataCache/sizeLimit` until the next launch – https://github.com/kean/Nuke/pull/930
 
 # Nuke 13
 

--- a/Sources/Nuke/Caching/DataCache.swift
+++ b/Sources/Nuke/Caching/DataCache.swift
@@ -9,7 +9,8 @@ import os
 ///
 /// ``DataCache`` uses LRU cleanup policy (least recently used items are removed
 /// first). The elements stored in the cache are automatically discarded if
-/// the size limit is reached. The sweeps are performed periodically.
+/// the size limit is reached. The sweeps are performed periodically for as
+/// long as the cache is alive, see ``DataCache/sweepInterval``.
 ///
 /// DataCache always writes and removes data asynchronously. It also allows for
 /// reading and writing data in parallel. It is implemented using a staging
@@ -44,12 +45,18 @@ public final class DataCache: DataCaching, Sendable {
     }
 
     /// The time interval between cache sweeps. The default value is 30 minutes.
+    ///
+    /// The first sweep runs shortly after the initialization and is skipped if
+    /// one was already performed within the interval, e.g. by the previous launch.
     public var sweepInterval: TimeInterval {
         get { state.withLock { $0.sweepInterval } }
         set { state.withLock { $0.sweepInterval = newValue } }
     }
 
     /// If `false`, the automatic LRU sweep is disabled. The default value is `true`.
+    ///
+    /// The scheduled sweeps are skipped while it is off, so turning it back on
+    /// resumes them within ``sweepInterval``.
     public var isSweepEnabled: Bool {
         get { state.withLock { $0.isSweepEnabled } }
         set { state.withLock { $0.isSweepEnabled = newValue } }
@@ -86,7 +93,6 @@ public final class DataCache: DataCaching, Sendable {
     private let state = OSAllocatedUnfairLock(initialState: State())
 
     private let filenameGenerator: FilenameGenerator
-    private let sweepDelay: DispatchTimeInterval
     private let onSweepCompleted: (@Sendable () -> Void)?
 
     /// The serial queue that all of the disk I/O runs on.
@@ -148,30 +154,34 @@ public final class DataCache: DataCaching, Sendable {
     /// - parameter filenameGenerator: Generates a filename for the given URL.
     /// The default implementation generates a filename using SHA1 hash function.
     public convenience init(path: URL, filenameGenerator: @escaping FilenameGenerator = DataCache.filename(for:)) throws {
-        try self.init(path: path, filenameGenerator: filenameGenerator, sweepDelay: .seconds(5), onSweepCompleted: nil)
+        try self.init(path: path, filenameGenerator: filenameGenerator, sweepDelay: .seconds(5), sweepInterval: nil, onSweepCompleted: nil)
     }
 
     convenience init(
         name: String,
         filenameGenerator: @escaping FilenameGenerator = DataCache.filename(for:),
         sweepDelay: DispatchTimeInterval,
+        sweepInterval: TimeInterval? = nil,
         onSweepCompleted: @escaping @Sendable () -> Void
     ) throws {
-        try self.init(path: URL.cachesDirectory.appendingPathComponent(name, isDirectory: true), filenameGenerator: filenameGenerator, sweepDelay: sweepDelay, onSweepCompleted: onSweepCompleted)
+        try self.init(path: URL.cachesDirectory.appendingPathComponent(name, isDirectory: true), filenameGenerator: filenameGenerator, sweepDelay: sweepDelay, sweepInterval: sweepInterval, onSweepCompleted: onSweepCompleted)
     }
 
     private init(
         path: URL,
         filenameGenerator: @escaping FilenameGenerator,
         sweepDelay: DispatchTimeInterval,
+        sweepInterval: TimeInterval?,
         onSweepCompleted: (@Sendable () -> Void)?
     ) throws {
         self.path = path
         self.filenameGenerator = filenameGenerator
-        self.sweepDelay = sweepDelay
         self.onSweepCompleted = onSweepCompleted
+        if let sweepInterval { // Testing only
+            state.withLock { $0.sweepInterval = sweepInterval }
+        }
         try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true, attributes: nil)
-        scheduleSweep()
+        scheduleSweep(deadline: .now() + sweepDelay)
     }
 
     /// A ``FilenameGenerator`` implementation that uses SHA1 to generate a
@@ -470,17 +480,25 @@ public final class DataCache: DataCaching, Sendable {
 
     // MARK: Sweep
 
-    /// Schedules the sweep that runs on launch. It is performed only if one
-    /// hasn't been performed recently (see ``DataCache/sweepInterval``).
-    private func scheduleSweep() {
-        // Add a bit of a delay to free the resources during launch.
-        ioQueue.asyncAfter(deadline: .now() + sweepDelay, qos: .utility) { [weak self] in
-            guard let self, isSweepEnabled, isSweepNeeded() else { return }
-            performPendingChanges() // The sweep has to see the staged writes
-            performSweep()
-            updateMetadata { $0.lastSweepDate = Date() }
-            onSweepCompleted?()
+    /// Schedules the next sweep. The first one runs after a small delay to free
+    /// the resources during launch, the rest every ``DataCache/sweepInterval``.
+    private func scheduleSweep(deadline: DispatchTime) {
+        // `self` is captured weakly: the repeating sweep must not keep the cache alive.
+        ioQueue.asyncAfter(deadline: deadline, qos: .utility) { [weak self] in
+            guard let self else { return }
+            performScheduledSweep()
+            scheduleSweep(deadline: .now() + sweepInterval) // Also when skipped
         }
+    }
+
+    /// Performs the sweep unless it is disabled or one has already been
+    /// performed within the last ``DataCache/sweepInterval``. Runs on ``ioQueue``.
+    private func performScheduledSweep() {
+        guard isSweepEnabled, isSweepNeeded() else { return }
+        performPendingChanges() // The sweep has to see the staged writes
+        performSweep()
+        updateMetadata { $0.lastSweepDate = Date() }
+        onSweepCompleted?()
     }
 
     private func isSweepNeeded() -> Bool {

--- a/Tests/NukeTests/DataCacheTests.swift
+++ b/Tests/NukeTests/DataCacheTests.swift
@@ -11,6 +11,29 @@ private let blob = "123".data(using: .utf8)
 private let otherBlob = "456".data(using: .utf8)
 private let trafficKeyCount = 10
 
+/// Counts the sweeps that a cache performs and lets a test wait for them.
+private final class SweepCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int { lock.withLock { count } }
+
+    func record() {
+        lock.withLock { count += 1 }
+    }
+
+    func wait(for target: Int, timeout: Duration = .seconds(10)) async {
+        let deadline = ContinuousClock.now + timeout
+        while value < target {
+            guard ContinuousClock.now < deadline else {
+                Issue.record("Timed out waiting for \(target) sweeps, performed \(value)")
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
 @Suite(.timeLimit(.minutes(5)))
 final class DataCacheTests {
     private let cache: DataCache
@@ -853,6 +876,73 @@ final class DataCacheTests {
         // THEN the sweep never ran, so it never stamped its metadata either
         let metadataURL = cache.path.appendingPathComponent(".data-cache-info")
         #expect(!FileManager.default.fileExists(atPath: metadataURL.path))
+    }
+
+    @Test func scheduledSweepRepeatsOnTheSweepInterval() async throws {
+        // GIVEN a cache that sweeps every 50 ms
+        let counter = SweepCounter()
+        let cache = try DataCache(
+            name: UUID().uuidString,
+            filenameGenerator: { String($0.reversed()) },
+            sweepDelay: .milliseconds(0),
+            sweepInterval: 0.05,
+            onSweepCompleted: { counter.record() }
+        )
+        defer { try? FileManager.default.removeItem(at: cache.path) }
+
+        // THEN the sweeps keep coming instead of stopping after the first one
+        await counter.wait(for: 3)
+        cache.isSweepEnabled = false
+    }
+
+    @Test func periodicSweepTrimsTheDataWrittenAfterTheFirstSweep() async throws {
+        // GIVEN a long-lived cache that has already performed its first sweep
+        let mb = 1024 * 1024
+        let counter = SweepCounter()
+        let cache = try DataCache(
+            name: UUID().uuidString,
+            filenameGenerator: { String($0.reversed()) },
+            sweepDelay: .milliseconds(0),
+            sweepInterval: 0.05,
+            onSweepCompleted: { counter.record() }
+        )
+        defer { try? FileManager.default.removeItem(at: cache.path) }
+        cache.sizeLimit = mb * 3
+        await counter.wait(for: 1)
+
+        // WHEN more data than the limit fits is written after that sweep
+        for index in 1...5 {
+            cache["key\(index)"] = Data(repeating: UInt8(index), count: mb)
+        }
+        await cache.flush()
+
+        // THEN one of the sweeps that follow brings the cache back under it
+        await counter.wait(for: counter.value + 2)
+        #expect(cache.totalSize <= mb * 3)
+        cache.isSweepEnabled = false
+    }
+
+    @Test func scheduledSweepResumesWhenItIsReEnabled() async throws {
+        // GIVEN a cache with the sweep turned off before the first one runs
+        let counter = SweepCounter()
+        let cache = try DataCache(
+            name: UUID().uuidString,
+            filenameGenerator: { String($0.reversed()) },
+            sweepDelay: .milliseconds(50),
+            sweepInterval: 0.05,
+            onSweepCompleted: { counter.record() }
+        )
+        defer { try? FileManager.default.removeItem(at: cache.path) }
+        cache.isSweepEnabled = false
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(counter.value == 0)
+
+        // WHEN it's turned back on
+        cache.isSweepEnabled = true
+
+        // THEN the sweeps that were skipped didn't take the schedule with them
+        await counter.wait(for: 1)
+        cache.isSweepEnabled = false
     }
 
     @Test func scheduledSweepRunsWhenTheLastOneIsOlderThanTheInterval() async throws {


### PR DESCRIPTION
`DataCache.scheduleSweep()` ran once, `sweepDelay` after the initialization, and was never scheduled again. An app that stays alive for days – common on iOS with heavy image traffic, the norm on macOS – swept the cache once per launch, no matter how much data was written after that, so the cache could grow past its `sizeLimit` without a bound until the next launch.

Both the class documentation ("The sweeps are performed periodically") and `sweepInterval` ("The time interval between cache sweeps") described the periodic behavior the code no longer had.

The sweep now re-schedules itself on `sweepInterval` when it finishes:

- `self` is still captured weakly, so the repeating sweep doesn't keep the cache alive and stops re-scheduling itself once the client releases it. At most one block is pending at a time.
- The next sweep is scheduled even when the current one is skipped, so turning `isSweepEnabled` back on takes effect within `sweepInterval` instead of requiring a relaunch.
- The metadata gate is unchanged: a sweep is performed only if one hasn't been performed within the last `sweepInterval`, by the previous launch or by another instance managing the same directory.

The documentation for `sweepInterval` and `isSweepEnabled` now spells out when the first sweep runs and what happens to the skipped ones.

## Testing

Three tests, each of which fails without the re-schedule:

- `scheduledSweepRepeatsOnTheSweepInterval` – the sweeps keep coming instead of stopping after the first one.
- `periodicSweepTrimsTheDataWrittenAfterTheFirstSweep` – 5 MB written into a 3 MB cache after its first sweep is brought back under the limit by a later one (it stays at 5 MB on `main`).
- `scheduledSweepResumesWhenItIsReEnabled` – the skipped sweeps don't take the schedule with them.

`NukeTests` (963 tests) and `NukeThreadSafetyTests` pass on macOS.