### PR TITLE
Record the sweep date when sweep() is called manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fix `DataCache` updating the entry access date on the calling thread on every disk cache hit, which can be the main thread. The update now joins the staged changes, so the reads that arrive within the same window are written in a single pass – https://github.com/kean/Nuke/pull/927
 - Fix a data race on `DataLoader/prefersIncrementalDelivery`, which the loader reads when it creates a task while it can be written from any thread – https://github.com/kean/Nuke/pull/928
 - Fix `DataCache` sweeping only once per launch instead of every `DataCache/sweepInterval`, letting a long-running app grow the cache past its `DataCache/sizeLimit` until the next launch – https://github.com/kean/Nuke/pull/930
+- Fix `DataCache/sweep()` not recording the sweep date, so the next scheduled sweep ran again within `DataCache/sweepInterval` – https://github.com/kean/Nuke/pull/932
 
 # Nuke 13
 

--- a/Sources/Nuke/Caching/DataCache.swift
+++ b/Sources/Nuke/Caching/DataCache.swift
@@ -318,11 +318,11 @@ public final class DataCache: DataCaching, Sendable {
 
     /// Performs a cache sweep, removing the least recently used items that no
     /// longer fit in the cache, and waits for it to finish.
+    ///
+    /// The sweep counts as a recent one: the next scheduled sweep skips it if it
+    /// happens within ``DataCache/sweepInterval``.
     public func sweep() async {
-        await performIO {
-            self.performPendingChanges() // The sweep has to see the staged writes
-            self.performSweep()
-        }
+        await performIO { self.performSweepAndRecordIt() }
     }
 
     /// Schedules the drain of the staging area unless one is already scheduled.
@@ -495,10 +495,16 @@ public final class DataCache: DataCaching, Sendable {
     /// performed within the last ``DataCache/sweepInterval``. Runs on ``ioQueue``.
     private func performScheduledSweep() {
         guard isSweepEnabled, isSweepNeeded() else { return }
+        performSweepAndRecordIt()
+        onSweepCompleted?()
+    }
+
+    /// Performs the sweep and records its completion in the metadata file so
+    /// that the next scheduled sweep can skip it.
+    private func performSweepAndRecordIt() {
         performPendingChanges() // The sweep has to see the staged writes
         performSweep()
         updateMetadata { $0.lastSweepDate = Date() }
-        onSweepCompleted?()
     }
 
     private func isSweepNeeded() -> Bool {

--- a/Tests/NukeTests/DataCacheTests.swift
+++ b/Tests/NukeTests/DataCacheTests.swift
@@ -861,6 +861,42 @@ final class DataCacheTests {
         #expect(cache["key"] == blob)
     }
 
+    @Test func manualSweepUpdatesMetadata() async throws {
+        // WHEN performing the sweep manually
+        await cache.sweep()
+
+        // THEN it records the date the same way the scheduled one does
+        let date = try #require(lastSweepDate(at: cache.path))
+        #expect(Date().timeIntervalSince(date) < 5)
+    }
+
+    @Test func scheduledSweepIsSkippedAfterAManualOne() async throws {
+        // GIVEN a cache swept manually
+        let name = UUID().uuidString
+        let cache = try DataCache(
+            name: name,
+            filenameGenerator: { String($0.reversed()) },
+            sweepDelay: .seconds(100), // Long enough to never fire during the test
+            onSweepCompleted: {}
+        )
+        defer { try? FileManager.default.removeItem(at: cache.path) }
+        await cache.sweep()
+        let dateAfterManualSweep = try #require(lastSweepDate(at: cache.path))
+
+        // WHEN the app launches again shortly after
+        let other = try DataCache(
+            name: name,
+            filenameGenerator: { String($0.reversed()) },
+            sweepDelay: .milliseconds(0),
+            onSweepCompleted: { Issue.record("the sweep ran within `sweepInterval` of the manual one") }
+        )
+        try await Task.sleep(for: .milliseconds(300))
+
+        // THEN the launch sweep sees the recent one and skips, leaving the date be
+        #expect(lastSweepDate(at: cache.path) == dateAfterManualSweep)
+        _ = other
+    }
+
     @Test func scheduledSweepIsSkippedWhenDisabled() async throws {
         let cache = try DataCache(
             name: UUID().uuidString,
@@ -969,6 +1005,14 @@ final class DataCacheTests {
 
         // THEN the stale date doesn't hold the sweep back
         await expectation.wait(timeout: .seconds(5))
+    }
+
+    private func lastSweepDate(at path: URL) -> Date? {
+        struct CacheMetadata: Codable { var lastSweepDate: Date? }
+        guard let data = try? Data(contentsOf: path.appendingPathComponent(".data-cache-info")) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(CacheMetadata.self, from: data).lastSweepDate
     }
 
     // MARK: Sweep Edge Cases


### PR DESCRIPTION
The sweep scheduled on launch records its completion in the `.data-cache-info` metadata file, and `isSweepNeeded()` reads it back to skip a sweep that ran within `sweepInterval`. The public `DataCache/sweep()` did the same work but never stamped the date, so a launch shortly after a manual sweep swept the cache again inside the interval.

Both paths now go through `performSweepAndRecordIt()`, which flushes the staged writes, sweeps, and records the date. A manual sweep counts as a recent one, which is what the metadata is for.

## To test

1. Run the `NukeTests` scheme – 1013 tests pass, including the two new ones.
2. `manualSweepUpdatesMetadata` and `scheduledSweepIsSkippedAfterAManualOne` both fail without the fix: the metadata file doesn't exist after `sweep()` returns.
