### PR TITLE
Make CoreImageFilter.Error and filter parameters Sendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
 - `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
 - `ImageProcessors/CoreImageFilter/Error` is now `Sendable` instead of `@unchecked Sendable`: its cases carry a filter name and descriptions instead of the `CIFilter`, `CIImage`, and `[String: Any]` payloads, which escaped the processing queue wrapped in `ImagePipeline/Error/processingFailed(processor:context:error:)` – https://github.com/kean/Nuke/pull/934
+- `ImageProcessors/CoreImageFilter` now takes `[String: any Sendable]` filter parameters instead of `[String: Any]`, matching the rest of the public API. The types Core Image filters commonly take – `CIImage`, `CIColor`, `CIVector`, `CGImage`, `NSNumber` – are all `Sendable` – https://github.com/kean/Nuke/pull/934
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `DataCache` is now `Sendable` instead of `@unchecked Sendable`: all of its mutable state, including the configuration properties, is guarded by a single lock. `DataCache/flush()` and `DataCache/sweep()` are now `async`, and `DataCache/queue` and `flush(for:)` are removed – https://github.com/kean/Nuke/pull/925
 - Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
 - `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
+- `ImageProcessors/CoreImageFilter/Error` is now `Sendable` instead of `@unchecked Sendable`: its cases carry a filter name and descriptions instead of the `CIFilter`, `CIImage`, and `[String: Any]` payloads, which escaped the processing queue wrapped in `ImagePipeline/Error/processingFailed(processor:context:error:)` – https://github.com/kean/Nuke/pull/934
 
 **Bug Fixes**
 

--- a/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
@@ -95,7 +95,7 @@ extension ImageProcessors {
 
         static func applyFilter(named name: String, parameters: [String: Any] = [:], to image: PlatformImage) throws -> PlatformImage {
             guard let filter = CIFilter(name: name, parameters: parameters) else {
-                throw Error.failedToCreateFilter(name: name, parameters: parameters)
+                throw Error.failedToCreateFilter(name: name, parameters: "\(parameters)")
             }
             // The filter is created here and is used exclusively by this call
             return try _apply(filter: filter, to: image)
@@ -122,14 +122,14 @@ extension ImageProcessors {
                 if let image = image.cgImage {
                     return CoreImage.CIImage(cgImage: image)
                 }
-                throw Error.inputImageIsEmpty(inputImage: image)
+                throw Error.inputImageIsEmpty(inputImage: "\(image)")
             }
             filter.setValue(try getCIImage(), forKey: kCIInputImageKey)
             guard let outputImage = filter.outputImage else {
-                throw Error.failedToApplyFilter(filter: filter)
+                throw Error.failedToApplyFilter(name: filter.name)
             }
             guard let imageRef = context.createCGImage(outputImage, from: outputImage.extent) else {
-                throw Error.failedToCreateOutputCGImage(image: outputImage)
+                throw Error.failedToCreateOutputCGImage(extent: outputImage.extent, image: "\(outputImage)")
             }
             return PlatformImage.make(cgImage: imageRef, source: image)
         }
@@ -143,11 +143,25 @@ extension ImageProcessors {
             }
         }
 
-        public enum Error: Swift.Error, CustomStringConvertible, @unchecked Sendable {
-            case failedToCreateFilter(name: String, parameters: [String: Any])
-            case inputImageIsEmpty(inputImage: PlatformImage)
-            case failedToApplyFilter(filter: CIFilter)
-            case failedToCreateOutputCGImage(image: CIImage)
+        /// Errors produced by ``CoreImageFilter``.
+        ///
+        /// The errors reach the client wrapped in
+        /// ``ImagePipeline/Error/processingFailed(processor:context:error:)``,
+        /// crossing isolation boundaries on the way, so they capture the
+        /// descriptions of the objects that failed rather than the objects
+        /// themselves, which aren't `Sendable`.
+        public enum Error: Swift.Error, CustomStringConvertible, Sendable {
+            /// Failed to create a `CIFilter` with the given name and parameters.
+            case failedToCreateFilter(name: String, parameters: String)
+
+            /// The input image has neither a `CIImage` nor a `CGImage` representation.
+            case inputImageIsEmpty(inputImage: String)
+
+            /// The filter with the given name produced no output image.
+            case failedToApplyFilter(name: String)
+
+            /// Failed to render the output image with the given extent into a `CGImage`.
+            case failedToCreateOutputCGImage(extent: CGRect, image: String)
 
             public var description: String {
                 switch self {
@@ -155,10 +169,10 @@ extension ImageProcessors {
                     return "Failed to create filter named \(name) with parameters: \(parameters)"
                 case let .inputImageIsEmpty(inputImage):
                     return "Failed to create input CIImage for \(inputImage)"
-                case let .failedToApplyFilter(filter):
-                    return "Failed to apply filter: \(filter.name)"
-                case let .failedToCreateOutputCGImage(image):
-                    return "Failed to create output image for extent: \(image.extent) from \(image)"
+                case let .failedToApplyFilter(name):
+                    return "Failed to apply filter: \(name)"
+                case let .failedToCreateOutputCGImage(extent, image):
+                    return "Failed to create output image for extent: \(extent) from \(image)"
                 }
             }
         }

--- a/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
@@ -151,9 +151,16 @@ extension ImageProcessors {
         /// descriptions of the objects that failed, not the objects themselves,
         /// which aren't `Sendable`.
         public enum Error: Swift.Error, CustomStringConvertible, Sendable {
+            /// Failed to create a `CIFilter` with the given name and parameters.
             case failedToCreateFilter(name: String, parameters: String)
+
+            /// The input image has neither a `CIImage` nor a `CGImage` representation.
             case inputImageIsEmpty(inputImage: String)
+
+            /// The filter with the given name produced no output image.
             case failedToApplyFilter(name: String)
+
+            /// Failed to render the output image with the given extent into a `CGImage`.
             case failedToCreateOutputCGImage(extent: CGRect, image: String)
 
             public var description: String {

--- a/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
@@ -28,9 +28,8 @@ extension ImageProcessors {
     /// - [Core Image Programming Guide](https://developer.apple.com/library/ios/documentation/GraphicsImaging/Conceptual/CoreImaging/ci_intro/ci_intro.html)
     /// - [Core Image Filter Reference](https://developer.apple.com/library/prerelease/ios/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html)
     public struct CoreImageFilter: ImageProcessing, CustomStringConvertible, @unchecked Sendable {
-        // The `Sendable` conformance is unchecked because of `Filter.custom`: a
-        // `CIFilter` is a mutable object owned by the client, so no amount of
-        // care taken here can make it safe to share. `Filter.named` is checked.
+        // Unchecked because of `Filter.custom`: the client owns the `CIFilter`
+        // and can mutate it at any time. `Filter.named` is checked.
         let filter: Filter
         public let identifier: String
 
@@ -42,11 +41,9 @@ extension ImageProcessors {
         /// Initializes the processor with a name of the `CIFilter` and its parameters.
         ///
         /// - parameter name: The name of the `CIFilter` to apply.
-        /// - parameter parameters: The parameters for the filter. The values are
-        /// passed to `CIFilter` as-is, but have to be `Sendable`: the processor
-        /// can be shared by the requests running on different threads. The types
-        /// Core Image filters commonly take – `CIImage`, `CIColor`, `CIVector`,
-        /// `CGImage`, `NSNumber` – all are.
+        /// - parameter parameters: The parameters for the filter. The types Core
+        /// Image filters commonly take – `CIImage`, `CIColor`, `CIVector`,
+        /// `CGImage`, `NSNumber` – all are `Sendable`.
         /// - parameter identifier: Uniquely identifies the processor.
         public init(name: String, parameters: [String: any Sendable], identifier: String) {
             self.filter = .named(name, parameters: parameters)
@@ -150,24 +147,13 @@ extension ImageProcessors {
             }
         }
 
-        /// Errors produced by ``CoreImageFilter``.
-        ///
-        /// The errors reach the client wrapped in
-        /// ``ImagePipeline/Error/processingFailed(processor:context:error:)``,
-        /// crossing isolation boundaries on the way, so they capture the
-        /// descriptions of the objects that failed rather than the objects
-        /// themselves, which aren't `Sendable`.
+        /// Errors produced by ``CoreImageFilter``. The cases capture the
+        /// descriptions of the objects that failed, not the objects themselves,
+        /// which aren't `Sendable`.
         public enum Error: Swift.Error, CustomStringConvertible, Sendable {
-            /// Failed to create a `CIFilter` with the given name and parameters.
             case failedToCreateFilter(name: String, parameters: String)
-
-            /// The input image has neither a `CIImage` nor a `CGImage` representation.
             case inputImageIsEmpty(inputImage: String)
-
-            /// The filter with the given name produced no output image.
             case failedToApplyFilter(name: String)
-
-            /// Failed to render the output image with the given extent into a `CGImage`.
             case failedToCreateOutputCGImage(extent: CGRect, image: String)
 
             public var description: String {

--- a/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+CoreImage.swift
@@ -28,20 +28,27 @@ extension ImageProcessors {
     /// - [Core Image Programming Guide](https://developer.apple.com/library/ios/documentation/GraphicsImaging/Conceptual/CoreImaging/ci_intro/ci_intro.html)
     /// - [Core Image Filter Reference](https://developer.apple.com/library/prerelease/ios/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html)
     public struct CoreImageFilter: ImageProcessing, CustomStringConvertible, @unchecked Sendable {
+        // The `Sendable` conformance is unchecked because of `Filter.custom`: a
+        // `CIFilter` is a mutable object owned by the client, so no amount of
+        // care taken here can make it safe to share. `Filter.named` is checked.
         let filter: Filter
         public let identifier: String
 
         enum Filter {
-            case named(String, parameters: [String: Any])
+            case named(String, parameters: [String: any Sendable])
             case custom(CIFilter)
         }
 
         /// Initializes the processor with a name of the `CIFilter` and its parameters.
         ///
         /// - parameter name: The name of the `CIFilter` to apply.
-        /// - parameter parameters: The parameters for the filter.
+        /// - parameter parameters: The parameters for the filter. The values are
+        /// passed to `CIFilter` as-is, but have to be `Sendable`: the processor
+        /// can be shared by the requests running on different threads. The types
+        /// Core Image filters commonly take – `CIImage`, `CIColor`, `CIVector`,
+        /// `CGImage`, `NSNumber` – all are.
         /// - parameter identifier: Uniquely identifies the processor.
-        public init(name: String, parameters: [String: Any], identifier: String) {
+        public init(name: String, parameters: [String: any Sendable], identifier: String) {
             self.filter = .named(name, parameters: parameters)
             self.identifier = identifier
         }
@@ -93,7 +100,7 @@ extension ImageProcessors {
 
         private static let _context = OSAllocatedUnfairLock(initialState: CIContext(options: [.priorityRequestLow: true]))
 
-        static func applyFilter(named name: String, parameters: [String: Any] = [:], to image: PlatformImage) throws -> PlatformImage {
+        static func applyFilter(named name: String, parameters: [String: any Sendable] = [:], to image: PlatformImage) throws -> PlatformImage {
             guard let filter = CIFilter(name: name, parameters: parameters) else {
                 throw Error.failedToCreateFilter(name: name, parameters: "\(parameters)")
             }

--- a/Sources/Nuke/Processing/ImageProcessors.swift
+++ b/Sources/Nuke/Processing/ImageProcessors.swift
@@ -94,7 +94,7 @@ extension ImageProcessing where Self == ImageProcessors.CoreImageFilter {
     /// - parameter name: The name of the `CIFilter` to apply.
     /// - parameter parameters: The parameters for the filter.
     /// - parameter identifier: Uniquely identifies the processor.
-    public static func coreImageFilter(name: String, parameters: [String: Any], identifier: String) -> ImageProcessors.CoreImageFilter {
+    public static func coreImageFilter(name: String, parameters: [String: any Sendable], identifier: String) -> ImageProcessors.CoreImageFilter {
         ImageProcessors.CoreImageFilter(name: name, parameters: parameters, identifier: identifier)
     }
 

--- a/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
@@ -184,7 +184,7 @@ struct ImageProcessorsCoreImageFilterTests {
         // `ImagePipeline.Error.processingFailed(processor:context:error:)`
         let description = await Task { @Sendable in error.description }.value
 
-        // THEN it carries the message, but none of the objects that produced it
+        // THEN
         #expect(description == "Failed to create filter named yo with parameters: [\"inputIntensity\": 0.5]")
     }
 

--- a/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
@@ -40,6 +40,19 @@ struct ImageProcessorsCoreImageFilterTests {
         _ = output // image was produced successfully
     }
 
+    @Test func applyFilterWithAnImageParameter() throws {
+        // GIVEN a filter that takes a `CIImage` parameter
+        let input = Test.image(named: "fixture-tiny.jpeg")
+        let background = CIImage(cgImage: try #require(input.cgImage))
+        let processor = ImageProcessors.CoreImageFilter(name: "CISourceOverCompositing", parameters: [kCIInputBackgroundImageKey: background], identifier: "composite")
+
+        // WHEN
+        let output = try #require(processor.process(input))
+
+        // THEN
+        _ = output // image was produced successfully
+    }
+
     @Test func applyFilterWithInvalidName() throws {
         // GIVEN
         let input = Test.image(named: "fixture-tiny.jpeg")

--- a/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/CoreImageFilterTests.swift
@@ -149,15 +149,30 @@ struct ImageProcessorsCoreImageFilterTests {
     @Test func errorDescriptions() throws {
         typealias Error = ImageProcessors.CoreImageFilter.Error
 
-        #expect("\(Error.failedToCreateFilter(name: "CIYo", parameters: [:]))" == "Failed to create filter named CIYo with parameters: [:]")
+        #expect("\(Error.failedToCreateFilter(name: "CIYo", parameters: "[:]"))" == "Failed to create filter named CIYo with parameters: [:]")
 
-        #expect("\(Error.inputImageIsEmpty(inputImage: PlatformImage()))".hasPrefix("Failed to create input CIImage for "))
+        #expect("\(Error.inputImageIsEmpty(inputImage: "\(PlatformImage())"))".hasPrefix("Failed to create input CIImage for "))
 
-        let filter = try #require(CIFilter(name: "CISepiaTone"))
-        #expect("\(Error.failedToApplyFilter(filter: filter))" == "Failed to apply filter: CISepiaTone")
+        #expect("\(Error.failedToApplyFilter(name: "CISepiaTone"))" == "Failed to apply filter: CISepiaTone")
 
         let image = CIImage(cgImage: try #require(Test.image(named: "fixture-tiny.jpeg").cgImage))
-        #expect("\(Error.failedToCreateOutputCGImage(image: image))".hasPrefix("Failed to create output image for extent: "))
+        #expect("\(Error.failedToCreateOutputCGImage(extent: image.extent, image: "\(image)"))".hasPrefix("Failed to create output image for extent: "))
+    }
+
+    @Test func errorIsSendable() async throws {
+        // GIVEN an error thrown by the processor
+        let processor = ImageProcessors.CoreImageFilter(name: "yo", parameters: ["inputIntensity": 0.5], identifier: "yo")
+        let thrown = #expect(throws: ImageProcessors.CoreImageFilter.Error.self) {
+            try processor.processThrowing(Test.image(named: "fixture-tiny.jpeg"))
+        }
+        let error = try #require(thrown)
+
+        // WHEN it crosses an isolation boundary, as it does wrapped in
+        // `ImagePipeline.Error.processingFailed(processor:context:error:)`
+        let description = await Task { @Sendable in error.description }.value
+
+        // THEN it carries the message, but none of the objects that produced it
+        #expect(description == "Failed to create filter named yo with parameters: [\"inputIntensity\": 0.5]")
     }
 
     @Test func applyCustomFilter() throws {


### PR DESCRIPTION
`ImageProcessors.CoreImageFilter.Error` was `@unchecked Sendable` while carrying a `CIFilter`, a `CIImage`, a `PlatformImage`, and a `[String: Any]`. None of those are `Sendable`, and the error doesn't stay on the processing queue: it reaches the client wrapped in `ImagePipeline.Error.processingFailed(processor:context:error:)`, which is itself `Sendable`. A caller can pull the `CIFilter` – a mutable object the processing code is still using – out of it on the main actor.

The cases now carry only what `description` needs, captured on the queue that owns the objects:

```swift
case failedToCreateFilter(name: String, parameters: String)
case inputImageIsEmpty(inputImage: String)
case failedToApplyFilter(name: String)
case failedToCreateOutputCGImage(extent: CGRect, image: String)
```

The conformance is now checked by the compiler instead of asserted. The `description` strings are unchanged.

## Sendable filter parameters

The same treatment for the processor's own payload: `parameters` is now `[String: any Sendable]` instead of `[String: Any]`, matching `ImageRequest.userInfo` and `ImageContainer.userInfo`. The processor is shared by the requests running on different threads, so the parameters travel with it, and `[String: Any]` let a caller hand it a mutable object with nothing to catch it.

The cost to clients is small: the types Core Image filters commonly take – `CIImage`, `CIColor`, `CIVector`, `CGImage`, `CGColor`, `NSNumber` – are all `Sendable`, and a `[String: any Sendable]` still converts implicitly to the `[String: Any]` that `CIFilter(name:parameters:)` expects.

The struct's conformance stays `@unchecked`, now only because of `Filter.custom`: the client owns that `CIFilter` and can mutate it at any time, which nothing in Nuke can fix. That's now stated in a comment next to the storage.

**Source-breaking**: code that pattern-matches the error cases to get at the `CIFilter`, `CIImage`, or `PlatformImage` needs updating (`failedToApplyFilter(filter:)` is now `failedToApplyFilter(name:)`), and filter parameters holding a non-`Sendable` value – an `NSValue`-wrapped transform, say – no longer compile; those callers can use `CoreImageFilter(_:identifier:)` with a preconfigured `CIFilter`.

## To test

1. Run the `Nuke` scheme – 968 tests pass, including two new ones: `errorIsSendable`, which captures a thrown error in a `@Sendable` closure and so fails to compile without the conformance, and `applyFilterWithAnImageParameter`, which passes a `CIImage` through the new parameter type.