### PR TITLE
Rename Nuke_ImageDisplaying to ImageDisplaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `NukeUI`, `NukeExtensions`, and `NukeVideo` now re-export `Nuke`, so importing them is enough. The `NukeUI.ImageRequest` typealias is removed – https://github.com/kean/Nuke/pull/946
 - `ImagePipeline/Delegate` now declares the isolation of every method instead of documenting it: `willLoadData`, `willCache`, `imageTaskDidStart`, and `imageTask(_:didReceiveEvent:pipeline:)` run on `ImagePipelineActor`, and the rest are `nonisolated` – https://github.com/kean/Nuke/pull/945
 - `NukeExtensions` is folded into `NukeUI`. The image view extensions now ship in `NukeUI`, and `NukeExtensions` is an empty module that re-exports it, scheduled for removal in Nuke 15 – https://github.com/kean/Nuke/pull/947
+- `Nuke_ImageDisplaying` is renamed to `ImageDisplaying` and `nuke_display(image:data:)` to `display(image:data:)`. The protocol is no longer `@objc`, but the built-in conformances keep their `nuke_displayWithImage:data:` selector, so subclasses can still override them – https://github.com/kean/Nuke/pull/950
 
 **Bug Fixes**
 

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -16,7 +16,7 @@ Apps that need to support earlier OS versions can stay on Nuke 13.x, which conti
 
 ## `NukeExtensions` Folded into `NukeUI`
 
-The image view extensions – `loadImage(with:into:)`, `cancelRequest(for:)`, `ImageLoadingOptions`, and `Nuke_ImageDisplaying` – moved from `NukeExtensions` to `NukeUI`, which is where the other UIKit and AppKit views already lived. The package now ships three modules: `Nuke`, `NukeUI`, and `NukeVideo`.
+The image view extensions – `loadImage(with:into:)`, `cancelRequest(for:)`, `ImageLoadingOptions`, and `ImageDisplaying` – moved from `NukeExtensions` to `NukeUI`, which is where the other UIKit and AppKit views already lived. The package now ships three modules: `Nuke`, `NukeUI`, and `NukeVideo`.
 
 `NukeExtensions` still exists as an empty module that re-exports `NukeUI`, so existing code keeps compiling. It will be removed in Nuke 15.
 
@@ -37,6 +37,38 @@ NukeExtensions.loadImage(with: url, into: imageView)
 // After
 NukeUI.loadImage(with: url, into: imageView)
 ```
+
+## `Nuke_ImageDisplaying` Renamed to `ImageDisplaying`
+
+The protocol and its requirement dropped their Objective-C prefixes.
+
+```swift
+// Before
+extension MyImageView: Nuke_ImageDisplaying {
+    func nuke_display(image: UIImage?, data: Data?) {
+        self.image = image
+    }
+}
+
+// After
+extension MyImageView: ImageDisplaying {
+    func display(image: UIImage?, data: Data?) {
+        self.image = image
+    }
+}
+```
+
+The protocol is no longer `@objc`. The prefixes were there to keep it from clashing with other protocols and methods in the Objective-C runtime, but only the built-in conformances ever needed to be visible to it: they are declared in extensions of `UIImageView`, `NSImageView`, and `TVPosterView`, and Swift can only override a member declared in an extension if it's `@objc`. Those conformances keep the `nuke_displayWithImage:data:` selector they had in Nuke 13, so overriding the method in a subclass still works, and an Objective-C subclass needs no changes at all.
+
+```swift
+// Before
+override func nuke_display(image: UIImage?, data: Data?)
+
+// After
+override func display(image: UIImage?, data: Data?)
+```
+
+`ImageDisplayingView`, `loadImage(with:into:)`, and `cancelRequest(for:)` are unchanged, so code that only uses the built-in `UIImageView` and `NSImageView` support needs no changes.
 
 ## Removed Deprecated APIs
 

--- a/Documentation/NukeUI.docc/ImageViewExtensions.md
+++ b/Documentation/NukeUI.docc/ImageViewExtensions.md
@@ -109,19 +109,17 @@ Nuke supports progressive JPEG out of the box.
 
 ## Custom Views
 
-You can use image view extensions with custom views by implementing ``Nuke_ImageDisplaying`` protocol.
-
-> The name of the protocol has a prefix because it's an Objective-C protocol. Objective-C runtime allows you to override methods declared in extensions in subclasses.
+You can use image view extensions with custom views by implementing ``ImageDisplaying`` protocol.
 
 ```swift
-extension UIImageView: Nuke_ImageDisplaying {
-    open func nuke_display(image: UIImage?, data: Data?) {
+extension MyImageView: ImageDisplaying {
+    func display(image: UIImage?, data: Data?) {
         self.image = image
     }
 }
 ```
 
-Nuke provides built-in implementations for `UIImageView` and `NSImageView`.
+Nuke provides built-in implementations for `UIImageView` and `NSImageView`. They are declared in extensions and exposed to the Objective-C runtime under a prefixed selector, which is what makes it possible to override `display(image:data:)` in a subclass.
 
 ## Customizing Requests
 

--- a/Documentation/NukeUI.docc/NukeUI.md
+++ b/Documentation/NukeUI.docc/NukeUI.md
@@ -28,7 +28,7 @@ The module also provides <doc:ImageViewExtensions> – a set of global functions
 - ``loadImage(with:options:into:completion:)-(URL?,_,_,_)``
 - ``cancelRequest(for:)``
 - ``ImageLoadingOptions``
-- ``Nuke_ImageDisplaying``
+- ``ImageDisplaying``
 - ``ImageDisplayingView``
 
 ### Helpers

--- a/Sources/NukeUI/Deprecated.swift
+++ b/Sources/NukeUI/Deprecated.swift
@@ -17,3 +17,8 @@ extension FetchImage {
         fatalError()
     }
 }
+
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
+@available(*, unavailable, renamed: "ImageDisplaying", message: "Renamed in Nuke 14. The protocol is no longer `@objc`, so it no longer needs a prefix. Rename `nuke_display(image:data:)` to `display(image:data:)` in your conformances.")
+public typealias Nuke_ImageDisplaying = ImageDisplaying
+#endif

--- a/Sources/NukeUI/ImageViewExtensions.swift
+++ b/Sources/NukeUI/ImageViewExtensions.swift
@@ -17,54 +17,56 @@ import AppKit.NSImage
 /// Displays images. Add the conformance to this protocol to your views to make
 /// them compatible with Nuke image loading extensions.
 ///
-/// The protocol is defined as `@objc` to make it possible to override its
-/// methods in extensions (e.g. you can override `nuke_display(image:data:)` in
-/// a `UIImageView` subclass like `Gifu.ImageView`).
-///
-/// The protocol and its methods have prefixes to make sure they don't clash
-/// with other similar methods and protocols in the Objective-C runtime.
+/// The built-in conformances are declared in extensions, and Swift can only
+/// override a member declared in an extension if it's exposed to the
+/// Objective-C runtime. That's why they are `@objc`, and why their selector has
+/// a prefix that keeps it from clashing with other methods in the runtime. It
+/// makes it possible to override `display(image:data:)` in a `UIImageView`
+/// subclass, like `Gifu.ImageView` does.
 @MainActor
-@objc public protocol Nuke_ImageDisplaying {
+public protocol ImageDisplaying: AnyObject {
     /// Display a given image.
-    @objc func nuke_display(image: PlatformImage?, data: Data?)
+    func display(image: PlatformImage?, data: Data?)
 
 #if os(macOS)
-    @objc var layer: CALayer? { get }
+    var layer: CALayer? { get }
 #endif
 }
 
-extension Nuke_ImageDisplaying {
+extension ImageDisplaying {
     func display(_ container: ImageContainer) {
-        nuke_display(image: container.image, data: container.data)
+        display(image: container.image, data: container.data)
     }
 }
 
 #if os(macOS)
-extension Nuke_ImageDisplaying {
+extension ImageDisplaying {
     public var layer: CALayer? { nil }
 }
 #endif
 
 #if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
-/// A `UIView` that implements the `ImageDisplaying` protocol.
-public typealias ImageDisplayingView = UIView & Nuke_ImageDisplaying
+/// A `UIView` that implements the ``ImageDisplaying`` protocol.
+public typealias ImageDisplayingView = UIView & ImageDisplaying
 
-extension UIImageView: Nuke_ImageDisplaying {
+extension UIImageView: ImageDisplaying {
     /// Displays an image.
-    open func nuke_display(image: UIImage?, data: Data? = nil) {
+    @objc(nuke_displayWithImage:data:)
+    open func display(image: UIImage?, data: Data? = nil) {
         self.image = image
     }
 }
 #elseif os(macOS)
 import Cocoa
-/// An `NSObject` that implements the `ImageDisplaying` protocol.
+/// An `NSObject` that implements the ``ImageDisplaying`` protocol.
 /// Can support `NSView` and `NSCell`. The latter can return nil for layer.
-public typealias ImageDisplayingView = NSObject & Nuke_ImageDisplaying
+public typealias ImageDisplayingView = NSObject & ImageDisplaying
 
-extension NSImageView: Nuke_ImageDisplaying {
+extension NSImageView: ImageDisplaying {
     /// Displays an image.
-    open func nuke_display(image: NSImage?, data: Data? = nil) {
+    @objc(nuke_displayWithImage:data:)
+    open func display(image: NSImage?, data: Data? = nil) {
         self.image = image
     }
 }
@@ -73,9 +75,10 @@ extension NSImageView: Nuke_ImageDisplaying {
 #if os(tvOS)
 import TVUIKit
 
-extension TVPosterView: Nuke_ImageDisplaying {
+extension TVPosterView: ImageDisplaying {
     /// Displays an image.
-    open func nuke_display(image: UIImage?, data: Data? = nil) {
+    @objc(nuke_displayWithImage:data:)
+    open func display(image: UIImage?, data: Data? = nil) {
         self.image = image
     }
 }
@@ -263,7 +266,7 @@ private final class ImageViewController {
         // Handle a scenario where request is `nil` (in the same way as a failure)
         guard var request else {
             if options.isPrepareForReuseEnabled {
-                imageView.nuke_display(image: nil, data: nil)
+                imageView.display(image: nil, data: nil)
             }
             let result: Result<ImageResponse, ImagePipeline.Error> = .failure(.imageRequestMissing)
             handle(result: result, isFromMemory: true)
@@ -289,7 +292,7 @@ private final class ImageViewController {
         if let placeholder = options.placeholder {
             display(ImageContainer(image: placeholder), true, .placeholder)
         } else if options.isPrepareForReuseEnabled {
-            imageView.nuke_display(image: nil, data: nil) // Remove previously displayed images (if any)
+            imageView.display(image: nil, data: nil) // Remove previously displayed images (if any)
         }
 
         task = pipeline.loadImage(with: request, progress: { [weak self] response, completedCount, totalCount in
@@ -401,7 +404,7 @@ extension ImageViewController {
             duration: params.duration,
             options: params.options.union(.transitionCrossDissolve),
             animations: {
-                imageView.nuke_display(image: image.image, data: image.data)
+                imageView.display(image: image.image, data: image.data)
             },
             completion: nil
         )

--- a/Tests/NukeUITests/ImageViewExtensionsTests.swift
+++ b/Tests/NukeUITests/ImageViewExtensionsTests.swift
@@ -252,6 +252,37 @@ struct ImageViewExtensionsTests {
             localImageView = nil
         }
     }
+
+    // MARK: - ImageDisplaying
+
+    @Test func subclassOverridesDisplay() async {
+        // GIVEN a subclass that overrides the built-in `UIImageView` conformance,
+        // which is only possible because the conformance is exposed to the
+        // Objective-C runtime
+        let imageView = MockSubclassedImageView()
+
+        // WHEN
+        await loadImageExpectingSuccess(with: Test.request, options: options, into: imageView)
+
+        // THEN the override runs instead of the built-in implementation
+        #expect(imageView.lastDisplayedImage != nil)
+        #expect(imageView.image == nil)
+    }
+
+    @Test func displayKeepsPrefixedSelector() {
+        // The selector is unchanged since Nuke 8 so that the Objective-C
+        // subclasses that override it keep working
+        let selector = #selector(_ImageView.display(image:data:))
+        #expect(NSStringFromSelector(selector) == "nuke_displayWithImage:data:")
+    }
+}
+
+private final class MockSubclassedImageView: _ImageView {
+    var lastDisplayedImage: PlatformImage?
+
+    override func display(image: PlatformImage?, data: Data?) {
+        lastDisplayedImage = image
+    }
 }
 
 #endif

--- a/Tests/NukeUITests/ImageViewIntegrationTests.swift
+++ b/Tests/NukeUITests/ImageViewIntegrationTests.swift
@@ -97,8 +97,8 @@ struct ImageViewIntegrationTests {
     // MARK: - Data Passed
 
 #if os(iOS) || os(visionOS)
-    private final class MockView: UIView, Nuke_ImageDisplaying {
-        func nuke_display(image: PlatformImage?, data: Data?) {
+    private final class MockView: UIView, ImageDisplaying {
+        func display(image: PlatformImage?, data: Data?) {
             recordedData.append(data)
         }
 

--- a/Tests/NukeUITests/ImageViewLoadingOptionsTests.swift
+++ b/Tests/NukeUITests/ImageViewLoadingOptionsTests.swift
@@ -393,7 +393,7 @@ struct ImageViewLoadingOptionsTests {
         var options = ImageLoadingOptions(placeholder: Test.image)
         options.processors = [ImageProcessors.Resize(width: 100)]
         options.transition = .custom { view, image in
-            view.nuke_display(image: image, data: nil)
+            view.display(image: image, data: nil)
         }
 #if os(iOS) || os(tvOS) || os(visionOS)
         options.contentModes = ImageLoadingOptions.ContentModes(


### PR DESCRIPTION
`Nuke_ImageDisplaying.nuke_display(image:data:)` was the last Objective-C-prefixed, snake-cased name in the public API. It existed because the protocol was `@objc`, which it had to be for one reason: Swift can only override a member declared in an extension if that member is exposed to the Objective-C runtime, and the `UIImageView`, `NSImageView`, and `TVPosterView` conformances are declared in extensions so that subclasses like `Gifu.ImageView` can intercept display.

Only the conformances need that, not the protocol. They now carry an explicit `@objc(nuke_displayWithImage:data:)` selector — the one they already had — so the Objective-C runtime stays namespaced and an Objective-C subclass overriding the method is unaffected. In Swift, the protocol is `ImageDisplaying` and its requirement is `display(image:data:)`.

```swift
// Before
extension MyImageView: Nuke_ImageDisplaying {
    func nuke_display(image: UIImage?, data: Data?) { self.image = image }
}

// After
extension MyImageView: ImageDisplaying {
    func display(image: UIImage?, data: Data?) { self.image = image }
}
```

Dropping `@objc` from the protocol also fixes its macOS `layer` requirement: a protocol extension can't witness an `@objc` requirement, so the `nil` default that the `NSCell` case in the comment relies on never compiled. It does now.

`ImageDisplayingView`, `loadImage(with:into:)`, `cancelRequest(for:)`, and `ImageLoadingOptions` are unchanged, so this only affects custom conformances. `Nuke_ImageDisplaying` stays as an unavailable typealias that names the replacement, following the convention in `Deprecated.swift`.

## To test

1. `make ci` — all 22 jobs pass (iOS/tvOS/macOS tests, watchOS/visionOS builds, SPM, SwiftLint).
2. Two new tests in `ImageViewExtensionsTests` cover the mechanism: `subclassOverridesDisplay` loads an image into a `UIImageView` subclass that overrides `display(image:data:)` and asserts the override runs instead of the built-in implementation; `displayKeepsPrefixedSelector` asserts the selector is still `nuke_displayWithImage:data:`.
