### PR TITLE
Add previewPolicy to the ImageDecodingContext initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Add `AssetType/avif`. Image I/O decodes AVIF on every supported platform, but `AssetType/init(_:)` didn't recognize the `avif` and `avis` brands, so `ImageContainer/type` was `nil` – https://github.com/kean/Nuke/pull/926
 - `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
 - `ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` now conform to `Sendable`. They were the only non-`Sendable` value types left in the public API, even though `ImageLoadingOptions/shared` is `@MainActor`. The `ImageLoadingOptions/Transition/custom(_:)` closure is now `@MainActor @Sendable`, which is where it already ran – https://github.com/kean/Nuke/pull/935
+- `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy`. It was the only property you couldn't set at initialization – https://github.com/kean/Nuke/pull/936
 
 **Bug Fixes**
 

--- a/Sources/Nuke/Decoding/ImageDecoderRegistry.swift
+++ b/Sources/Nuke/Decoding/ImageDecoderRegistry.swift
@@ -89,15 +89,20 @@ public struct ImageDecodingContext: Sendable {
     public var isCompleted: Bool
     public var urlResponse: URLResponse?
     public var cacheType: ImageResponse.CacheType?
-    /// The preview policy for progressive decoding. Set by the pipeline
-    /// delegate for partial data; defaults to `.incremental`.
-    public var previewPolicy: ImagePipeline.PreviewPolicy = .incremental
+    /// The strategy a decoder uses to produce previews from the partially
+    /// downloaded data.
+    ///
+    /// The pipeline resolves it with
+    /// ``ImagePipeline/Delegate/previewPolicy(for:pipeline:)`` and only for
+    /// the contexts where ``isCompleted`` is `false`.
+    public var previewPolicy: ImagePipeline.PreviewPolicy
 
-    public init(request: ImageRequest, data: Data, isCompleted: Bool = true, urlResponse: URLResponse? = nil, cacheType: ImageResponse.CacheType? = nil) {
+    public init(request: ImageRequest, data: Data, isCompleted: Bool = true, urlResponse: URLResponse? = nil, cacheType: ImageResponse.CacheType? = nil, previewPolicy: ImagePipeline.PreviewPolicy = .incremental) {
         self.request = request
         self.data = data
         self.isCompleted = isCompleted
         self.urlResponse = urlResponse
         self.cacheType = cacheType
+        self.previewPolicy = previewPolicy
     }
 }

--- a/Tests/Helpers/Helpers.swift
+++ b/Tests/Helpers/Helpers.swift
@@ -132,8 +132,8 @@ extension ImageDecodingContext {
         mock(data: Test.data)
     }
 
-    static func mock(data: Data) -> ImageDecodingContext {
-        ImageDecodingContext(request: Test.request, data: data)
+    static func mock(data: Data, previewPolicy: ImagePipeline.PreviewPolicy = .incremental) -> ImageDecodingContext {
+        ImageDecodingContext(request: Test.request, data: data, previewPolicy: previewPolicy)
     }
 }
 

--- a/Tests/NukeTests/ImageDecoderTests.swift
+++ b/Tests/NukeTests/ImageDecoderTests.swift
@@ -75,13 +75,23 @@ struct ImageDecoderTests {
         #expect(decoder.numberOfScans == 3)
     }
 
+    @Test func previewPolicyPassedToDecoder() throws {
+        let data = Test.data(name: "progressive", extension: "jpeg")
+
+        // The policy defaults to .incremental
+        #expect(ImageDecodingContext(request: Test.request, data: data).previewPolicy == .incremental)
+
+        // The policy given to the initializer reaches the decoder
+        let context = ImageDecodingContext(request: Test.request, data: data, isCompleted: false, previewPolicy: .thumbnail)
+        let decoder = try #require(ImageDecoders.Default(context: context))
+        #expect(decoder.previewPolicy == .thumbnail)
+    }
 
     @Test func decodingBaselineJPEG() throws {
         let data = Test.data(name: "baseline", extension: "jpeg")
 
         // Default policy for baseline JPEG is .disabled — no previews
-        var context = ImageDecodingContext.mock(data: data)
-        context.previewPolicy = .default(for: data)
+        let context = ImageDecodingContext.mock(data: data, previewPolicy: .default(for: data))
         let decoder = try #require(ImageDecoders.Default(context: context))
 
         let partial = decoder.decodePartiallyDownloadedData(data[0...(data.count / 2)])
@@ -97,8 +107,7 @@ struct ImageDecoderTests {
         let data = Test.data(name: "baseline", extension: "jpeg")
 
         // With .incremental policy, Image I/O produces partial top-down renders
-        var context = ImageDecodingContext.mock(data: data)
-        context.previewPolicy = .incremental
+        let context = ImageDecodingContext.mock(data: data, previewPolicy: .incremental)
         let decoder = try #require(ImageDecoders.Default(context: context))
 
         let partial = decoder.decodePartiallyDownloadedData(data[0...(data.count / 2)])
@@ -113,8 +122,7 @@ struct ImageDecoderTests {
     @Test func decodingBaselineJPEGWithThumbnailPolicy() throws {
         let data = Test.data(name: "baseline", extension: "jpeg")
 
-        var context = ImageDecodingContext.mock(data: data)
-        context.previewPolicy = .thumbnail
+        let context = ImageDecodingContext.mock(data: data, previewPolicy: .thumbnail)
         let decoder = try #require(ImageDecoders.Default(context: context))
 
         // Baseline JPEG typically has no embedded EXIF thumbnail
@@ -127,8 +135,7 @@ struct ImageDecoderTests {
     @Test func decodingProgressiveJPEGWithDisabledPolicy() throws {
         let data = Test.data(name: "progressive", extension: "jpeg")
 
-        var context = ImageDecodingContext.mock(data: data)
-        context.previewPolicy = .disabled
+        let context = ImageDecodingContext.mock(data: data, previewPolicy: .disabled)
         let decoder = try #require(ImageDecoders.Default(context: context))
 
         // No previews with .disabled policy
@@ -145,8 +152,7 @@ struct ImageDecoderTests {
         let data = Test.data(name: "fixture", extension: "png")
 
         // Default policy for PNG is .disabled — no previews
-        var context = ImageDecodingContext.mock(data: data)
-        context.previewPolicy = .default(for: data)
+        let context = ImageDecodingContext.mock(data: data, previewPolicy: .default(for: data))
         let decoder = try #require(ImageDecoders.Default(context: context))
 
         #expect(decoder.decodePartiallyDownloadedData(data[0...100]) == nil)
@@ -287,8 +293,7 @@ struct ImageDecoderTests {
         let data = Test.data(name: "cat", extension: "gif")
         let chunk = data[...60000]
 
-        var context = ImageDecodingContext.mock(data: chunk)
-        context.previewPolicy = .disabled
+        let context = ImageDecodingContext.mock(data: chunk, previewPolicy: .disabled)
         let decoder = try #require(ImageDecoders.Default(context: context))
 
         // No previews with the .disabled policy, GIFs included
@@ -306,8 +311,7 @@ struct ImageDecoderTests {
         let data = Test.data(name: "cat", extension: "gif")
         let chunk = data[...60000]
 
-        var context = ImageDecodingContext.mock(data: chunk)
-        context.previewPolicy = .thumbnail
+        let context = ImageDecodingContext.mock(data: chunk, previewPolicy: .thumbnail)
         let decoder = try #require(ImageDecoders.Default(context: context))
 
         // GIFs can't be decoded incrementally, so a single preview is still


### PR DESCRIPTION
`ImageDecodingContext.previewPolicy` was the only stored property without a matching initializer parameter, so a context could only be given a non-default policy by mutating it after construction:

```swift
var context = ImageDecodingContext(request: request, data: data, isCompleted: false)
context.previewPolicy = .thumbnail
```

That works – the property is a public `var` – but the policy is invisible at the point where you'd look for it, and a `let` context can't be fully configured in one expression. The parameter is defaulted and last, so every existing call site compiles unchanged.

The property's documentation described the pipeline's behavior rather than the property. It now says what the value means to a decoder reading it, and points at `ImagePipeline/Delegate/previewPolicy(for:pipeline:)`, whose own default is `.default(for:)` rather than the `.incremental` the property defaults to.

`TaskFetchOriginalImage` keeps assigning the property after construction: it builds the context to hand to `resolvePreviewPolicy(for:)`, which passes it to the delegate, so the policy can't be known before the context exists.

## To test

1. Run the `NukeTests` scheme – 1022 tests pass, including the new `ImageDecoderTests/previewPolicyPassedToDecoder`, which checks the default and that a policy given to the initializer reaches `ImageDecoders.Default`.
2. The seven decoding tests that used the mutate-after-construction form now pass the policy to `ImageDecodingContext.mock(data:previewPolicy:)` instead.