### PR TITLE
Re-export Nuke from NukeUI, NukeExtensions, and NukeVideo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy` – https://github.com/kean/Nuke/pull/936
 - `TaskQueue/maxConcurrentOperationCount` and the matching initializer parameter are renamed to `maxConcurrentTaskCount`; the old names are deprecated – https://github.com/kean/Nuke/pull/942
 - `ImagePipeline/Delegate/willCache(data:image:for:pipeline:)` is now `async` and returns the data to store instead of taking a completion closure. Return `nil` to prevent caching – https://github.com/kean/Nuke/pull/943
+- `NukeUI`, `NukeExtensions`, and `NukeVideo` now re-export `Nuke`, so importing them is enough. The `NukeUI.ImageRequest` typealias is removed – https://github.com/kean/Nuke/pull/945
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - `ImageDecodingContext/init(request:data:isCompleted:urlResponse:cacheType:previewPolicy:)` now takes `previewPolicy` – https://github.com/kean/Nuke/pull/936
 - `TaskQueue/maxConcurrentOperationCount` and the matching initializer parameter are renamed to `maxConcurrentTaskCount`; the old names are deprecated – https://github.com/kean/Nuke/pull/942
 - `ImagePipeline/Delegate/willCache(data:image:for:pipeline:)` is now `async` and returns the data to store instead of taking a completion closure. Return `nil` to prevent caching – https://github.com/kean/Nuke/pull/943
-- `NukeUI`, `NukeExtensions`, and `NukeVideo` now re-export `Nuke`, so importing them is enough. The `NukeUI.ImageRequest` typealias is removed – https://github.com/kean/Nuke/pull/945
+- `NukeUI`, `NukeExtensions`, and `NukeVideo` now re-export `Nuke`, so importing them is enough. The `NukeUI.ImageRequest` typealias is removed – https://github.com/kean/Nuke/pull/946
 
 **Bug Fixes**
 

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,9 @@ let package = Package(
         .target(name: "Nuke"),
         .target(name: "NukeUI", dependencies: ["Nuke"]),
         .target(name: "NukeVideo", dependencies: ["Nuke"]),
-        .target(name: "NukeExtensions", dependencies: ["Nuke"])
+        .target(name: "NukeExtensions", dependencies: ["Nuke"]),
+        // The other modules are tested from Nuke.xcodeproj; NukeVideo has no
+        // test target there, so this one keeps its API covered.
+        .testTarget(name: "NukeVideoTests", dependencies: ["NukeVideo"])
     ]
 )

--- a/Sources/NukeExtensions/ImageViewExtensions.swift
+++ b/Sources/NukeExtensions/ImageViewExtensions.swift
@@ -3,7 +3,9 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
-import Nuke
+
+// NukeExtensions' API is written in Nuke types, so `import NukeExtensions` is enough to use it.
+@_exported import Nuke
 
 #if !os(macOS)
 import UIKit.UIImage

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -3,10 +3,10 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
-import Nuke
 import SwiftUI
 
-public typealias ImageRequest = Nuke.ImageRequest
+// NukeUI's API is written in Nuke types, so `import NukeUI` is enough to use it.
+@_exported import Nuke
 
 /// A view that asynchronously loads and displays an image.
 ///

--- a/Sources/NukeVideo/AVDataAsset.swift
+++ b/Sources/NukeVideo/AVDataAsset.swift
@@ -4,7 +4,9 @@
 
 import AVKit
 import Foundation
-import Nuke
+
+// NukeVideo extends Nuke types, so `import NukeVideo` is enough to use it.
+@_exported import Nuke
 
 extension AssetType {
     /// Returns `true` if the asset represents a video file.

--- a/Tests/NukeExtensionsTests/NukeExtensionsExportsTests.swift
+++ b/Tests/NukeExtensionsTests/NukeExtensionsExportsTests.swift
@@ -1,0 +1,40 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import Foundation
+import NukeExtensions // Deliberately the only Nuke import in this file.
+
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
+
+/// NukeExtensions writes its API in Nuke types, so `import NukeExtensions` has
+/// to be enough to use it. These tests stop compiling if the re-export is removed.
+@Suite @MainActor
+struct NukeExtensionsExportsTests {
+    @Test func imageLoadingOptions() {
+        var options = ImageLoadingOptions()
+        options.pipeline = ImagePipeline.shared
+        options.processors = [ImageProcessors.Resize(width: 100)]
+
+        #expect(options.pipeline != nil)
+        #expect(options.processors.count == 1)
+    }
+
+    @Test func loadImageIntoView() {
+        var options = ImageLoadingOptions()
+        options.pipeline = ImagePipeline { $0.dataLoader = MockDataLoader() }
+
+        let view: ImageDisplayingView = _ImageView()
+        let request = ImageRequest(url: URL(string: "https://example.com/image.jpeg"))
+        let task: ImageTask? = loadImage(with: request, options: options, into: view) { (result: Result<ImageResponse, ImagePipeline.Error>) in
+            _ = result
+        }
+        task?.cancel()
+        cancelRequest(for: view)
+
+        #expect(task != nil)
+    }
+}
+
+#endif

--- a/Tests/NukeUITests/NukeUIExportsTests.swift
+++ b/Tests/NukeUITests/NukeUIExportsTests.swift
@@ -1,0 +1,57 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import Foundation
+import SwiftUI
+import NukeUI // Deliberately the only Nuke import in this file.
+
+/// NukeUI writes its API in Nuke types, so `import NukeUI` has to be enough to
+/// use it. These tests stop compiling if the re-export is removed.
+@Suite @MainActor
+struct NukeUIExportsTests {
+    @Test func lazyImage() {
+        let request = ImageRequest(url: Self.url, processors: [ImageProcessors.Resize(width: 100)], priority: .high)
+        let view = LazyImage(request: request)
+            .processors([ImageProcessors.Circle()])
+            .priority(.veryHigh)
+            .pipeline(ImagePipeline.shared)
+            .onStart { (task: ImageTask) in _ = task }
+            .onCompletion { (result: Result<ImageResponse, Error>) in _ = result }
+
+        #expect(request.priority == .high)
+        withExtendedLifetime(view) {}
+    }
+
+    @Test func fetchImage() {
+        let image = FetchImage()
+        image.priority = .high
+        image.pipeline = ImagePipeline.shared
+        image.processors = [ImageProcessors.Resize(width: 100)]
+
+        let container: ImageContainer? = image.imageContainer
+        let result: Result<ImageResponse, Error>? = image.result
+
+        #expect(container == nil)
+        #expect(result == nil)
+    }
+
+#if !os(watchOS)
+    @Test func lazyImageView() {
+        let view = LazyImageView()
+        view.priority = .high
+        view.pipeline = ImagePipeline.shared
+        view.processors = [ImageProcessors.Resize(width: 100)]
+        view.onProgress = { (progress: ImageTask.Progress) in _ = progress }
+
+        let request: ImageRequest? = view.request
+        let task: ImageTask? = view.imageTask
+
+        #expect(request == nil)
+        #expect(task == nil)
+    }
+#endif
+
+    private static let url = URL(string: "https://example.com/image.jpeg")
+}

--- a/Tests/NukeVideoTests/NukeVideoExportsTests.swift
+++ b/Tests/NukeVideoTests/NukeVideoExportsTests.swift
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import Foundation
+import NukeVideo // Deliberately the only Nuke import in this file.
+
+/// NukeVideo extends Nuke types, so `import NukeVideo` has to be enough to use
+/// it. These tests stop compiling if the re-export is removed.
+@Suite
+struct NukeVideoExportsTests {
+    @Test func assetType() {
+        #expect(AssetType.mp4.isVideo)
+        #expect(!AssetType.jpeg.isVideo)
+    }
+
+#if !os(watchOS) && !os(visionOS)
+    @Test func videoDecoder() {
+        let makeDecoder: (ImageDecodingContext) -> (any ImageDecoding)? = {
+            ImageDecoders.Video(context: $0)
+        }
+        let key: ImageContainer.UserInfoKey = .videoAssetKey
+
+        #expect(key.rawValue == "com.github/kean/nuke/video-asset")
+        withExtendedLifetime(makeDecoder) {}
+    }
+#endif
+}


### PR DESCRIPTION
NukeUI re-exported `ImageRequest` with a public typealias, so its own signatures read as `NukeUI.ImageRequest` and the generated documentation carried two spellings of one type. Replacing the typealias with `@_exported import Nuke` leaves one spelling and keeps `import NukeUI` self-sufficient for `ImagePipeline` and `ImageProcessing`, which its API already named unaliased. Nothing breaks for callers: unqualified `ImageRequest` still resolves, and so does the old `NukeUI.ImageRequest`, now through the re-export.

NukeExtensions and NukeVideo have the same shape — `loadImage` takes an `ImageRequest`, `ImageLoadingOptions` carries an `ImagePipeline`, and NukeVideo is entirely extensions on Nuke types, so it can't be used at all without importing Nuke — so both re-export it too.

The new tests import only the umbrella module and name the Nuke types in its API, so they stop compiling if a re-export goes away (verified by putting `import Nuke` back). NukeVideo has no test target in Nuke.xcodeproj, so it gets one in Package.swift, covered by the existing `swift build --build-tests` job.

### To test

1. `make ci-ios-ui`, `make ci-tvos`, `make ci-macos` — the new `NukeUIExportsTests` and `NukeExtensionsExportsTests` run alongside the existing suites.
2. `make ci-platforms` — builds every module on watchOS and visionOS and compiles `NukeVideoExportsTests` via SPM.