### PR TITLE
Keep removed APIs as unavailable stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@
 - `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
 - `ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` now conform to `Sendable`. They were the only non-`Sendable` value types left in the public API, even though `ImageLoadingOptions/shared` is `@MainActor`. The `ImageLoadingOptions/Transition/custom(_:)` closure is now `@MainActor @Sendable`, which is where it already ran – https://github.com/kean/Nuke/pull/935
 - `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy`. It was the only property you couldn't set at initialization – https://github.com/kean/Nuke/pull/936
-- The APIs removed in Nuke 14 are now unavailable stubs that name their replacement, so the compiler reports the migration instead of "has no member" – https://github.com/kean/Nuke/pull/939
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `DataLoader/Error` now conforms to `Sendable`. It was the only public error type that didn't, despite crossing isolation boundaries wrapped in `ImagePipeline/Error/dataLoadingFailed(error:)` – https://github.com/kean/Nuke/pull/933
 - `ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` now conform to `Sendable`. They were the only non-`Sendable` value types left in the public API, even though `ImageLoadingOptions/shared` is `@MainActor`. The `ImageLoadingOptions/Transition/custom(_:)` closure is now `@MainActor @Sendable`, which is where it already ran – https://github.com/kean/Nuke/pull/935
 - `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy`. It was the only property you couldn't set at initialization – https://github.com/kean/Nuke/pull/936
+- The APIs removed in Nuke 14 are now unavailable stubs that name their replacement, so the compiler reports the migration instead of "has no member" – https://github.com/kean/Nuke/pull/939
 
 **Bug Fixes**
 

--- a/Sources/Nuke/Pipeline/Deprecated.swift
+++ b/Sources/Nuke/Pipeline/Deprecated.swift
@@ -4,6 +4,81 @@
 
 import Foundation
 
+// MARK: - Removed in Nuke 14
+//
+// Removed APIs are kept as unavailable stubs that name their replacement: the
+// message goes straight into the compiler error, and `renamed:` also becomes an
+// Xcode fix-it. They are deleted two major versions after the removal.
+
+/// - warning: Renamed to ``ImagePipeline/Delegate``.
+@available(*, unavailable, renamed: "ImagePipeline.Delegate")
+public typealias ImagePipelineDelegate = ImagePipeline.Delegate
+
+extension ImageRequest {
+    @available(*, unavailable, renamed: "imageID")
+    public var imageId: String? {
+        get { fatalError() }
+        set { fatalError() }
+    }
+
+    @available(*, unavailable, message: "Removed in Nuke 14. Set the `userInfo` property on the request instead.")
+    public init(url: URL?, processors: [any ImageProcessing] = [], priority: Priority = .normal, options: Options = [], userInfo: [UserInfoKey: any Sendable]?) {
+        fatalError()
+    }
+
+    @available(*, unavailable, message: "Removed in Nuke 14. Set the `userInfo` property on the request instead.")
+    public init(urlRequest: URLRequest, processors: [any ImageProcessing] = [], priority: Priority = .normal, options: Options = [], userInfo: [UserInfoKey: any Sendable]?) {
+        fatalError()
+    }
+
+    @available(*, unavailable, message: "Removed in Nuke 14. Set the `userInfo` property on the request instead.")
+    public init(id: String, data: @Sendable @escaping () async throws -> Data, processors: [any ImageProcessing] = [], priority: Priority = .normal, options: Options = [], userInfo: [UserInfoKey: any Sendable]?) {
+        fatalError()
+    }
+
+    @available(*, unavailable, message: "Removed in Nuke 14. Set the `userInfo` property on the request instead.")
+    public init(id: String, image: @Sendable @escaping () async throws -> ImageContainer, processors: [any ImageProcessing] = [], priority: Priority = .normal, options: Options = [], userInfo: [UserInfoKey: any Sendable]?) {
+        fatalError()
+    }
+}
+
+extension ImageRequest.UserInfoKey {
+    @available(*, unavailable, message: "Removed in Nuke 14. Use `ImageRequest.imageID`.")
+    public static let imageIdKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/imageId"
+
+    @available(*, unavailable, message: "Removed in Nuke 14. Use `ImageRequest.scale`.")
+    public static let scaleKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/scale"
+
+    @available(*, unavailable, message: "Removed in Nuke 14. Use `ImageRequest.thumbnail`.")
+    public static let thumbnailKey: ImageRequest.UserInfoKey = "github.com/kean/nuke/thumbnail"
+}
+
+extension ImagePipeline.Configuration {
+    @available(*, unavailable, message: "Removed in Nuke 14. Automatic downscaling is gone; use `ImageRequest.ThumbnailOptions` per request.")
+    public var maximumDecodedImageSize: Int? {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}
+
+extension ImageDecodingContext {
+    @available(*, unavailable, message: "Removed in Nuke 14. Automatic downscaling is gone; use `ImageRequest.ThumbnailOptions` per request.")
+    public var maximumDecodedImageSize: Int? {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}
+
+extension ImagePipeline {
+    @available(*, unavailable, message: "Removed in Nuke 14. Use `image(for:)` or `imageTask(with:)`. For progressive previews use `ImageTask.previews`.")
+    nonisolated public func imagePublisher(with url: URL) -> Never { fatalError() }
+
+    @available(*, unavailable, message: "Removed in Nuke 14. Use `image(for:)` or `imageTask(with:)`. For progressive previews use `ImageTask.previews`.")
+    nonisolated public func imagePublisher(with request: ImageRequest) -> Never { fatalError() }
+}
+
+// MARK: - Soft-deprecated in Nuke 12.9
+
 extension ImagePipeline {
     // MARK: - Loading Images (Closures)
 

--- a/Sources/NukeUI/Deprecated.swift
+++ b/Sources/NukeUI/Deprecated.swift
@@ -1,0 +1,19 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Combine
+import Nuke
+
+// MARK: - Removed in Nuke 14
+//
+// Removed APIs are kept as unavailable stubs that name their replacement: the
+// message goes straight into the compiler error. They are deleted two major
+// versions after the removal.
+
+extension FetchImage {
+    @available(*, unavailable, message: "Removed in Nuke 14. Use `load(_:)` with an async closure, for example `load { try await pipeline.image(for: url) }`.")
+    public func load<P: Publisher>(_ publisher: P) where P.Output == ImageResponse {
+        fatalError()
+    }
+}


### PR DESCRIPTION
Nuke 14 deletes the APIs deprecated in Nuke 13, and a deleted symbol takes with it the only signal that could have redirected the caller:

```
error: value of type 'ImagePipeline' has no member 'imagePublisher'
```

Every removed symbol is now a zero-cost stub annotated `@available(*, unavailable)` carrying the fix, so the migration lands in the error itself:

```
error: 'imagePublisher(with:)' is unavailable: Removed in Nuke 14.
Use `image(for:)` or `imageTask(with:)`. For progressive previews use
`ImageTask.previews`.
```

`renamed:` also becomes a fix-it in Xcode. There is no runtime or size cost, and Nuke is not ABI-stable, so there's no ABI concern either. The stubs live in `Deprecated.swift` next to the existing soft-deprecations, under a `Removed in Nuke 14` mark; NukeUI gets its own `Deprecated.swift` for the one `FetchImage` overload.

The policy behind it is the durable part. The cycle today is deprecate → delete; this makes it deprecate → unavailable-with-message → delete two majors later. The callers reading these errors are increasingly not people.

### What's covered

Every row of the migration guide's removal tables:

| Stub | Error |
|---|---|
| `ImagePipelineDelegate` | renamed to `ImagePipeline.Delegate` (fix-it) |
| `ImageRequest.imageId` | renamed to `imageID` (fix-it) |
| `UserInfoKey.imageIdKey` / `.scaleKey` / `.thumbnailKey` | Use `ImageRequest.imageID` / `.scale` / `.thumbnail` |
| `Configuration.maximumDecodedImageSize`, `ImageDecodingContext.maximumDecodedImageSize` | Automatic downscaling is gone; use `ImageRequest.ThumbnailOptions` per request |
| the four `ImageRequest.init(…userInfo:)` | Set the `userInfo` property on the request instead |
| `imagePublisher(with:)` ×2 | Use `image(for:)` or `imageTask(with:)` |
| `FetchImage.load(_:)` taking a `Publisher` | Use `load(_:)` with an async closure |

The `userInfo` initializers keep `userInfo` non-defaulted, so `ImageRequest(url:)` stays unambiguous. The publisher stubs return `Never`, which keeps Combine out of the module.

### Two rows left alone

**`ImageTask.Event.started`.** Swift can't express this one. A static-var stub turns `case .started:` into `operator function '~=' requires that 'ImageTask.Event' conform to 'Equatable'`, which points nowhere. An `@available(*, unavailable) case started` inside the enum is worse: a switch pattern matches it with *no diagnostic at all*, silently compiling dead code. I tried both. Since the delegate switch was the only way anyone could use `.started` — it was never yielded by `ImageTask/events` — the unshimmed `has no member 'started'` is the least misleading of the three, and the migration guide carries the before/after.

**`Float` → `CGFloat`** on `ImageRequest.scale` and `ThumbnailOptions.init(maxPixelSize:)`. These are type changes, not removals, and already produce a clear error. A `Float` overload of `init(maxPixelSize:)` would make `ThumbnailOptions(maxPixelSize: 400)` ambiguous, breaking the guide's "literals continue to work as is".

## To test

1. Run the `NukeTests` and `NukeUITests` schemes — both build and pass unchanged; the stubs are additive and no call site resolves differently.
2. Paste a Nuke 13 call into a file that imports Nuke and confirm the error names the replacement, e.g. `pipeline.imagePublisher(with: url)`, `request.imageId`, `ImageRequest(url: url, userInfo: [:])`, `ImageRequest.UserInfoKey.scaleKey`.
3. Check `request.imageId` and `ImagePipelineDelegate` offer an Xcode fix-it.
4. Confirm nothing regressed at the ambiguous call sites: `ImageRequest(url:)` and `ImageRequest.ThumbnailOptions(maxPixelSize: 400)` still compile.
