### PR TITLE
Rename Border.width to widthInPixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
 - `ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` now conform to `Sendable`. They were the only non-`Sendable` value types left in the public API, even though `ImageLoadingOptions/shared` is `@MainActor`. The `ImageLoadingOptions/Transition/custom(_:)` closure is now `@MainActor @Sendable`, which is where it already ran – https://github.com/kean/Nuke/pull/935
 - `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy`. It was the only property you couldn't set at initialization – https://github.com/kean/Nuke/pull/936
+- `ImageProcessingOptions/Border/width` is renamed to `widthInPixels`. The initializer converts the given width to pixels, so the property never returned what the caller passed – https://github.com/kean/Nuke/pull/938
 
 **Bug Fixes**
 

--- a/Sources/Nuke/Internal/Graphics.swift
+++ b/Sources/Nuke/Internal/Graphics.swift
@@ -123,7 +123,7 @@ struct ImageProcessingExtensions {
         if let border {
             ctx.setStrokeColor(border.color.cgColor)
             ctx.addPath(path)
-            ctx.setLineWidth(border.width)
+            ctx.setLineWidth(border.widthInPixels)
             ctx.strokePath()
         }
         guard let outputCGImage = ctx.makeImage() else {

--- a/Sources/Nuke/Processing/ImageProcessingOptions.swift
+++ b/Sources/Nuke/Processing/ImageProcessingOptions.swift
@@ -38,29 +38,38 @@ public enum ImageProcessingOptions: Sendable {
     /// consider adding border to a view layer. This should be your primary
     /// option regardless.
     public struct Border: Hashable, CustomStringConvertible, Sendable {
-        public let width: CGFloat
+        /// The border width in pixels.
+        ///
+        /// The initializer converts the given width to pixels using the unit
+        /// you pass, so this is not necessarily the value you passed in.
+        public let widthInPixels: CGFloat
+
+        @available(*, deprecated, renamed: "widthInPixels", message: "Deprecated in Nuke 14.0. Renamed to `widthInPixels` to reflect what it returns: the width converted to pixels, not the value passed to the initializer.")
+        public var width: CGFloat { widthInPixels }
 
 #if canImport(UIKit)
         public let color: UIColor
 
         /// - parameters:
         ///   - color: Border color.
-        ///   - width: Border width.
-        ///   - unit: Unit of the width.
+        ///   - width: Border width, in the given unit.
+        ///   - unit: Unit of the width. The width is converted to pixels and
+        ///   is available as ``widthInPixels``.
         public init(color: UIColor, width: CGFloat = 1, unit: Unit = .points) {
             self.color = color
-            self.width = width.converted(to: unit)
+            self.widthInPixels = width.converted(to: unit)
         }
 #else
         public let color: NSColor
 
         /// - parameters:
         ///   - color: Border color.
-        ///   - width: Border width.
-        ///   - unit: Unit of the width.
+        ///   - width: Border width, in the given unit.
+        ///   - unit: Unit of the width. The width is converted to pixels and
+        ///   is available as ``widthInPixels``.
         public init(color: NSColor, width: CGFloat = 1, unit: Unit = .points) {
             self.color = color
-            self.width = width.converted(to: unit)
+            self.widthInPixels = width.converted(to: unit)
         }
 #endif
 
@@ -70,7 +79,7 @@ public enum ImageProcessingOptions: Sendable {
             // processors that draw borders, so the fallback has to stay
             // distinct per color instead of collapsing every such color onto
             // the same – and, in the case of "#00000000", already taken – value.
-            "Border(color: \(color.hex ?? String(describing: color)), width: \(width) pixels)"
+            "Border(color: \(color.hex ?? String(describing: color)), width: \(widthInPixels) pixels)"
         }
     }
 

--- a/Tests/NukeTests/ImageProcessingOptionsTests.swift
+++ b/Tests/NukeTests/ImageProcessingOptionsTests.swift
@@ -59,7 +59,19 @@ struct ImageProcessingOptionsTests {
 #else
         let border = ImageProcessingOptions.Border(color: .blue)
 #endif
-        #expect(border.width > 0)
+        #expect(border.widthInPixels > 0)
+    }
+
+    @Test func borderWidthInPixelsIsUsedAsIs() {
+        let border = ImageProcessingOptions.Border(color: .red, width: 2, unit: .pixels)
+        #expect(border.widthInPixels == 2)
+    }
+
+    /// The width used to be stored in pixels but reported by a property named
+    /// `width`, so it didn't return what the caller passed in.
+    @Test func borderWidthInPointsIsConvertedToPixels() {
+        let border = ImageProcessingOptions.Border(color: .red, width: 2, unit: .points)
+        #expect(border.widthInPixels == 2 * Screen.scale)
     }
 
     @Test func bordersWithSameColorAndWidthAreEqual() {


### PR DESCRIPTION
`ImageProcessingOptions.Border` takes a width plus a unit and stores the converted value, but reported it through a property named `width`, so it never returned what the caller passed:

```swift
Border(color: .red, width: 2, unit: .points).width // 6 on a 3x screen, not 2
```

The stored property is now `widthInPixels`, which is what `description` already printed. `width` stays as a deprecated alias for the same value.
