### PR TITLE
Write DataCache entries atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fix a data race on `ImagePrefetcher/didComplete`, which the prefetcher reads on the pipeline actor while it can be written from any thread – https://github.com/kean/Nuke/pull/929
 - Fix `DataCache` sweeping only once per launch instead of every `DataCache/sweepInterval`, letting a long-running app grow the cache past its `DataCache/sizeLimit` until the next launch – https://github.com/kean/Nuke/pull/930
 - Fix `DataCache/sweep()` not recording the sweep date, so the next scheduled sweep ran again within `DataCache/sweepInterval` – https://github.com/kean/Nuke/pull/932
+- Fix `DataCache` writing entries non-atomically. Reads run on the calling thread, so a read that arrived while the drain overwrote the same key returned a truncated file. The data now goes to a temporary file that is renamed over the destination – https://github.com/kean/Nuke/pull/937
 
 # Nuke 13
 

--- a/Sources/Nuke/Caching/DataCache.swift
+++ b/Sources/Nuke/Caching/DataCache.swift
@@ -457,15 +457,44 @@ public final class DataCache: DataCaching, Sendable {
         switch change.type {
         case let .add(data):
             do {
-                try data.write(to: url)
+                try write(data, to: url)
             } catch let error as NSError where error.code == CocoaError.fileNoSuchFile.rawValue && error.domain == CocoaError.errorDomain {
                 createDirectory() // The directory is gone, re-create it and try again
-                try? data.write(to: url)
+                try? write(data, to: url)
             } catch {
                 // There is nothing we can do about it
             }
         case .remove:
             try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// Writes the data to a temporary file and renames it over the destination.
+    ///
+    /// The rename is what makes the write atomic, and it has to be: reads run
+    /// on the caller's thread, not on ``ioQueue``, so a write that truncated
+    /// the file in place would hand a reader that missed the staging shortcut
+    /// a prefix of it. The rename swaps the two whole files instead.
+    ///
+    /// `Data.WritingOptions.atomic` does the same thing but is roughly twice as
+    /// slow, and the temporary file it creates is a regular one, so the
+    /// inspection API counts it as an entry while the write is in flight. This
+    /// one is hidden, which ``contents(keys:)`` already skips. Its name is
+    /// derived from the destination, so a process that dies mid-write leaves at
+    /// most one behind per key and the next write to that key reclaims it.
+    private func write(_ data: Data, to url: URL) throws {
+        let tempURL = url.deletingLastPathComponent()
+            .appendingPathComponent("." + url.lastPathComponent + ".tmp", isDirectory: false)
+        try data.write(to: tempURL)
+        let didRename = tempURL.withUnsafeFileSystemRepresentation { source in
+            url.withUnsafeFileSystemRepresentation { destination in
+                guard let source, let destination else { return false }
+                return rename(source, destination) == 0
+            }
+        }
+        guard didRename else {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw CocoaError(.fileWriteUnknown)
         }
     }
 

--- a/Tests/NukeTests/DataCacheTests.swift
+++ b/Tests/NukeTests/DataCacheTests.swift
@@ -766,6 +766,42 @@ final class DataCacheTests {
         #expect(String(data: data, encoding: .utf8) == "2")
     }
 
+    /// A read that misses the staging shortcut falls through to the disk on the
+    /// caller's thread, which can run while the drain writes the same key. The
+    /// write has to be atomic: one that truncates in place hands the reader a
+    /// prefix of the file.
+    @Test func concurrentReadNeverSeesAPartiallyWrittenFile() async throws {
+        // Big enough that the write is not over before a reader can catch it.
+        let size = 4 * 1024 * 1024
+        let first = Data(repeating: 1, count: size)
+        let second = Data(repeating: 2, count: size)
+
+        cache["key"] = first
+        await cache.flush()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<4 {
+                group.addTask { [cache] in
+                    for _ in 0..<250 {
+                        guard let data = cache["key"] else { continue }
+                        // Both values are the same length, so a torn read is
+                        // always short. Check the bytes too, in case it is not.
+                        if data.count != size || (data != first && data != second) {
+                            Issue.record("Read a partially written file: \(data.count) of \(size) bytes")
+                            return
+                        }
+                    }
+                }
+            }
+            group.addTask { [cache] in
+                for index in 0..<60 {
+                    cache["key"] = index.isMultiple(of: 2) ? second : first
+                    await cache.flush()
+                }
+            }
+        }
+    }
+
     // MARK: Persistence
 
     @Test func flushedDataIsVisibleToANewInstanceAtTheSamePath() async throws {


### PR DESCRIPTION
`DataCache` reads run on the calling thread, not on `ioQueue`, and `try data.write(to: url)` truncates the file in place. A read that arrives after the staging entry was flushed but while the drain is overwriting that same key falls through to the disk and gets a prefix of the file.

The pipeline degrades gracefully here — `TaskLoadImage.didFinishDecoding` falls back to `fetchImage()` on a decode failure — so it costs a refetch. But `DataCache` is public API and a client storing non-image blobs has no such fallback.

The data now goes to a temporary file that is renamed over the destination, so a reader sees either the old file or the new one whole.

### Why `rename(2)` and not `Data.WritingOptions.atomic`

`.atomic` is roughly twice as slow, and the temporary file it creates is a regular one, so `contents(keys:)` — and `totalCount`, `totalSize`, `totalAllocatedSize` on top of it — counts it as an entry while the write is in flight. It broke `stagedChangesAreDrainedWithoutAnExplicitFlush` for exactly that reason. The temporary file here is hidden, which the enumeration already skips, and its name is derived from the destination, so a process that dies mid-write leaves at most one behind per key and the next write to that key reclaims it.

The sweep can't observe the temporary file at all: it runs on the same serial `ioQueue` as the writes.

### Performance

`DataCachePeformanceTests`, macOS, Release, median of 3 runs (ms):

| Test | Before | After | |
|---|---|---|---|
| `writeWithFlush` | 111 | 184 | **+66%** |
| `writeWithFlushAfterEachItem` | 17.2 | 37.3 | **+117%** |
| `concurrentReadsAndWrites` | 55.2 | 143.7 | **+160%** |
| `sweepWithEviction` | 162.9 | 234.8 | +44% (all of it the writes it re-populates; the sweep itself is 51.9 → 50.8) |
| `writeWithoutFlush` | 0.041 | 0.038 | – |
| `readFlushedPerformance` | 15.3 | 14.8 | – |
| `readFlushedPerformanceSync` | 22.4 | 22.1 | – |
| `readFromStaging` | 0.031 | 0.032 | – |
| `containsData` | 2.5 | 2.6 | – |
| `sweep` | 2.2 | 2.0 | – |

The cost is a flat **~0.07–0.10 ms per write** — one extra file create plus a rename — independent of the blob size. It reads as +160% on `concurrentReadsAndWrites` only because that test writes 1 KB blobs, where the fixed cost dominates. Nothing on the read path, the sweep, or the inspection API moves.

For reference, `Data.WritingOptions.atomic` on the same machine: `writeWithFlush` 238, `writeWithFlushAfterEachItem` 43.2, `concurrentReadsAndWrites` 179.5, and `containsData` 2.5 → 8.8 from the temporary files churning the directory.

### Tests

`concurrentReadNeverSeesAPartiallyWrittenFile` races four readers against a writer on one key with 4 MB values. On `main` it reports reads of `0 of 4194304 bytes`; it passes here. Full suite: 971 tests, all passing.