### PR TITLE
Make ImagePipeline.Delegate.willCache async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `ImageProcessors/CoreImageFilter` now takes `[String: any Sendable]` filter parameters instead of `[String: Any]`, matching the rest of the public API. The types Core Image filters commonly take – `CIImage`, `CIColor`, `CIVector`, `CGImage`, `NSNumber` – are all `Sendable` – https://github.com/kean/Nuke/pull/934
 - `ImageLoadingOptions` and its nested `ContentModes`, `TintColors`, and `Transition` now conform to `Sendable`. They were the only non-`Sendable` value types left in the public API, even though `ImageLoadingOptions/shared` is `@MainActor`. The `ImageLoadingOptions/Transition/custom(_:)` closure is now `@MainActor @Sendable`, which is where it already ran – https://github.com/kean/Nuke/pull/935
 - `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy`. It was the only property you couldn't set at initialization – https://github.com/kean/Nuke/pull/936
+- `ImagePipeline/Delegate/willCache(data:image:for:pipeline:)` is now `async` and returns the data to store instead of handing out an escaping, non-`Sendable` completion closure. Return `nil` to prevent caching – https://github.com/kean/Nuke/pull/943
 
 **Bug Fixes**
 

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -104,3 +104,21 @@ request.scale = Float(traitCollection.displayScale)
 // Nuke 14
 request.scale = traitCollection.displayScale
 ```
+
+## `willCache` is now `async`
+
+`ImagePipeline.Delegate.willCache(data:image:for:pipeline:)` returns the data to store instead of taking a completion closure. Return `nil` to prevent caching.
+
+```swift
+// Nuke 13
+func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline, completion: @escaping (Data?) -> Void) {
+    completion(shouldStore(request) ? data : nil)
+}
+
+// Nuke 14
+func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline) async -> Data? {
+    shouldStore(request) ? data : nil
+}
+```
+
+The method runs on `@ImagePipelineActor`, and the pipeline awaits it before storing the data.

--- a/Documentation/Nuke.docc/Extensions/ImagePipelineDelegate-Extension.md
+++ b/Documentation/Nuke.docc/Extensions/ImagePipelineDelegate-Extension.md
@@ -18,7 +18,7 @@
 - ``imageCache(for:pipeline:)``
 - ``dataCache(for:pipeline:)``
 - ``cacheKey(for:pipeline:)``
-- ``willCache(data:image:for:pipeline:completion:)``
+- ``willCache(data:image:for:pipeline:)``
 
 ### Decompression
 

--- a/Sources/Nuke/Pipeline/ImagePipeline+Delegate.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Delegate.swift
@@ -65,11 +65,11 @@ extension ImagePipeline {
         func cacheKey(for request: ImageRequest, pipeline: ImagePipeline) -> String?
 
         /// Gets called when the pipeline is about to save data for the given request.
-        /// The implementation must call the completion closure passing `non-nil` data
-        /// to enable caching or `nil` to prevent it.
         ///
         /// This method is called only if the request parameters and data caching policy
         /// of the pipeline already allow caching.
+        ///
+        /// The default implementation returns `data` unchanged.
         ///
         /// - parameters:
         ///   - data: Either the original data or the encoded image in case of storing
@@ -77,11 +77,9 @@ extension ImagePipeline {
         ///   - image: Non-nil in case storing an encoded image.
         ///   - request: The request for which image is being stored.
         ///   - pipeline: The pipeline that is about to store the data.
-        ///   - completion: The implementation must call the completion closure
-        ///   passing `non-nil` data to enable caching or `nil` to prevent it. You can
-        ///   safely call it synchronously. The callback gets called on the background
-        ///   thread.
-        func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline, completion: @escaping (Data?) -> Void)
+        /// - returns: The data to store. Return `nil` to prevent caching.
+        @ImagePipelineActor
+        func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline) async -> Data?
 
         // MARK: Decompression
 
@@ -147,8 +145,9 @@ extension ImagePipeline.Delegate {
         nil
     }
 
-    public func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline, completion: @escaping (Data?) -> Void) {
-        completion(data)
+    @ImagePipelineActor
+    public func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline) async -> Data? {
+        data
     }
 
     public func shouldDecompress(response: ImageResponse, for request: ImageRequest, pipeline: ImagePipeline) -> Bool {

--- a/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
@@ -108,13 +108,13 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
             try await loadData(with: urlRequest, dataLoader: dataLoader)
 
             signpost(self, "LoadImageData", .end, "Finished with size \(Formatter.bytes(self.data.count))")
-            dataTaskDidFinish()
+            await dataTaskDidFinish()
         } catch {
             signpost(self, "LoadImageData", .end, "Failed")
             if let error = error as? ImagePipeline.Error {
-                dataTaskDidFinish(error: error)
+                await dataTaskDidFinish(error: error)
             } else {
-                dataTaskDidFinish(error: .dataLoadingFailed(error: error))
+                await dataTaskDidFinish(error: .dataLoadingFailed(error: error))
             }
         }
     }
@@ -216,7 +216,7 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
         send(value: (data, response))
     }
 
-    private func dataTaskDidFinish(error: ImagePipeline.Error? = nil) {
+    private func dataTaskDidFinish(error: ImagePipeline.Error? = nil) async {
         guard !isDisposed else { return }
 
         if let error {
@@ -232,7 +232,7 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
         }
 
         // Store in data cache
-        storeDataInCacheIfNeeded(data)
+        await storeDataInCacheIfNeeded(data)
 
         send(value: (data, urlResponse), isCompleted: true)
     }
@@ -258,18 +258,18 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
         guard !isDisposed else { return }
         do {
             let data = try await fetch()
-            asyncDataDidFinish(data)
+            await asyncDataDidFinish(data)
         } catch {
             send(error: .dataLoadingFailed(error: error))
         }
     }
 
-    private func asyncDataDidFinish(_ data: Data) {
+    private func asyncDataDidFinish(_ data: Data) async {
         guard !data.isEmpty else {
             send(error: .dataIsEmpty)
             return
         }
-        storeDataInCacheIfNeeded(data)
+        await storeDataInCacheIfNeeded(data)
         send(value: (data, nil), isCompleted: true)
     }
 
@@ -293,17 +293,15 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
 }
 
 extension AsyncPipelineTask where Value == (Data, URLResponse?) {
-    func storeDataInCacheIfNeeded(_ data: Data) {
+    func storeDataInCacheIfNeeded(_ data: Data) async {
         let request = makeSanitizedRequest()
         guard let dataCache = pipeline.delegate.dataCache(for: request, pipeline: pipeline), shouldStoreDataInDiskCache() else {
             return
         }
         let key = pipeline.cache.makeDataCacheKey(for: request)
-        pipeline.delegate.willCache(data: data, image: nil, for: request, pipeline: pipeline) {
-            guard let data = $0 else { return }
-            // Important! Storing directly ignoring `ImageRequest.Options`.
-            dataCache.storeData(data, for: key)
-        }
+        guard let data = await pipeline.delegate.willCache(data: data, image: nil, for: request, pipeline: pipeline) else { return }
+        // Important! Storing directly ignoring `ImageRequest.Options`.
+        dataCache.storeData(data, for: key)
     }
 
     /// Returns a request that doesn't contain any information non-related

--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -166,11 +166,9 @@ final class TaskLoadImage: AsyncPipelineTask<ImageResponse> {
                 }
             }
             guard let data, !data.isEmpty else { return }
-            pipeline.delegate.willCache(data: data, image: response.container, for: request, pipeline: pipeline) {
-                guard let data = $0, !data.isEmpty else { return }
-                // Important! Storing directly ignoring `ImageRequest.Options`.
-                dataCache.storeData(data, for: key) // This is instant, writes are async
-            }
+            guard let data = await pipeline.delegate.willCache(data: data, image: response.container, for: request, pipeline: pipeline), !data.isEmpty else { return }
+            // Important! Storing directly ignoring `ImageRequest.Options`.
+            dataCache.storeData(data, for: key) // This is instant, writes are async
         }
     }
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDelegateTests.swift
@@ -60,6 +60,8 @@ struct ImagePipelineDelegateTests {
         #expect(dataLoader.createdTaskCount == 1)
     }
 
+    // MARK: - willCache
+
     @Test func dataIsStoredInCache() async throws {
         // WHEN
         _ = try await pipeline.image(for: Test.request)
@@ -77,6 +79,46 @@ struct ImagePipelineDelegateTests {
 
         // THEN
         #expect(dataCache.store.isEmpty)
+    }
+
+    @Test func willCacheReturningNilPreventsStoringData() async throws {
+        // GIVEN a delegate that returns `nil` from `willCache`
+        delegate.willCacheTransform = { _ in nil }
+
+        // WHEN
+        _ = try await pipeline.image(for: Test.request)
+
+        // THEN nothing is written to the disk cache
+        #expect(dataCache.store.isEmpty)
+        #expect(dataCache.writeCount == 0)
+    }
+
+    @Test func willCacheReturningModifiedDataStoresModifiedData() async throws {
+        // GIVEN a delegate that replaces the data passed to `willCache`
+        let modifiedData = Data("modified".utf8)
+        delegate.willCacheTransform = { _ in modifiedData }
+
+        // WHEN
+        _ = try await pipeline.image(for: Test.request)
+
+        // THEN the modified data is what ends up in the disk cache
+        #expect(dataCache.store.count == 1)
+        #expect(dataCache.store.values.first == modifiedData)
+    }
+
+    @Test func willCacheReturningNilPreventsStoringEncodedImage() async throws {
+        // GIVEN a delegate that returns `nil` from `willCache` and a request
+        // that makes the pipeline store a processed (re-encoded) image
+        delegate.willCacheTransform = { _ in nil }
+        let request = ImageRequest(url: Test.url, processors: [.resize(width: 44)])
+
+        // WHEN
+        _ = try await pipeline.image(for: request)
+        await pipeline.configuration.imageEncodingQueue.waitUntilAllOperationsAreFinished()
+
+        // THEN nothing is written to the disk cache
+        #expect(dataCache.store.isEmpty)
+        #expect(dataCache.writeCount == 0)
     }
 
     // MARK: - willLoadData
@@ -180,6 +222,9 @@ struct ImagePipelineDelegateTests {
 private final class MockImagePipelineDelegate: ImagePipeline.Delegate, @unchecked Sendable {
     var isCacheEnabled = true
 
+    /// Applied to the data passed to `willCache`. Return `nil` to prevent caching.
+    var willCacheTransform: ((Data) -> Data?)?
+
     // willLoadData tracking
     var willLoadDataCallCount = 0
     var willLoadDataRequest: URLRequest?
@@ -192,8 +237,9 @@ private final class MockImagePipelineDelegate: ImagePipeline.Delegate, @unchecke
         request.userInfo["imageId"] as? String
     }
 
-    func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline, completion: @escaping (Data?) -> Void) {
-        completion(isCacheEnabled ? data : nil)
+    func willCache(data: Data, image: ImageContainer?, for request: ImageRequest, pipeline: ImagePipeline) async -> Data? {
+        guard isCacheEnabled else { return nil }
+        return willCacheTransform.map { $0(data) } ?? data
     }
 
     func willLoadData(


### PR DESCRIPTION
`willCache` was the last completion-handler method left in `ImagePipeline.Delegate`, and it handed an escaping, non-`@Sendable` closure out of a protocol that refines `Sendable` — so implementations had no safe way to resume it off the pipeline actor, unlike its sibling `willLoadData`, which is already `@ImagePipelineActor ... async`. It now returns the data to store instead: `func willCache(data:image:for:pipeline:) async -> Data?`, returning `nil` to prevent caching. The two pipeline call sites await it inline, so the store still happens before the value is delivered. This is source-breaking for anyone implementing the delegate — replace the `completion(x)` call with `return x`.