### PR TITLE
Rename TaskQueue.maxConcurrentOperationCount to maxConcurrentTaskCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `ImageProcessors/CoreImageFilter` now takes `[String: any Sendable]` filter parameters instead of `[String: Any]`, matching the rest of the public API. The types Core Image filters commonly take – `CIImage`, `CIColor`, `CIVector`, `CGImage`, `NSNumber` – are all `Sendable` – https://github.com/kean/Nuke/pull/934
 - `ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` now conform to `Sendable`. They were the only non-`Sendable` value types left in the public API, even though `ImageLoadingOptions/shared` is `@MainActor`. The `ImageLoadingOptions/Transition/custom(_:)` closure is now `@MainActor @Sendable`, which is where it already ran – https://github.com/kean/Nuke/pull/935
 - `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy`. It was the only property you couldn't set at initialization – https://github.com/kean/Nuke/pull/936
+- `TaskQueue/maxConcurrentOperationCount` and the matching initializer parameter are renamed to `maxConcurrentTaskCount`, which is what the queue's own docs and the five `ImagePipeline/Configuration` queue properties already call it. The old names are deprecated – https://github.com/kean/Nuke/pull/942
 - `ImagePipeline/Delegate/willCache(data:image:for:pipeline:)` is now `async` and returns the data to store instead of handing out an escaping, non-`Sendable` completion closure. Return `nil` to prevent caching – https://github.com/kean/Nuke/pull/943
 
 **Bug Fixes**

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -122,3 +122,24 @@ func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pi
 ```
 
 The method runs on `@ImagePipelineActor`, and the pipeline awaits it before storing the data.
+
+## Renamed `TaskQueue.maxConcurrentOperationCount`
+
+`TaskQueue` has no operations behind it – every unit of work is a Swift `Task` – so it no longer carries the `OperationQueue`-era name. The old name is deprecated and keeps working.
+
+| Nuke 13 | Nuke 14 |
+|---|---|
+| `TaskQueue.maxConcurrentOperationCount` | `TaskQueue.maxConcurrentTaskCount` |
+| `TaskQueue(maxConcurrentOperationCount:)` | `TaskQueue(maxConcurrentTaskCount:)` |
+
+```swift
+// Nuke 13
+let pipeline = ImagePipeline {
+    $0.imageProcessingQueue.maxConcurrentOperationCount = 4
+}
+
+// Nuke 14
+let pipeline = ImagePipeline {
+    $0.imageProcessingQueue.maxConcurrentTaskCount = 4
+}
+```

--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -170,19 +170,19 @@ extension ImagePipeline {
         // MARK: - Task Queues
 
         /// Data loading queue. Default maximum concurrent task count is 6.
-        public var dataLoadingQueue = TaskQueue(maxConcurrentOperationCount: 6)
+        public var dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 6)
 
         /// Image decoding queue. Default maximum concurrent task count is 1.
-        public var imageDecodingQueue = TaskQueue(maxConcurrentOperationCount: 1)
+        public var imageDecodingQueue = TaskQueue(maxConcurrentTaskCount: 1)
 
         /// Image encoding queue. Default maximum concurrent task count is 1.
-        public var imageEncodingQueue = TaskQueue(maxConcurrentOperationCount: 1)
+        public var imageEncodingQueue = TaskQueue(maxConcurrentTaskCount: 1)
 
         /// Image processing queue. Default maximum concurrent task count is 2.
-        public var imageProcessingQueue = TaskQueue(maxConcurrentOperationCount: 2)
+        public var imageProcessingQueue = TaskQueue(maxConcurrentTaskCount: 2)
 
         /// Image decompressing queue. Default maximum concurrent task count is 2.
-        public var imageDecompressingQueue = TaskQueue(maxConcurrentOperationCount: 2)
+        public var imageDecompressingQueue = TaskQueue(maxConcurrentTaskCount: 2)
 
         // MARK: - Initializer
 

--- a/Sources/Nuke/Pipeline/TaskQueue.swift
+++ b/Sources/Nuke/Pipeline/TaskQueue.swift
@@ -202,3 +202,24 @@ public final class TaskQueue: Sendable {
         }
     }
 }
+
+// MARK: - TaskQueue (Deprecated)
+
+extension TaskQueue {
+    /// The maximum number of concurrently running tasks.
+    ///
+    /// - warning: Deprecated in Nuke 14.0. Use ``maxConcurrentTaskCount`` instead.
+    @available(*, deprecated, renamed: "maxConcurrentTaskCount", message: "Deprecated in Nuke 14.0. The queue no longer has operations behind it. Use `maxConcurrentTaskCount` instead.")
+    nonisolated public var maxConcurrentOperationCount: Int {
+        get { maxConcurrentTaskCount }
+        set { maxConcurrentTaskCount = newValue }
+    }
+
+    /// Initializes the queue.
+    ///
+    /// - warning: Deprecated in Nuke 14.0. Use ``init(maxConcurrentTaskCount:)`` instead.
+    @available(*, deprecated, renamed: "init(maxConcurrentTaskCount:)", message: "Deprecated in Nuke 14.0. The queue no longer has operations behind it. Use `init(maxConcurrentTaskCount:)` instead.")
+    nonisolated public convenience init(maxConcurrentOperationCount: Int) {
+        self.init(maxConcurrentTaskCount: maxConcurrentOperationCount)
+    }
+}

--- a/Sources/Nuke/Pipeline/TaskQueue.swift
+++ b/Sources/Nuke/Pipeline/TaskQueue.swift
@@ -42,10 +42,10 @@ public final class TaskQueue: Sendable {
     /// The default value matches the number of cores on the machine. For
     /// operations like image processing, it's recommended to use a lower number
     /// to avoid fully saturating the CPU.
-    nonisolated public var maxConcurrentOperationCount: Int {
-        get { _maxConcurrentOperationCount.withLock { $0 } }
+    nonisolated public var maxConcurrentTaskCount: Int {
+        get { _maxConcurrentTaskCount.withLock { $0 } }
         set {
-            let oldValue = _maxConcurrentOperationCount.withLock {
+            let oldValue = _maxConcurrentTaskCount.withLock {
                 let old = $0; $0 = newValue; return old
             }
             if newValue > oldValue {
@@ -54,7 +54,7 @@ public final class TaskQueue: Sendable {
         }
     }
 
-    nonisolated private let _maxConcurrentOperationCount: OSAllocatedUnfairLock<Int>
+    nonisolated private let _maxConcurrentTaskCount: OSAllocatedUnfairLock<Int>
     nonisolated private let _isSuspended = OSAllocatedUnfairLock(initialState: false)
 
     /// Events emitted by the queue for observation (testing only).
@@ -69,8 +69,8 @@ public final class TaskQueue: Sendable {
     var onEvent: ((Event) -> Void)?
 
     /// Initializes the queue.
-    nonisolated public init(maxConcurrentOperationCount: Int = ProcessInfo.processInfo.processorCount) {
-        self._maxConcurrentOperationCount = OSAllocatedUnfairLock(initialState: maxConcurrentOperationCount)
+    nonisolated public init(maxConcurrentTaskCount: Int = ProcessInfo.processInfo.processorCount) {
+        self._maxConcurrentTaskCount = OSAllocatedUnfairLock(initialState: maxConcurrentTaskCount)
     }
 
     /// Adds work to the queue. The closure runs `@ImagePipelineActor`. The
@@ -97,7 +97,7 @@ public final class TaskQueue: Sendable {
 
     private func drain() {
         guard !isSuspended else { return }
-        while runningCount < maxConcurrentOperationCount && pendingCount > 0 {
+        while runningCount < maxConcurrentTaskCount && pendingCount > 0 {
             guard let operation = dequeueHighestPriority() else { break }
             execute(operation)
         }

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -87,7 +87,7 @@ public final class ImagePrefetcher: Sendable {
     ) {
         self.pipeline = pipeline
         self.destination = destination
-        self.queue = TaskQueue(maxConcurrentOperationCount: maxConcurrentRequestCount)
+        self.queue = TaskQueue(maxConcurrentTaskCount: maxConcurrentRequestCount)
     }
 
     nonisolated deinit {

--- a/Tests/NukeExtensionsTests/ImageViewExtensionsProgressiveDecodingTests.swift
+++ b/Tests/NukeExtensionsTests/ImageViewExtensionsProgressiveDecodingTests.swift
@@ -37,7 +37,7 @@ struct ImagePipelineProgressiveDecodingTests {
             $0.isProgressiveDecodingEnabled = true
             $0.progressiveDecodingInterval = 0
             $0.isStoringPreviewsInMemoryCache = true
-            $0.imageProcessingQueue.maxConcurrentOperationCount = 1
+            $0.imageProcessingQueue.maxConcurrentTaskCount = 1
         }
     }
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -39,7 +39,7 @@ struct ImagePipelineProgressiveDecodingTests {
             $0.isProgressiveDecodingEnabled = true
             $0.isStoringPreviewsInMemoryCache = true
             $0.progressiveDecodingInterval = 0
-            $0.imageProcessingQueue = TaskQueue(maxConcurrentOperationCount: 1)
+            $0.imageProcessingQueue = TaskQueue(maxConcurrentTaskCount: 1)
         }
     }
 

--- a/Tests/NukeTests/TaskQueueTests.swift
+++ b/Tests/NukeTests/TaskQueueTests.swift
@@ -12,7 +12,7 @@ struct TaskQueueTests {
 
     @Test func addedWorkIsExecuted() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let executed = Ref(false)
 
         // When
@@ -25,7 +25,7 @@ struct TaskQueueTests {
 
     @Test func multipleWorkItemsAllComplete() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let count = Ref(0)
 
         // When
@@ -40,7 +40,7 @@ struct TaskQueueTests {
 
     @Test func addReturnsTaskQueueOperation() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
 
         // When
         let operation = queue.add { }
@@ -51,9 +51,9 @@ struct TaskQueueTests {
 
     // MARK: - Concurrency Limit
 
-    @Test func respectsmaxConcurrentOperationCountOfOne() async {
+    @Test func respectsMaxConcurrentTaskCountOfOne() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let item1Started = TestExpectation()
         let item2Started = Ref(false)
         let gate = TestExpectation()
@@ -69,7 +69,7 @@ struct TaskQueueTests {
         // When – wait for item 1 to start
         await item1Started.wait()
 
-        // Then – item 2 hasn't started because maxConcurrentOperationCount is 1
+        // Then – item 2 hasn't started because maxConcurrentTaskCount is 1
         #expect(!item2Started.value)
 
         // Cleanup – release item 1 so the queue drains
@@ -78,9 +78,9 @@ struct TaskQueueTests {
         #expect(item2Started.value)
     }
 
-    @Test func respectsmaxConcurrentOperationCountOfTwo() async {
+    @Test func respectsMaxConcurrentTaskCountOfTwo() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 2)
+        let queue = TaskQueue(maxConcurrentTaskCount: 2)
         let item1Started = TestExpectation()
         let item2Started = TestExpectation()
         let item3Started = Ref(false)
@@ -113,9 +113,9 @@ struct TaskQueueTests {
         #expect(item3Started.value)
     }
 
-    @Test func increasingmaxConcurrentOperationCountDrainsPendingWork() async {
+    @Test func increasingMaxConcurrentTaskCountDrainsPendingWork() async {
         // Given – capacity 1, two items: one running, one blocked
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let item1Started = TestExpectation()
         let item2Started = TestExpectation()
         let gate1 = TestExpectation()
@@ -133,7 +133,7 @@ struct TaskQueueTests {
         await item1Started.wait()
 
         // When – increase capacity to 2
-        queue.maxConcurrentOperationCount = 2
+        queue.maxConcurrentTaskCount = 2
 
         // Then – item 2 starts immediately
         await item2Started.wait()
@@ -144,9 +144,9 @@ struct TaskQueueTests {
         await queue.waitUntilAllOperationsAreFinished()
     }
 
-    @Test func decreasingmaxConcurrentOperationCountLetsRunningFinish() async {
+    @Test func decreasingMaxConcurrentTaskCountLetsRunningFinish() async {
         // Given – capacity 2, two items running
-        let queue = TaskQueue(maxConcurrentOperationCount: 2)
+        let queue = TaskQueue(maxConcurrentTaskCount: 2)
         let item1Started = TestExpectation()
         let item2Started = TestExpectation()
         let item3Started = Ref(false)
@@ -169,7 +169,7 @@ struct TaskQueueTests {
         await item2Started.wait()
 
         // When – reduce capacity to 1 while 2 are running
-        queue.maxConcurrentOperationCount = 1
+        queue.maxConcurrentTaskCount = 1
 
         // Then – both running items complete
         gate1.fulfill()
@@ -180,9 +180,9 @@ struct TaskQueueTests {
         #expect(item3Started.value)
     }
 
-    @Test func settingSamemaxConcurrentOperationCountDoesNotDrain() async {
+    @Test func settingSameMaxConcurrentTaskCountDoesNotDrain() async {
         // Given – capacity 1, one item running, one pending
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let item1Started = TestExpectation()
         let item2Started = Ref(false)
         let gate = TestExpectation()
@@ -198,7 +198,7 @@ struct TaskQueueTests {
         await item1Started.wait()
 
         // When – set to the same value
-        queue.maxConcurrentOperationCount = 1
+        queue.maxConcurrentTaskCount = 1
 
         // Then – no extra drain, item 2 still pending
         #expect(!item2Started.value)
@@ -212,7 +212,7 @@ struct TaskQueueTests {
 
     @Test func highPriorityItemExecutesFirst() async {
         // Given – suspended queue so we can enqueue before any execute
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
 
         let order = Ref<[String]>([])
@@ -235,7 +235,7 @@ struct TaskQueueTests {
 
     @Test func priorityCanBeUpdatedBeforeExecution() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
 
         let order = Ref<[String]>([])
@@ -256,7 +256,7 @@ struct TaskQueueTests {
 
     @Test func fifoOrderWithinSamePriority() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let order = Ref<[Int]>([])
 
@@ -274,7 +274,7 @@ struct TaskQueueTests {
 
     @Test func decreasingPriorityMovesOperationBackward() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let order = Ref<[String]>([])
 
@@ -298,7 +298,7 @@ struct TaskQueueTests {
 
     @Test func decreasedPriorityGoesAheadOfExistingLowerPriorityItems() async {
         // Given – A(high), B(normal), C(normal)
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let order = Ref<[String]>([])
 
@@ -320,7 +320,7 @@ struct TaskQueueTests {
 
     @Test func decreasedPriorityPrependsAcrossMultipleDrops() async {
         // Given – A(veryHigh), B(normal), C(normal)
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let order = Ref<[String]>([])
 
@@ -342,7 +342,7 @@ struct TaskQueueTests {
 
     @Test func increasedPriorityAppendsAfterExistingHigherPriorityItems() async {
         // Given – A(normal), B(high), C(high)
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let order = Ref<[String]>([])
 
@@ -364,7 +364,7 @@ struct TaskQueueTests {
 
     @Test func twoDecreasesPrependInOrder() async {
         // Given – A(high), B(high), C(normal)
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let order = Ref<[String]>([])
 
@@ -387,7 +387,7 @@ struct TaskQueueTests {
 
     @Test func multiplePriorityChangesBeforeExecution() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let order = Ref<[String]>([])
 
@@ -410,7 +410,7 @@ struct TaskQueueTests {
 
     @Test func priorityChangeOfRunningOperationIsNoOp() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let started = TestExpectation()
         let gate = TestExpectation()
 
@@ -436,7 +436,7 @@ struct TaskQueueTests {
 
     @Test func cancelledOperationIsNotExecuted() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let executed = Ref(false)
 
@@ -456,7 +456,7 @@ struct TaskQueueTests {
 
     @Test func cancellingOperationRemovesItFromPending() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
 
         let done = Ref(false)
@@ -478,7 +478,7 @@ struct TaskQueueTests {
         // Given – the queue has a free slot, so the operation is dequeued and
         // started right away, but its work doesn't run until the underlying
         // task gets scheduled
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let executed = Ref(false)
         let operation = queue.add { executed.value = true }
 
@@ -492,7 +492,7 @@ struct TaskQueueTests {
 
     @Test func runningOperationIsRetainedByTheQueue() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let started = TestExpectation()
         let gate = TestExpectation()
 
@@ -515,7 +515,7 @@ struct TaskQueueTests {
 
     @Test func cancellingAlreadyCancelledOperationIsNoop() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let operation = queue.add { }
 
         // When
@@ -528,7 +528,7 @@ struct TaskQueueTests {
 
     @Test func cancellingRunningOperationCancelsUnderlyingTask() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let started = TestExpectation()
         let taskWasCancelled = Ref(false)
         let gate = TestExpectation()
@@ -555,7 +555,7 @@ struct TaskQueueTests {
 
     @Test func cancelledItemIsSkippedDuringDrain() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
 
         let order = Ref<[Int]>([])
@@ -577,7 +577,7 @@ struct TaskQueueTests {
 
     @Test func suspendedQueueDoesNotExecuteWork() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let executed = Ref(false)
 
@@ -590,7 +590,7 @@ struct TaskQueueTests {
 
     @Test func resumingQueueExecutesPendingWork() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let executed = Ref(false)
 
@@ -606,7 +606,7 @@ struct TaskQueueTests {
 
     @Test func suspendingAlreadySuspendedQueueIsNoop() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
 
         // When
         queue.isSuspended = true
@@ -618,7 +618,7 @@ struct TaskQueueTests {
 
     @Test func resumingAlreadyResumedQueueIsNoop() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
 
         // When
         queue.isSuspended = false
@@ -631,7 +631,7 @@ struct TaskQueueTests {
 
     @Test func throwingWorkFreesSlot() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let secondRan = Ref(false)
 
         struct TestError: Error {}
@@ -654,7 +654,7 @@ struct TaskQueueTests {
 
     @Test func priorityChangeFiresEvent() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         var didChange = false
         queue.onEvent = { event in
@@ -672,7 +672,7 @@ struct TaskQueueTests {
 
     @Test func settingSamePriorityDoesNotFireEvent() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         var changeCount = 0
         queue.onEvent = { event in
@@ -695,7 +695,7 @@ struct TaskQueueTests {
 
     @Test func cancelFiresEvent() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         var called = false
         queue.onEvent = { event in
@@ -714,7 +714,7 @@ struct TaskQueueTests {
 
     @Test func onEventEnqueuedCalledForEachAdd() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 2)
+        let queue = TaskQueue(maxConcurrentTaskCount: 2)
         var enqueuedCount = 0
         queue.onEvent = { event in
             if case .enqueued = event { enqueuedCount += 1 }
@@ -731,7 +731,7 @@ struct TaskQueueTests {
 
     @Test func onEventEnqueuedReceivesCorrectOperation() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
 
         var enqueuedOperations = [TaskQueue.Operation]()
@@ -753,7 +753,7 @@ struct TaskQueueTests {
 
     @Test func operationCountReflectsPendingItems() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
 
         // When
@@ -766,7 +766,7 @@ struct TaskQueueTests {
 
     @Test func operationCountIncludesRunningItems() {
         // Given – unsuspended queue, items start immediately
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
 
         // When
         queue.add { }
@@ -777,13 +777,13 @@ struct TaskQueueTests {
     }
 
     @Test func operationCountIsZeroWhenEmpty() {
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         #expect(queue.operationCount == 0)
     }
 
     @Test func operationCountDecreasesAfterCancellation() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         let op = queue.add { }
         #expect(queue.operationCount == 1)
@@ -799,7 +799,7 @@ struct TaskQueueTests {
 
     @Test func waitForOperationsHelper() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
 
         // When
@@ -816,7 +816,7 @@ struct TaskQueueTests {
 
     @Test func suspendingQueueDoesNotAffectRunningOperations() async {
         // Given – one running, one pending
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let item1Started = TestExpectation()
         let item1Finished = TestExpectation()
         let gate = TestExpectation()
@@ -852,7 +852,7 @@ struct TaskQueueTests {
 
     @Test func onEventFinishedCalledForEachCompletion() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         var finishedCount = 0
         queue.onEvent = { event in
             if case .finished = event { finishedCount += 1 }
@@ -870,14 +870,14 @@ struct TaskQueueTests {
     // MARK: - Edge Cases
 
     @Test func emptyQueueDoesNotCrash() {
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         #expect(!queue.isSuspended)
         #expect(queue.operationCount == 0)
     }
 
     @Test func waitUntilAllOperationsAreFinishedOnEmptyQueue() async {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
 
         // When/Then – returns immediately, no hang
         await queue.waitUntilAllOperationsAreFinished()
@@ -885,7 +885,7 @@ struct TaskQueueTests {
 
     @Test func addingWorkAfterQueueHasDrained() async {
         // Given – queue has already processed work
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.add { }
         await queue.waitUntilAllOperationsAreFinished()
         #expect(queue.operationCount == 0)
@@ -901,7 +901,7 @@ struct TaskQueueTests {
 
     @Test func priorityChangeOnCancelledOperationIsNoOp() {
         // Given
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         queue.isSuspended = true
         var priorityEventCount = 0
         queue.onEvent = { event in
@@ -920,7 +920,7 @@ struct TaskQueueTests {
 
     @Test func cancellingRunningOperationDoesNotChangePendingCount() async {
         // Given – one running, one pending
-        let queue = TaskQueue(maxConcurrentOperationCount: 1)
+        let queue = TaskQueue(maxConcurrentTaskCount: 1)
         let started = TestExpectation()
         let gate = TestExpectation()
 

--- a/Tests/NukeUITests/FetchImageTests.swift
+++ b/Tests/NukeUITests/FetchImageTests.swift
@@ -231,7 +231,7 @@ struct FetchImageTests {
             $0.imageCache = nil
             $0.isProgressiveDecodingEnabled = true
             $0.progressiveDecodingInterval = 0
-            $0.imageProcessingQueue.maxConcurrentOperationCount = 1
+            $0.imageProcessingQueue.maxConcurrentTaskCount = 1
         }
         image.pipeline = progressivePipeline
 

--- a/Tests/NukeUITests/LazyImageViewTests.swift
+++ b/Tests/NukeUITests/LazyImageViewTests.swift
@@ -695,7 +695,7 @@ struct LazyImageViewTests {
             $0.imageCache = nil
             $0.isProgressiveDecodingEnabled = true
             $0.progressiveDecodingInterval = 0
-            $0.imageProcessingQueue.maxConcurrentOperationCount = 1
+            $0.imageProcessingQueue.maxConcurrentTaskCount = 1
         }
         // The reset is deferred until a new image is ready, so it is applied
         // when the first preview is displayed.
@@ -788,7 +788,7 @@ struct LazyImageViewTests {
             $0.imageCache = nil
             $0.isProgressiveDecodingEnabled = true
             $0.progressiveDecodingInterval = 0
-            $0.imageProcessingQueue.maxConcurrentOperationCount = 1
+            $0.imageProcessingQueue.maxConcurrentTaskCount = 1
         }
     }
 


### PR DESCRIPTION
`TaskQueue` no longer has operations behind it, but it still carried the `OperationQueue`-era `maxConcurrentOperationCount` name, even though its own docs and all five `ImagePipeline.Configuration` queue properties already describe it as a "maximum concurrent task count". It was also `public` while living in `Sources/Nuke/Internal/`, the one directory a reader would assume holds nothing public — it has to stay public because `ImagePipeline.Configuration` exposes five `TaskQueue` properties.

- `TaskQueue.maxConcurrentOperationCount` and the matching initializer parameter label are now `maxConcurrentTaskCount` (`TaskQueue.Operation` is untouched).
- The old name shipped in Nuke 13.0, so it stays as a deprecated alias: the property and an initializer with the old label forward to the new ones and carry a `renamed:` fix-it. `TaskQueue()` stays unambiguous because the deprecated initializer has no default value.
- `TaskQueue.swift` moved from `Sources/Nuke/Internal/` to `Sources/Nuke/Pipeline/`, next to the other public pipeline types.
