### PR TITLE
Document that copies of a configuration share their task queues

### DIFF
--- a/Documentation/Nuke.docc/Extensions/ImagePipelineConfiguration-Extension.md
+++ b/Documentation/Nuke.docc/Extensions/ImagePipelineConfiguration-Extension.md
@@ -43,6 +43,8 @@ To learn more about caching, see <doc:caching>.
 
 ### Operation Queues
 
+``TaskQueue`` is a class, so copies of a configuration share the same queues. Changing a queue obtained from `ImagePipeline.shared.configuration` also changes it for the shared pipeline.
+
 - ``dataLoadingQueue``
 - ``imageProcessingQueue``
 - ``imageDecompressingQueue``

--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -8,6 +8,23 @@ import os
 
 extension ImagePipeline {
     /// The pipeline configuration.
+    ///
+    /// - important: `Configuration` is a struct, but the task queues it holds –
+    /// ``dataLoadingQueue``, ``imageDecodingQueue``, ``imageEncodingQueue``,
+    /// ``imageProcessingQueue``, and ``imageDecompressingQueue`` – are instances
+    /// of ``TaskQueue``, which is a class. Copying a configuration shares these
+    /// queues instead of duplicating them, so changing a queue on a copy also
+    /// changes it for the pipeline the configuration came from:
+    ///
+    /// ```swift
+    /// var configuration = ImagePipeline.shared.configuration
+    /// configuration.imageProcessingQueue.maxConcurrentOperationCount = 1
+    /// // ImagePipeline.shared is now throttled as well
+    /// ```
+    ///
+    /// To change the queues for a new pipeline without affecting an existing
+    /// one, start from a fresh configuration – `Configuration()` or one of the
+    /// predefined configurations – each of which creates its own queues.
     public struct Configuration: Sendable {
         // MARK: - Dependencies
 


### PR DESCRIPTION
`ImagePipeline.Configuration` is a `Sendable` struct, but its five task queues are `TaskQueue` class references, so copying a configuration shares the queues rather than duplicating them. That makes `var config = ImagePipeline.shared.configuration; config.imageProcessingQueue.maxConcurrentOperationCount = 1` silently throttle the shared pipeline too, which is easy to hit and impossible to guess from the type. This adds an `- important:` note with that exact example to the `Configuration` doc comment and a matching sentence to the Operation Queues section of the DocC page — documentation only, no behavior or API change. Making the value semantics real (a copy-on-assignment wrapper, or plain `Int` concurrency limits on `Configuration`) was deliberately left out as a separate design decision.