### PR TITLE
Add ImagePipeline.Error.isCancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - `ImagePipeline/Delegate` now declares the isolation of every method instead of documenting it: `willLoadData`, `willCache`, `imageTaskDidStart`, and `imageTask(_:didReceiveEvent:pipeline:)` run on `ImagePipelineActor`, and the rest are `nonisolated` – https://github.com/kean/Nuke/pull/945
 - `NukeExtensions` is folded into `NukeUI`. The image view extensions now ship in `NukeUI`, and `NukeExtensions` is an empty module that re-exports it, scheduled for removal in Nuke 15 – https://github.com/kean/Nuke/pull/947
 - `NukeUI` now surfaces the typed `ImagePipeline/Error` instead of `any Error`: `FetchImage/result`, `LazyImageState/result`, `LazyImageState/error`, and the `onCompletion` and `onFailure` callbacks – https://github.com/kean/Nuke/pull/949
+- Add `ImagePipeline/Error/isCancelled` – https://github.com/kean/Nuke/pull/952
 
 **Bug Fixes**
 

--- a/Documentation/Nuke.docc/Extensions/ImagePipeline-Extension.md
+++ b/Documentation/Nuke.docc/Extensions/ImagePipeline-Extension.md
@@ -92,6 +92,19 @@ If progressive decoding is enabled, the pipeline attempts to produce previews as
 
 **Backpressure:** Every preview goes through the same processing and decompression phases as the final image. If a stage can't keep up, the pipeline waits for the current operation to finish before starting the next one. All outstanding progressive operations are canceled when the data is fully downloaded.
 
+## Error Handling
+
+The pipeline fails with a typed ``ImagePipeline/Error``. Cancellation is one of its cases, and it's by far the most common one: every image view that scrolls offscreen cancels its request. Use ``ImagePipeline/Error/isCancelled`` to filter it out before showing an error or reporting it.
+
+```swift
+do {
+    imageView.image = try await pipeline.image(for: url)
+} catch {
+    guard !error.isCancelled else { return }
+    logger.error("Failed to load image: \(error)")
+}
+```
+
 ## Topics
 
 ### Getting a Pipeline

--- a/Sources/Nuke/Pipeline/ImagePipeline+Error.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Error.swift
@@ -34,6 +34,20 @@ extension ImagePipeline {
 }
 
 extension ImagePipeline.Error {
+    /// Returns `true` if the request was cancelled.
+    ///
+    /// Cancellation is an expected outcome, not a failure: every image view
+    /// that scrolls offscreen produces one. Use it to filter cancellations out
+    /// of the error UI and the logs.
+    ///
+    /// ```swift
+    /// guard !error.isCancelled else { return }
+    /// logger.error("Failed to load image: \(error)")
+    /// ```
+    public var isCancelled: Bool {
+        if case .cancelled = self { true } else { false }
+    }
+
     /// Returns underlying data loading error.
     public var dataLoadingError: Swift.Error? {
         switch self {

--- a/Tests/NukeTests/ImagePipelineErrorTests.swift
+++ b/Tests/NukeTests/ImagePipelineErrorTests.swift
@@ -9,6 +9,26 @@ import Foundation
 @Suite(.timeLimit(.minutes(5)))
 struct ImagePipelineErrorTests {
 
+    // MARK: - isCancelled
+
+    @Test func isCancelledReturnsTrueForCancelled() {
+        #expect(ImagePipeline.Error.cancelled.isCancelled)
+    }
+
+    @Test func isCancelledReturnsFalseForOtherCases() {
+        let cases: [ImagePipeline.Error] = [
+            .dataMissingInCache,
+            .dataLoadingFailed(error: URLError(.notConnectedToInternet)),
+            .dataIsEmpty,
+            .imageRequestMissing,
+            .pipelineInvalidated,
+            .dataDownloadExceededMaximumSize,
+        ]
+        for error in cases {
+            #expect(!error.isCancelled)
+        }
+    }
+
     // MARK: - dataLoadingError
 
     @Test func dataLoadingErrorReturnsUnderlyingError() {
@@ -26,6 +46,7 @@ struct ImagePipelineErrorTests {
             .imageRequestMissing,
             .pipelineInvalidated,
             .dataDownloadExceededMaximumSize,
+            .cancelled,
         ]
         for error in cases {
             #expect(error.dataLoadingError == nil)


### PR DESCRIPTION
`.cancelled` is the most-branched-on case of `ImagePipeline.Error` and the only common one without an accessor. Every disappearing cell produces one, so filtering it out of logging and error UI is near-universal — and today that means `if case .cancelled = error` at each call site, while the neighbouring `dataLoadingError` convenience already establishes the pattern.

```swift
extension ImagePipeline.Error {
    public var isCancelled: Bool {
        if case .cancelled = self { true } else { false }
    }
}
```

Reads well in both `guard` and `filter`, and gives the "don't report cancellations" advice somewhere to live: the new **Error Handling** section in the `ImagePipeline` article.

Covered by unit tests in `ImagePipelineErrorTests`.