### PR TITLE
Make ImageLoadingOptions conform to Sendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `DataCache` is now `Sendable` instead of `@unchecked Sendable`: all of its mutable state, including the configuration properties, is guarded by a single lock. `DataCache/flush()` and `DataCache/sweep()` are now `async`, and `DataCache/queue` and `flush(for:)` are removed – https://github.com/kean/Nuke/pull/925
 - Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
 - `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
+- `ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` now conform to `Sendable`. They were the only non-`Sendable` value types left in the public API, even though `ImageLoadingOptions/shared` is `@MainActor`. The `ImageLoadingOptions/Transition/custom(_:)` closure is now `@MainActor @Sendable`, which is where it already ran – https://github.com/kean/Nuke/pull/935
 
 **Bug Fixes**
 

--- a/Sources/NukeExtensions/ImageLoadingOptions.swift
+++ b/Sources/NukeExtensions/ImageLoadingOptions.swift
@@ -13,7 +13,7 @@ import AppKit.NSImage
 #endif
 
 /// A set of options that control how the image is loaded and displayed.
-public struct ImageLoadingOptions {
+public struct ImageLoadingOptions: Sendable {
     /// Shared options.
     @MainActor public static var shared = ImageLoadingOptions()
 
@@ -74,7 +74,7 @@ public struct ImageLoadingOptions {
 
     /// Custom content modes to be used for each image type (placeholder, success,
     /// failure).
-    public struct ContentModes {
+    public struct ContentModes: Sendable {
         /// Content mode to be used for the loaded image.
         public var success: UIView.ContentMode
         /// Content mode to be used when displaying a `failureImage`.
@@ -105,7 +105,7 @@ public struct ImageLoadingOptions {
 
     /// Custom tint color to be used for each image type (placeholder, success,
     /// failure).
-    public struct TintColors {
+    public struct TintColors: Sendable {
         /// Tint color to be used for the loaded image.
         public var success: UIColor?
         /// Tint color to be used when displaying a `failureImage`.
@@ -181,13 +181,13 @@ public struct ImageLoadingOptions {
 #endif
 
     /// An animated image transition.
-    public struct Transition {
+    public struct Transition: Sendable {
         var style: Style
 
 #if os(iOS) || os(tvOS) || os(visionOS)
         enum Style { // internal representation
             case fadeIn(parameters: Parameters)
-            case custom((ImageDisplayingView, UIImage) -> Void)
+            case custom(@MainActor @Sendable (ImageDisplayingView, UIImage) -> Void)
         }
 
         struct Parameters { // internal representation
@@ -202,13 +202,13 @@ public struct ImageLoadingOptions {
         }
 
         /// Custom transition. Only runs when the image was not found in memory cache.
-        public static func custom(_ closure: @escaping (ImageDisplayingView, UIImage) -> Void) -> Transition {
+        public static func custom(_ closure: @escaping @MainActor @Sendable (ImageDisplayingView, UIImage) -> Void) -> Transition {
             Transition(style: .custom(closure))
         }
 #elseif os(macOS)
         enum Style { // internal representation
             case fadeIn(parameters: Parameters)
-            case custom((ImageDisplayingView, NSImage) -> Void)
+            case custom(@MainActor @Sendable (ImageDisplayingView, NSImage) -> Void)
         }
 
         struct Parameters { // internal representation
@@ -221,7 +221,7 @@ public struct ImageLoadingOptions {
         }
 
         /// Custom transition. Only runs when the image was not found in memory cache.
-        public static func custom(_ closure: @escaping (ImageDisplayingView, NSImage) -> Void) -> Transition {
+        public static func custom(_ closure: @escaping @MainActor @Sendable (ImageDisplayingView, NSImage) -> Void) -> Transition {
             Transition(style: .custom(closure))
         }
 #else

--- a/Tests/NukeExtensionsTests/ImageViewLoadingOptionsTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewLoadingOptionsTests.swift
@@ -386,6 +386,39 @@ struct ImageViewLoadingOptionsTests {
     }
 #endif
 
+    // MARK: - Sendable
+
+    @Test func optionsAreSendable() async {
+        // GIVEN options configured on the main actor
+        var options = ImageLoadingOptions(placeholder: Test.image)
+        options.processors = [ImageProcessors.Resize(width: 100)]
+        options.transition = .custom { view, image in
+            view.nuke_display(image: image, data: nil)
+        }
+#if os(iOS) || os(tvOS) || os(visionOS)
+        options.contentModes = ImageLoadingOptions.ContentModes(
+            success: .scaleAspectFill,
+            failure: .center,
+            placeholder: .scaleAspectFit
+        )
+        options.tintColors = ImageLoadingOptions.TintColors(
+            success: .red,
+            failure: .green,
+            placeholder: .blue
+        )
+#endif
+        let sendable = options
+
+        // WHEN a compile-time check: the options are created on the main actor,
+        // where `ImageLoadingOptions.shared` lives, but aren't confined to it.
+        let isProgressiveRenderingEnabled = await Task.detached {
+            sendable.isProgressiveRenderingEnabled
+        }.value
+
+        // THEN
+        #expect(isProgressiveRenderingEnabled)
+    }
+
     // MARK: - Misc
 
 #if os(iOS) || os(tvOS) || os(visionOS)


### PR DESCRIPTION
`ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` were the only non-`Sendable` value types left in the public API. Public types don't get the conformance inferred, so they silently opted out – and `ImageLoadingOptions.shared` is a `@MainActor static var`, which means every non-main-actor context that wants to build options off the shared ones has to hop to the main actor and then can't carry the result back out.

Everything the options store is already `Sendable`: `PlatformImage`, `ImagePipeline`, `[any ImageProcessing]`, `UIColor`, `UIView.ContentMode`, and the transition parameters. The one exception was `Transition.custom`, whose closure is now `@MainActor @Sendable`. That matches where it already runs – `ImageViewController` is `@MainActor` and invokes it while displaying the image – and per [SE-0434](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0434-global-actor-isolated-types-usability.md) a global-actor-isolated closure can still capture non-`Sendable` state, so the existing call sites keep compiling.

## To test

1. Build the `NukeExtensions` scheme for iOS, tvOS, watchOS, and macOS.
2. Run the `NukeExtensionsTests` scheme – 42 tests pass, including the new `ImageViewLoadingOptionsTests/optionsAreSendable`, which captures fully populated options (a custom transition included) in a detached task and so fails to compile without the conformance.
