### PR TITLE
Resume a looping video on macOS when the view returns to a window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - group: macos
             name: Tests (macOS)
           - group: platforms
-            name: Build (watchOS, visionOS, NukeVideo, SPM)
+            name: Build (watchOS, visionOS, NukeVideo) + Tests (SPM)
     steps:
       - uses: actions/checkout@v7
       - name: Run ${{ matrix.group }}

--- a/.scripts/ci.sh
+++ b/.scripts/ci.sh
@@ -57,7 +57,7 @@ JOBS=(
     "build-nukevideo-ios|platforms|build|NukeVideo|iOS"
     "build-nukevideo-macos|platforms|build|NukeVideo|macOS"
     "build-nukevideo-tvos|platforms|build|NukeVideo|tvOS"
-    "spm-build|platforms|spm|Package|SPM"
+    "spm-test|platforms|spm|Package|SPM"
 
     "lint|lint|lint|SwiftLint|—"
 )
@@ -421,7 +421,7 @@ run_job() {
     local label
     case "$action" in
         lint) label="SwiftLint" ;;
-        spm)  label="swift build --build-tests" ;;
+        spm)  label="swift test" ;;
         *)    label="$scheme · $platform" ;;
     esac
 
@@ -460,7 +460,7 @@ run_job() {
             fi
             ;;
         spm)
-            run_streamed "$id" swift env -C "$PROJECT_ROOT" swift build --build-tests || exit_code=$?
+            run_streamed "$id" swift env -C "$PROJECT_ROOT" swift test || exit_code=$?
             ;;
         build)
             run_streamed "$id" xcodebuild \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 - Fix `DataCache` sweeping only once per launch instead of every `DataCache/sweepInterval` – https://github.com/kean/Nuke/pull/930
 - Fix `DataCache/sweep()` not recording the sweep date, so the next scheduled sweep ran again within `DataCache/sweepInterval` – https://github.com/kean/Nuke/pull/932
 - Fix `DataCache` writing entries non-atomically, so a read that arrived while the same key was being overwritten could return a truncated file – https://github.com/kean/Nuke/pull/937
-- Fix `VideoPlayerView` not resuming a looping video on macOS when the view is added back to a window – https://github.com/kean/Nuke/pull/950
+- Fix `VideoPlayerView` not resuming a looping video on macOS when the view is added back to a window – https://github.com/kean/Nuke/pull/951
 
 **Documentation**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Fix `DataCache` sweeping only once per launch instead of every `DataCache/sweepInterval` – https://github.com/kean/Nuke/pull/930
 - Fix `DataCache/sweep()` not recording the sweep date, so the next scheduled sweep ran again within `DataCache/sweepInterval` – https://github.com/kean/Nuke/pull/932
 - Fix `DataCache` writing entries non-atomically, so a read that arrived while the same key was being overwritten could return a truncated file – https://github.com/kean/Nuke/pull/937
+- Fix `VideoPlayerView` not resuming a looping video on macOS when the view is added back to a window – https://github.com/kean/Nuke/pull/950
 
 **Documentation**
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 lint:
 	@$(CI) lint
 
-## Build the SPM package including tests
+## Run the SPM package tests (NukeVideo)
 spm:
 	@$(CI) spm
 

--- a/Sources/NukeVideo/VideoPlayerView.swift
+++ b/Sources/NukeVideo/VideoPlayerView.swift
@@ -200,6 +200,16 @@ public final class VideoPlayerView: _PlatformBaseView {
 
 #if os(iOS) || os(tvOS) || os(visionOS)
     override public func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+
+        if newWindow != nil && shouldResumeOnInterruption {
+            player?.play()
+        }
+    }
+#elseif os(macOS)
+    override public func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+
         if newWindow != nil && shouldResumeOnInterruption {
             player?.play()
         }

--- a/Tests/NukeVideoTests/VideoPlayerViewTests.swift
+++ b/Tests/NukeVideoTests/VideoPlayerViewTests.swift
@@ -1,0 +1,132 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import AVFoundation
+import NukeVideo
+
+#if !os(watchOS)
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+@Suite(.timeLimit(.minutes(5))) @MainActor
+struct VideoPlayerViewTests {
+    let host = WindowHost()
+
+    /// A looping video that was paused while its view was out of the window
+    /// resumes when the view is added back to it, on every platform.
+    @Test func resumesLoopingVideoWhenAddedBackToWindow() async throws {
+        let view = VideoPlayerView()
+        view.asset = AVURLAsset(url: try await makeVideoFixture())
+        host.add(view)
+        view.play()
+
+        let player = try #require(view.playerLayer.player)
+        try await poll { player.rate != 0 }
+
+        // The view leaves the window and playback is interrupted, the way it is
+        // when the app goes to the background.
+        view.removeFromSuperview()
+        player.pause()
+        #expect(player.rate == 0)
+
+        host.add(view)
+
+        #expect(player.rate != 0)
+    }
+
+    /// There is no player to resume until the video is played.
+    @Test func addingViewWithoutPlayerToWindowDoesNothing() {
+        let view = VideoPlayerView()
+        host.add(view)
+
+        #expect(view.playerLayer.player == nil)
+    }
+}
+
+/// Keeps a window alive for the test and attaches views to it the way an app does.
+@MainActor
+final class WindowHost {
+    private let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+#if os(macOS)
+    private let window: NSWindow
+#else
+    private let window: UIWindow
+#endif
+
+    init() {
+#if os(macOS)
+        window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = NSView(frame: frame)
+        window.orderFront(nil)
+#else
+        window = UIWindow(frame: frame)
+        window.isHidden = false
+#endif
+    }
+
+    func add(_ view: VideoPlayerView) {
+        view.frame = frame
+#if os(macOS)
+        window.contentView?.addSubview(view)
+#else
+        window.addSubview(view)
+#endif
+    }
+}
+
+/// Waits for a condition that AVFoundation only reaches asynchronously.
+@MainActor
+private func poll(
+    _ condition: () -> Bool,
+    sourceLocation: SourceLocation = #_sourceLocation
+) async throws {
+    for _ in 0..<500 {
+        if condition() { return }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+    Issue.record("Timed out waiting for the player", sourceLocation: sourceLocation)
+}
+
+/// Writes a short video to a temporary file. It is generated rather than checked
+/// in because the package target ships no test resources.
+private func makeVideoFixture() async throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(UUID().uuidString).mp4")
+    let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+    let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+        AVVideoCodecKey: AVVideoCodecType.h264,
+        AVVideoWidthKey: 16,
+        AVVideoHeightKey: 16
+    ])
+    writer.add(input)
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: input, sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+    ])
+    writer.startWriting()
+    writer.startSession(atSourceTime: .zero)
+
+    // Long enough that playback can't reach the end while the test runs.
+    let frameRate: Int32 = 30
+    let pool = try #require(adaptor.pixelBufferPool)
+    for frame in 0..<(frameRate * 10) {
+        while !input.isReadyForMoreMediaData {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        var buffer: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(nil, pool, &buffer)
+        adaptor.append(try #require(buffer), withPresentationTime: CMTime(value: CMTimeValue(frame), timescale: frameRate))
+    }
+    input.markAsFinished()
+    await writer.finishWriting()
+
+    return url
+}
+
+#endif


### PR DESCRIPTION
On macOS, a looping `VideoPlayerView` that left and re-entered the window hierarchy stayed paused. The resume hook was only installed on UIKit, as `willMove(toWindow:)`; AppKit calls the differently named `viewWillMove(toWindow:)`, which the view never overrode. The UIKit branch now also calls `super`, matching the new AppKit one.

The test hosts the view in a window, waits for playback, detaches it and pauses the player, then adds it back and expects playback to resume. It generates a short video with `AVAssetWriter` so it runs on every platform without the package target shipping a fixture.

`NukeVideoTests` exists because `NukeVideo` has no test target in the Xcode project, but the `spm` CI job only ran `swift build --build-tests`, so those tests compiled in CI and never ran. It now runs `swift test`.