### PR TITLE
Add ImagePrefetcher.events and waitUntilIdle()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `ImageTask` now conforms to `Identifiable` – https://github.com/kean/Nuke/pull/922
 - `DataCache` is now `Sendable` instead of `@unchecked Sendable`: all of its mutable state, including the configuration properties, is guarded by a single lock. `DataCache/flush()` and `DataCache/sweep()` are now `async`, and `DataCache/queue` and `flush(for:)` are removed – https://github.com/kean/Nuke/pull/925
 - Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
+- Add `ImagePrefetcher/events`, a stream reporting which requests the prefetcher started, how each one finished, and when it ran out of work, and `ImagePrefetcher/waitUntilIdle()` built on top of it – https://github.com/kean/Nuke/pull/930
 
 **Bug Fixes**
 
@@ -46,6 +47,7 @@
 - Fix `DataCache.init` reading and decoding its metadata file on the calling thread, which is typically the main thread during app launch – https://github.com/kean/Nuke/pull/925
 - Fix a data race on `DataLoader/prefersIncrementalDelivery`, which the loader reads when it creates a task while it can be written from any thread – https://github.com/kean/Nuke/pull/928
 - Fix a data race on `ImagePrefetcher/didComplete`, which the prefetcher reads on the pipeline actor while it can be written from any thread – https://github.com/kean/Nuke/pull/929
+- Fix `ImagePrefetcher/didComplete` not being called when the outstanding requests are cancelled with `stopPrefetching`, and being called while another batch was already scheduled – https://github.com/kean/Nuke/pull/930
 
 # Nuke 13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - `ImageTask` now conforms to `Identifiable` – https://github.com/kean/Nuke/pull/922
 - `DataCache` is now `Sendable` instead of `@unchecked Sendable`: all of its mutable state, including the configuration properties, is guarded by a single lock. `DataCache/flush()` and `DataCache/sweep()` are now `async`, and `DataCache/queue` and `flush(for:)` are removed – https://github.com/kean/Nuke/pull/925
 - Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
-- Add `ImagePrefetcher/events`, a stream reporting which requests the prefetcher started, how each one finished, and when it ran out of work, and `ImagePrefetcher/waitUntilIdle()` built on top of it – https://github.com/kean/Nuke/pull/930
+- Add `ImagePrefetcher/events`, a stream reporting which requests the prefetcher started, how each one finished, and when it ran out of work, and `ImagePrefetcher/waitUntilIdle()` built on top of it – https://github.com/kean/Nuke/pull/931
 
 **Bug Fixes**
 
@@ -47,7 +47,7 @@
 - Fix `DataCache.init` reading and decoding its metadata file on the calling thread, which is typically the main thread during app launch – https://github.com/kean/Nuke/pull/925
 - Fix a data race on `DataLoader/prefersIncrementalDelivery`, which the loader reads when it creates a task while it can be written from any thread – https://github.com/kean/Nuke/pull/928
 - Fix a data race on `ImagePrefetcher/didComplete`, which the prefetcher reads on the pipeline actor while it can be written from any thread – https://github.com/kean/Nuke/pull/929
-- Fix `ImagePrefetcher/didComplete` not being called when the outstanding requests are cancelled with `stopPrefetching`, and being called while another batch was already scheduled – https://github.com/kean/Nuke/pull/930
+- Fix `ImagePrefetcher/didComplete` not being called when the outstanding requests are cancelled with `stopPrefetching`, and being called while another batch was already scheduled – https://github.com/kean/Nuke/pull/931
 
 # Nuke 13
 

--- a/Documentation/Nuke.docc/Performance/prefetching.md
+++ b/Documentation/Nuke.docc/Performance/prefetching.md
@@ -74,5 +74,31 @@ To start prefetching, call ``ImagePrefetcher/startPrefetching(with:)-718dg`` met
 
 The prefetcher automatically cancels all of the outstanding tasks when deallocated. All ``ImagePrefetcher`` methods are thread-safe and are optimized to be used even from the main thread during scrolling.
 
+## Observing the prefetcher
+
+``ImagePrefetcher/events`` reports what the prefetcher is doing: which requests it started, how each one finished, and when it ran out of work. It's the place to measure how well prefetching is working – how many of the scheduled requests were already cached, and which ones failed.
+
+```swift
+for await event in prefetcher.events {
+    switch event {
+    case .didStartPrefetching(let request):
+        metrics.recordPrefetchStarted(for: request)
+    case .didFinishPrefetching(let request, let result):
+        metrics.recordPrefetchFinished(for: request, result: result)
+    case .didComplete:
+        break
+    }
+}
+```
+
+If all you need is to know when the prefetcher is done, use ``ImagePrefetcher/waitUntilIdle()``, which returns on the first ``ImagePrefetcher/Event/didComplete``:
+
+```swift
+prefetcher.startPrefetching(with: urls)
+await prefetcher.waitUntilIdle()
+```
+
+There is also ``ImagePrefetcher/didComplete``, a closure called on the main queue under the same conditions.
+
 > Important: Prefetching takes up users' data and puts extra pressure on CPU and memory. To reduce the CPU and memory usage, you have an option to choose only the disk cache as a prefetching destination: ``ImagePrefetcher/Destination/diskCache``. It doesn't require image decoding and processing and therefore uses less CPU. The images are stored on disk, so they also take up less memory. This policy doesn't work with ``ImagePipeline/DataCachePolicy/storeEncodedImages`` cache policy and other policies that affect `loadData()`. 
 

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -74,6 +74,16 @@ public final class ImagePrefetcher: Sendable {
     private var tasks = [TaskLoadImageKey: PrefetchTask]()
     let queue: TaskQueue // internal for testing
 
+    /// The number of batches that were scheduled but haven't reached the
+    /// pipeline actor yet. They count as outstanding work: without it,
+    /// ``waitUntilIdle()`` called right after ``startPrefetching(with:)-718dg``
+    /// would return before the batch it is waiting for even starts.
+    private nonisolated let _pendingBatchCount = OSAllocatedUnfairLock(initialState: 0)
+
+    private var isIdle: Bool {
+        tasks.isEmpty && _pendingBatchCount.withLock { $0 } == 0
+    }
+
     /// Initializes the ``ImagePrefetcher`` instance.
     ///
     /// - parameters:
@@ -91,6 +101,11 @@ public final class ImagePrefetcher: Sendable {
     }
 
     nonisolated deinit {
+        // Nothing else is going to produce an event, and a stream that never
+        // finishes leaves whoever iterates it suspended forever.
+        for continuation in streamContinuations.values {
+            continuation.finish()
+        }
         let tasks = self.tasks.values
         Task { @ImagePipelineActor in
             for task in tasks {
@@ -117,12 +132,14 @@ public final class ImagePrefetcher: Sendable {
     ///
     /// See also ``startPrefetching(with:)-1jef2`` that works with `URL`.
     nonisolated public func startPrefetching(with requests: [ImageRequest]) {
+        _pendingBatchCount.withLock { $0 += 1 }
         Task { @ImagePipelineActor in
             self._startPrefetching(with: requests)
         }
     }
 
     private func _startPrefetching(with requests: [ImageRequest]) {
+        _pendingBatchCount.withLock { $0 -= 1 }
         let currentPriority = _priority.withLock { $0 }
         for request in requests {
             var request = request
@@ -148,25 +165,33 @@ public final class ImagePrefetcher: Sendable {
         let operation = queue.add { [weak self] in
             let imageTask = pipeline.makeStartedImageTask(with: task.request, isDataTask: isDataTask)
             task.imageTask = imageTask
-            _ = try? await imageTask.response
-            self?._remove(task)
+            let result: Result<ImageResponse, ImagePipeline.Error>
+            do throws(ImagePipeline.Error) {
+                result = .success(try await imageTask.response)
+            } catch {
+                result = .failure(error)
+            }
+            self?._remove(task, result: result)
         }
         operation.priority = request.priority.taskPriority
         task.operation = operation
         tasks[key] = task
+        _dispatch(.didStartPrefetching(request))
     }
 
-    private func _remove(_ task: PrefetchTask) {
+    private func _remove(_ task: PrefetchTask, result: Result<ImageResponse, ImagePipeline.Error>) {
         guard tasks[task.key] === task else { return }
         tasks[task.key] = nil
+        _dispatch(.didFinishPrefetching(task.request, result))
         sendCompletionIfNeeded()
     }
 
     private func sendCompletionIfNeeded() {
-        guard tasks.isEmpty, let callback = didComplete else {
-            return
+        guard isIdle else { return }
+        _dispatch(.didComplete)
+        if let callback = didComplete {
+            DispatchQueue.main.async(execute: callback)
         }
-        DispatchQueue.main.async(execute: callback)
     }
 
     /// Stops prefetching images for the given URLs and cancels outstanding
@@ -187,8 +212,14 @@ public final class ImagePrefetcher: Sendable {
     /// See also ``stopPrefetching(with:)-2tcyq`` that works with `URL`.
     nonisolated public func stopPrefetching(with requests: [ImageRequest]) {
         Task { @ImagePipelineActor in
+            // Nothing to complete if the prefetcher was already idle, and the
+            // collection view calls this on every scroll.
+            let wasBusy = !self.tasks.isEmpty
             for request in requests {
                 self._stopPrefetching(with: request)
+            }
+            if wasBusy {
+                self.sendCompletionIfNeeded()
             }
         }
     }
@@ -196,14 +227,130 @@ public final class ImagePrefetcher: Sendable {
     private func _stopPrefetching(with request: ImageRequest) {
         if let task = tasks.removeValue(forKey: TaskLoadImageKey(request)) {
             task.cancel()
+            _dispatch(.didFinishPrefetching(task.request, .failure(.cancelled)))
         }
     }
 
     /// Stops all prefetching tasks.
     nonisolated public func stopPrefetching() {
         Task { @ImagePipelineActor in
-            self.tasks.values.forEach { $0.cancel() }
+            let wasBusy = !self.tasks.isEmpty
+            for task in self.tasks.values {
+                task.cancel()
+                self._dispatch(.didFinishPrefetching(task.request, .failure(.cancelled)))
+            }
             self.tasks.removeAll()
+            if wasBusy {
+                self.sendCompletionIfNeeded()
+            }
+        }
+    }
+
+    // MARK: - Events
+
+    /// An event produced by the prefetcher.
+    @frozen public enum Event: Sendable {
+        /// The prefetcher started prefetching the given request.
+        ///
+        /// Not sent for the requests the prefetcher skips: the images that are
+        /// already in the memory cache, and the requests equivalent to the ones
+        /// it is already prefetching.
+        case didStartPrefetching(ImageRequest)
+
+        /// The prefetcher finished prefetching the given request, successfully
+        /// or not. Sent exactly once for every ``Event/didStartPrefetching(_:)``.
+        ///
+        /// The requests cancelled with ``ImagePrefetcher/stopPrefetching(with:)-8cdam``
+        /// finish with ``ImagePipeline/Error/cancelled``.
+        case didFinishPrefetching(ImageRequest, Result<ImageResponse, ImagePipeline.Error>)
+
+        /// The prefetcher ran out of outstanding work – the stream equivalent
+        /// of ``ImagePrefetcher/didComplete``, sent under the same conditions.
+        case didComplete
+    }
+
+    /// The stream of events produced by the prefetcher.
+    ///
+    /// ```swift
+    /// for await event in prefetcher.events {
+    ///     if case .didFinishPrefetching(let request, .failure(let error)) = event {
+    ///         report(error, for: request)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Every access creates a new independent stream. Unlike a task, which has
+    /// an outcome to replay, a prefetcher outlives its batches: a stream only
+    /// delivers the events produced after it is created, and it finishes only
+    /// when the prefetcher is deallocated. Stop iterating, or cancel the task
+    /// that iterates, to unsubscribe earlier.
+    ///
+    /// - note: A stream buffers the events that the consumer hasn't picked up
+    /// yet, so a slow consumer never misses one.
+    /// - note: Subscribing reaches the pipeline actor asynchronously, so the
+    /// events produced in between are missed. Use ``waitUntilIdle()`` instead
+    /// of watching for ``Event/didComplete`` right after scheduling a batch.
+    nonisolated public var events: AsyncStream<Event> {
+        AsyncStream { continuation in
+            Task { @ImagePipelineActor in
+                self._subscribe(continuation)
+            }
+        }
+    }
+
+    /// Waits until the prefetcher runs out of outstanding work, returning
+    /// immediately if it is already idle.
+    ///
+    /// ```swift
+    /// prefetcher.startPrefetching(with: urls)
+    /// await prefetcher.waitUntilIdle()
+    /// ```
+    ///
+    /// A convenience over ``events``: it returns on the first
+    /// ``Event/didComplete``. Unlike subscribing to the stream, it is safe to
+    /// call right after scheduling a batch – the batches that haven't reached
+    /// the pipeline actor yet count as outstanding work.
+    ///
+    /// - important: The prefetcher is shared by everything that schedules work
+    /// on it, so this waits for all of the outstanding batches, not only for
+    /// the ones scheduled by the caller.
+    public func waitUntilIdle() async {
+        guard !isIdle else { return }
+        for await event in _makeStream() {
+            if case .didComplete = event {
+                return
+            }
+        }
+    }
+
+    private var streamContinuations = [Int: AsyncStream<Event>.Continuation]()
+    private var nextStreamId = 0
+
+    var subscriptionCount: Int { streamContinuations.count } // internal for testing
+
+    /// Creates a stream and subscribes it synchronously, which the async
+    /// ``events`` path can't do – that's what makes ``waitUntilIdle()`` safe
+    /// to call right after scheduling a batch.
+    private func _makeStream() -> AsyncStream<Event> {
+        AsyncStream { continuation in
+            _subscribe(continuation)
+        }
+    }
+
+    private func _subscribe(_ continuation: AsyncStream<Event>.Continuation) {
+        nextStreamId += 1
+        let id = nextStreamId
+        streamContinuations[id] = continuation
+        continuation.onTermination = { [weak self] _ in
+            Task { @ImagePipelineActor in
+                self?.streamContinuations[id] = nil
+            }
+        }
+    }
+
+    private func _dispatch(_ event: Event) {
+        for continuation in streamContinuations.values {
+            continuation.yield(event)
         }
     }
 

--- a/Tests/NukeTests/ImagePrefetcherTests.swift
+++ b/Tests/NukeTests/ImagePrefetcherTests.swift
@@ -463,35 +463,332 @@ struct ImagePrefetcherTests {
         #expect(count.withLock { $0 } == 1)
     }
 
+    // MARK: Events
+
+    @Test func eventsAreSentForASuccessfulPrefetch() async {
+        // WHEN
+        let events = await recordEvents {
+            prefetcher.startPrefetching(with: [Test.url])
+        }
+
+        // THEN the request is reported as started, then finished, and the
+        // prefetcher reports itself complete
+        #expect(events.count == 3)
+        guard case .didStartPrefetching(let started) = events.first else {
+            Issue.record("Unexpected events: \(events)")
+            return
+        }
+        #expect(started.url == Test.url)
+        guard case .didFinishPrefetching(let finished, let result) = events[1] else {
+            Issue.record("Unexpected events: \(events)")
+            return
+        }
+        #expect(finished.url == Test.url)
+        #expect((try? result.get()) != nil)
+        guard case .didComplete = events[2] else {
+            Issue.record("Unexpected events: \(events)")
+            return
+        }
+    }
+
+    @Test func didFinishPrefetchingReportsTheFailure() async {
+        // GIVEN a request that fails
+        dataLoader.results[Test.url] = .failure(NSError(domain: "t", code: 42))
+
+        // WHEN
+        let events = await recordEvents {
+            prefetcher.startPrefetching(with: [Test.url])
+        }
+
+        // THEN
+        guard case .didFinishPrefetching(_, .failure(let error))? = events.first(where: \.isDidFinishPrefetching) else {
+            Issue.record("Unexpected events: \(events)")
+            return
+        }
+        guard case .dataLoadingFailed = error else {
+            Issue.record("Unexpected error: \(error)")
+            return
+        }
+    }
+
+    @Test func didFinishPrefetchingReportsCancellation() async {
+        // GIVEN a request that stays outstanding
+        dataLoader.isSuspended = true
+
+        // WHEN it is cancelled
+        let events = await recordEvents {
+            prefetcher.startPrefetching(with: [Test.url])
+            prefetcher.stopPrefetching(with: [Test.url])
+        }
+
+        // THEN the cancelled request still finishes, with `.cancelled`, and the
+        // prefetcher reports itself complete
+        guard case .didFinishPrefetching(_, .failure(let error))? = events.first(where: \.isDidFinishPrefetching) else {
+            Issue.record("Unexpected events: \(events)")
+            return
+        }
+        guard case .cancelled = error else {
+            Issue.record("Unexpected error: \(error)")
+            return
+        }
+    }
+
+    @Test func noStartEventForAnImageInTheMemoryCache() async {
+        // GIVEN an image that is already in the memory cache
+        imageCache[Test.request] = Test.container
+
+        // WHEN
+        let events = await recordEvents {
+            prefetcher.startPrefetching(with: [Test.request])
+        }
+
+        // THEN the prefetcher skips it and only reports the completion
+        #expect(events.count == 1)
+        guard case .didComplete = events.first else {
+            Issue.record("Unexpected events: \(events)")
+            return
+        }
+    }
+
+    @Test func noStartEventForADuplicateRequest() async {
+        // WHEN the same URL is scheduled twice
+        let events = await recordEvents {
+            dataLoader.isSuspended = true
+            prefetcher.startPrefetching(with: [Test.url])
+            prefetcher.startPrefetching(with: [Test.url])
+            dataLoader.isSuspended = false
+        }
+
+        // THEN it is only prefetched once
+        #expect(events.count { $0.isDidStartPrefetching } == 1)
+        #expect(events.count { $0.isDidFinishPrefetching } == 1)
+    }
+
+    @Test func everyStreamIsIndependent() async {
+        // GIVEN two subscriptions
+        let first = prefetcher.events
+        let second = prefetcher.events
+        await pipelineActorFlush()
+
+        // WHEN
+        prefetcher.startPrefetching(with: [Test.url])
+
+        // THEN both receive the same events
+        #expect(await collect(first).count == 3)
+        #expect(await collect(second).count == 3)
+    }
+
+    @Test func unsubscribingReleasesTheContinuation() async {
+        // GIVEN a subscription that already received a batch
+        _ = await recordEvents {
+            prefetcher.startPrefetching(with: [Test.url])
+        }
+
+        // THEN the continuation doesn't outlive the iteration
+        await pipelineActorFlush()
+        #expect(await prefetcher.subscriptionCount == 0)
+    }
+
+    @Test func theStreamFinishesWhenThePrefetcherIsDeallocated() async {
+        // GIVEN a subscription to a prefetcher nothing else holds on to
+        var localPrefetcher: ImagePrefetcher? = ImagePrefetcher(pipeline: pipeline)
+        let events = localPrefetcher!.events
+        await pipelineActorFlush()
+
+        // WHEN the prefetcher is deallocated
+        autoreleasepool {
+            localPrefetcher = nil
+        }
+
+        // THEN the stream finishes instead of leaving the iteration suspended
+        var recorded: [ImagePrefetcher.Event] = []
+        for await event in events {
+            recorded.append(event)
+        }
+        #expect(recorded.isEmpty)
+    }
+
+    // MARK: WaitUntilIdle
+
+    @Test func waitUntilIdleReturnsImmediatelyWhenIdle() async {
+        // WHEN nothing was ever scheduled
+        await prefetcher.waitUntilIdle()
+
+        // THEN it returns without subscribing at all
+        #expect(await prefetcher.subscriptionCount == 0)
+    }
+
+    @Test func waitUntilIdleWaitsForTheScheduledBatch() async {
+        // WHEN waiting right after scheduling, before the batch reaches the
+        // pipeline actor
+        prefetcher.startPrefetching(with: [Test.url])
+        await prefetcher.waitUntilIdle()
+
+        // THEN it waits for the batch instead of returning immediately
+        #expect(pipeline.cache[Test.request] != nil)
+        #expect(observer.startedTaskCount == 1)
+    }
+
+    @Test func waitUntilIdleWaitsForABatchScheduledAtALowerPriority() async {
+        // GIVEN a batch scheduled from a background priority context, whose
+        // job the pipeline actor runs after the higher priority ones
+        await Task.detached(priority: .background) { [prefetcher] in
+            prefetcher.startPrefetching(with: [Test.url])
+        }.value
+
+        // WHEN waiting from a high priority context
+        await Task.detached(priority: .high) { [prefetcher] in
+            await prefetcher.waitUntilIdle()
+        }.value
+
+        // THEN it still waits for the batch
+        #expect(pipeline.cache[Test.request] != nil)
+        #expect(observer.startedTaskCount == 1)
+    }
+
+    @Test func waitUntilIdleReturnsWhenEverythingIsCancelled() async {
+        // GIVEN an outstanding request
+        dataLoader.isSuspended = true
+        prefetcher.startPrefetching(with: [Test.url])
+        await pipelineActorFlush()
+
+        // WHEN all of the prefetching is stopped
+        prefetcher.stopPrefetching()
+
+        // THEN the prefetcher reports itself idle rather than waiting forever
+        await prefetcher.waitUntilIdle()
+        #expect(pipeline.cache[Test.request] == nil)
+    }
+
+    @Test func waitUntilIdleReleasesItsSubscription() async {
+        // WHEN
+        dataLoader.isSuspended = true
+        prefetcher.startPrefetching(with: [Test.url])
+        Task { @ImagePipelineActor in self.dataLoader.isSuspended = false }
+        await prefetcher.waitUntilIdle()
+
+        // THEN the internal stream is torn down
+        await pipelineActorFlush()
+        #expect(await prefetcher.subscriptionCount == 0)
+    }
+
+    @Test func waitUntilIdleCanBeCalledConcurrently() async {
+        // WHEN multiple callers wait at the same time
+        prefetcher.startPrefetching(with: [Test.url, Self.otherURL])
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<4 {
+                group.addTask { [prefetcher] in await prefetcher.waitUntilIdle() }
+            }
+        }
+
+        // THEN they all return and clean up after themselves
+        #expect(pipeline.cache[Test.request] != nil)
+        await pipelineActorFlush()
+        #expect(await prefetcher.subscriptionCount == 0)
+    }
+
+    @Test func waitUntilIdleIsCancellable() async {
+        // GIVEN a prefetcher that never becomes idle
+        dataLoader.isSuspended = true
+        prefetcher.startPrefetching(with: [Test.url])
+        await pipelineActorFlush()
+
+        // WHEN the waiting task is cancelled
+        let task = Task { [prefetcher] in await prefetcher.waitUntilIdle() }
+        while await prefetcher.subscriptionCount == 0 {
+            await Task.yield()
+        }
+        task.cancel()
+        await task.value
+
+        // THEN it returns and releases the subscription
+        await pipelineActorFlush()
+        #expect(await prefetcher.subscriptionCount == 0)
+
+        // Cleanup
+        prefetcher.stopPrefetching()
+    }
+
+    // MARK: Helpers
+
+    /// Subscribes to the prefetcher events, runs `work`, and returns everything
+    /// the prefetcher sent up to and including ``ImagePrefetcher/Event/didComplete``.
+    private func recordEvents(_ work: () -> Void) async -> [ImagePrefetcher.Event] {
+        let events = prefetcher.events
+        // Subscribing reaches the pipeline actor asynchronously – let it land
+        // before scheduling any work, or the events race the subscription.
+        await pipelineActorFlush()
+        work()
+        return await collect(events)
+    }
+
+    /// Collects the events up to and including the first `.didComplete`. The
+    /// stream never finishes on its own.
+    private func collect(_ events: AsyncStream<ImagePrefetcher.Event>) async -> [ImagePrefetcher.Event] {
+        var recorded: [ImagePrefetcher.Event] = []
+        for await event in events {
+            recorded.append(event)
+            if case .didComplete = event {
+                break
+            }
+        }
+        return recorded
+    }
+
+    /// Waits for a round trip through the pipeline actor, which is where the
+    /// prefetcher does all of its work.
+    private func pipelineActorFlush() async {
+        await Task { @ImagePipelineActor in }.value
+    }
+
+    @Test func didCompleteIsCalledWhenPrefetchingIsStopped() async {
+        // GIVEN an outstanding request
+        dataLoader.isSuspended = true
+        let expectation = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in expectation.fulfill() }
+        let events = prefetcher.events
+        await pipelineActorFlush()
+        prefetcher.startPrefetching(with: [Test.url])
+        var iterator = events.makeAsyncIterator()
+        _ = await iterator.next() // .didStartPrefetching
+
+        // WHEN the outstanding request is cancelled
+        prefetcher.stopPrefetching()
+
+        // THEN the prefetcher still reports itself complete – it has no
+        // outstanding requests left
+        await expectation.wait()
+    }
+
+    @Test func didCompleteIsNotSentWhileAnotherBatchIsScheduled() async {
+        // GIVEN two batches that complete without starting a task, followed by
+        // one that starts a task
+        imageCache[Test.request] = Test.container
+        imageCache[ImageRequest(url: Self.otherURL)] = Test.container
+        let events = prefetcher.events
+        await pipelineActorFlush()
+
+        // WHEN they are scheduled back to back
+        prefetcher.startPrefetching(with: [Test.url])
+        prefetcher.startPrefetching(with: [Self.otherURL])
+        prefetcher.startPrefetching(with: [Self.thirdURL])
+
+        // THEN the prefetcher doesn't report itself complete while the batches
+        // that follow are still on their way to the pipeline actor
+        var completions = 0
+        for await event in events {
+            if case .didComplete = event {
+                completions += 1
+            }
+            if case .didFinishPrefetching = event {
+                break
+            }
+        }
+        #expect(completions == 0)
+    }
+
     private static let otherURL = URL(string: "http://test.com/example-2.jpeg")!
     private static let thirdURL = URL(string: "http://test.com/example-3.jpeg")!
-
-    // MARK: Empty Inputs
-
-    @Test func startPrefetchingWithEmptyURLArray() {
-        // WHEN - prefetching is started with an empty URL list
-        prefetcher.startPrefetching(with: [URL]())
-
-        // THEN - no tasks are created and nothing crashes
-        #expect(observer.startedTaskCount == 0)
-    }
-
-    @Test func startPrefetchingWithEmptyRequestArray() {
-        // WHEN - prefetching is started with an empty request list
-        prefetcher.startPrefetching(with: [ImageRequest]())
-
-        // THEN - no tasks are created and nothing crashes
-        #expect(observer.startedTaskCount == 0)
-    }
-
-    @Test func stopPrefetchingWithEmptyArrayIsNoOp() {
-        // GIVEN - nothing is currently being prefetched
-        // WHEN - stopping with an empty list
-        prefetcher.stopPrefetching(with: [URL]())
-
-        // THEN - no crash, no state change
-        #expect(observer.startedTaskCount == 0)
-    }
 
     // MARK: Misc
 
@@ -513,5 +810,17 @@ struct ImagePrefetcherTests {
                 localPrefetcher = nil
             }
         }
+    }
+}
+
+private extension ImagePrefetcher.Event {
+    var isDidStartPrefetching: Bool {
+        if case .didStartPrefetching = self { return true }
+        return false
+    }
+
+    var isDidFinishPrefetching: Bool {
+        if case .didFinishPrefetching = self { return true }
+        return false
     }
 }


### PR DESCRIPTION
Stacked on #929 – review that one first, or read the second commit alone.

The prefetcher had exactly one observation point: `didComplete`, which tells you it ran out of work and nothing else. You can't tell how many of the scheduled requests were already cached, or which ones failed – the two numbers that say whether prefetching is paying off at all.

`ImagePrefetcher.events` reports all of it, in the shape `ImageTask.events` already established:

```swift
for await event in prefetcher.events {
    switch event {
    case .didStartPrefetching(let request): metrics.started(request)
    case .didFinishPrefetching(let request, let result): metrics.finished(request, result)
    case .didComplete: break
    }
}
```

`.didStartPrefetching` is only sent for the requests the prefetcher accepts, so the requests it skips – memory cache hits and duplicates of outstanding work – are visible as the gap. `.didFinishPrefetching` is sent exactly once for every start, with `.cancelled` for the requests stopped with `stopPrefetching`. `.didComplete` is the stream equivalent of the closure.

`waitUntilIdle()` is the convenience on top: it returns on the first `.didComplete`, or immediately if the prefetcher is already idle.

```swift
prefetcher.startPrefetching(with: urls)
await prefetcher.waitUntilIdle()
```

Two things were needed to make that second line honest:

- **A pending batch counter.** `startPrefetching` hops to the pipeline actor, so `tasks` is still empty when `waitUntilIdle()` runs – it would return before the batch it's waiting for even starts. Batches that haven't landed yet now count as outstanding work. This isn't theoretical: the actor's queue is priority-ordered, so scheduling from a background context and waiting from a high priority one reorders them deterministically, which is what `waitUntilIdleWaitsForABatchScheduledAtALowerPriority` does. It also fixes `didComplete` firing while another batch was already scheduled.
- **Completing on cancellation.** `stopPrefetching` emptied `tasks` without ever calling `sendCompletionIfNeeded`, so `didComplete` was skipped for that round and `waitUntilIdle()` would have waited forever. It's sent now, but only if the prefetcher had work to begin with – the collection view calls `stopPrefetching(with:)` on every scroll.

`deinit` finishes the outstanding streams. Nothing else is going to produce an event, and an unfinished stream leaves whoever iterates it suspended forever.

Subscribing through `events` still reaches the actor asynchronously, same as `ImageTask.events`, so a subscription made right before scheduling a batch can miss the start of it. That's why `waitUntilIdle()` doesn't go through the public property – it subscribes synchronously on the actor, which is the whole reason it can be called after `startPrefetching`.

**Behaviour change:** `didComplete` is now also called when the outstanding requests are cancelled, and is no longer called while another batch is already scheduled.

## To test

1. Run the `NukeTests` scheme – 973 tests pass, including 15 new `ImagePrefetcherTests`.
2. Run the `NukeThreadSafetyTests` scheme with the thread sanitizer enabled – 7 tests pass.
3. Each of the three behaviours above has a test that fails without it: dropping the pending batch counter fails `waitUntilIdleWaitsForABatchScheduledAtALowerPriority` and `didCompleteIsNotSentWhileAnotherBatchIsScheduled` (2 completions instead of 0), and dropping the completion on cancellation times out `didCompleteIsCalledWhenPrefetchingIsStopped`.
