### PR TITLE
Expose assetType on ImageDecoders.Empty

### DIFF
--- a/Sources/Nuke/Decoding/ImageDecoders+Empty.swift
+++ b/Sources/Nuke/Decoding/ImageDecoders+Empty.swift
@@ -9,7 +9,7 @@ extension ImageDecoders {
     /// data to the image container.
     public struct Empty: ImageDecoding, Sendable {
         public let isProgressive: Bool
-        private let assetType: AssetType?
+        public let assetType: AssetType?
 
         public var isAsynchronous: Bool { false }
 

--- a/Tests/NukeTests/ImageDecodersEmptyTests.swift
+++ b/Tests/NukeTests/ImageDecodersEmptyTests.swift
@@ -23,6 +23,17 @@ struct ImageDecodersEmptyTests {
         #expect(decoder.isProgressive == true)
     }
 
+    @Test func assetTypeDefaultIsNil() {
+        let decoder = ImageDecoders.Empty()
+        #expect(decoder.assetType == nil)
+    }
+
+    @Test func assetTypeWhenProvided() {
+        let decoder = ImageDecoders.Empty(assetType: .png, isProgressive: true)
+        #expect(decoder.assetType == .png)
+        #expect(decoder.isProgressive == true)
+    }
+
     @Test func decodeReturnsContainerWithData() throws {
         let decoder = ImageDecoders.Empty()
         let data = Data("test-data".utf8)


### PR DESCRIPTION
`ImageDecoders.Empty` lets you configure an `assetType` in its initializer, but there is no way to read it back afterwards, unlike the `isProgressive` value set by the same initializer. The stored property was declared `private` while `isProgressive` was `public`; making it `public let` restores the symmetry and is purely additive.