### PR TITLE
Make DataLoader.Error conform to Sendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `ImageTask` now conforms to `Identifiable` – https://github.com/kean/Nuke/pull/922
 - `DataCache` is now `Sendable` instead of `@unchecked Sendable`: all of its mutable state, including the configuration properties, is guarded by a single lock. `DataCache/flush()` and `DataCache/sweep()` are now `async`, and `DataCache/queue` and `flush(for:)` are removed – https://github.com/kean/Nuke/pull/925
 - Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
+- `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
 
 **Bug Fixes**
 

--- a/Sources/Nuke/Loading/DataLoader.swift
+++ b/Sources/Nuke/Loading/DataLoader.swift
@@ -111,7 +111,7 @@ public final class DataLoader: DataLoading, @unchecked Sendable {
     }
 
     /// Errors produced by ``DataLoader``.
-    public enum Error: Swift.Error, CustomStringConvertible {
+    public enum Error: Swift.Error, CustomStringConvertible, Sendable {
         /// Validation failed.
         case statusCodeUnacceptable(Int)
 

--- a/Tests/NukeTests/DataLoaderTests.swift
+++ b/Tests/NukeTests/DataLoaderTests.swift
@@ -350,6 +350,14 @@ struct DataLoaderTests {
         #expect(error.description.contains("404"))
     }
 
+    @Test func errorIsSendable() async {
+        let error = DataLoader.Error.statusCodeUnacceptable(404)
+        // A compile-time check: the error crosses isolation boundaries wrapped
+        // in `ImagePipeline.Error.dataLoadingFailed(error:)`.
+        let description = await Task { @Sendable in error.description }.value
+        #expect(description.contains("404"))
+    }
+
     // MARK: - Large Data
 
     @Test func loadLargeData() async throws {


### PR DESCRIPTION
`DataLoader.Error` was the only public error type in Nuke that wasn't `Sendable`. Public types don't get the conformance inferred, so it silently opted out – and this is exactly the error that crosses isolation boundaries, wrapped in `ImagePipeline.Error.dataLoadingFailed(error:)`, which is itself `Sendable`. `ImageDecodingError` and `ImageProcessingError` already declare it.

The enum has a single `Int` payload, so the conformance is additive: no stored state changes, no source breakage for clients.

## To test

1. Run the `NukeTests` scheme – 1012 tests pass, including the new `DataLoaderTests/errorIsSendable`, which captures the error in a `@Sendable` closure and so fails to compile without the conformance.
