### PR TITLE
Return ImageTask.Progress from FetchImage and LazyImageState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - `ImagePipeline/Delegate` now declares the isolation of every method instead of documenting it: `willLoadData`, `willCache`, `imageTaskDidStart`, and `imageTask(_:didReceiveEvent:pipeline:)` run on `ImagePipelineActor`, and the rest are `nonisolated` – https://github.com/kean/Nuke/pull/945
 - `NukeExtensions` is folded into `NukeUI`. The image view extensions now ship in `NukeUI`, and `NukeExtensions` is an empty module that re-exports it, scheduled for removal in Nuke 15 – https://github.com/kean/Nuke/pull/947
 - `NukeUI` now surfaces the typed `ImagePipeline/Error` instead of `any Error`: `FetchImage/result`, `LazyImageState/result`, `LazyImageState/error`, and the `onCompletion` and `onFailure` callbacks – https://github.com/kean/Nuke/pull/949
+- `FetchImage/progress` and `LazyImageState/progress` now return `ImageTask/Progress`, which `FetchImage` publishes itself, instead of the nested `FetchImage.Progress` observable object that needed its own `@ObservedObject`. The old type is deprecated – https://github.com/kean/Nuke/pull/952
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - `ImagePipeline/Delegate` now declares the isolation of every method instead of documenting it: `willLoadData`, `willCache`, `imageTaskDidStart`, and `imageTask(_:didReceiveEvent:pipeline:)` run on `ImagePipelineActor`, and the rest are `nonisolated` – https://github.com/kean/Nuke/pull/945
 - `NukeExtensions` is folded into `NukeUI`. The image view extensions now ship in `NukeUI`, and `NukeExtensions` is an empty module that re-exports it, scheduled for removal in Nuke 15 – https://github.com/kean/Nuke/pull/947
 - `NukeUI` now surfaces the typed `ImagePipeline/Error` instead of `any Error`: `FetchImage/result`, `LazyImageState/result`, `LazyImageState/error`, and the `onCompletion` and `onFailure` callbacks – https://github.com/kean/Nuke/pull/949
-- `FetchImage/progress` and `LazyImageState/progress` now return `ImageTask/Progress`, which `FetchImage` publishes itself, instead of the nested `FetchImage.Progress` observable object that needed its own `@ObservedObject`. The old type is deprecated – https://github.com/kean/Nuke/pull/952
+- `FetchImage/progress` and `LazyImageState/progress` now return `ImageTask/Progress`, which `FetchImage` publishes itself, instead of the nested `FetchImage.Progress` observable object that needed its own `@ObservedObject`. The old type is deprecated – https://github.com/kean/Nuke/pull/953
 
 **Bug Fixes**
 

--- a/Documentation/Migrations/Nuke 14 Migration Guide.md
+++ b/Documentation/Migrations/Nuke 14 Migration Guide.md
@@ -179,6 +179,42 @@ The protocol used to describe where its methods run in a doc comment – "perfor
 
 A plain method still satisfies an isolated requirement, so most conformers need no changes – only a method with a *conflicting* isolation is now rejected. A `@MainActor` delegate, which previously failed to conform at all, now works.
 
+## `FetchImage.Progress` Replaced by `ImageTask.Progress`
+
+`NukeUI` had a progress type of its own: a nested `ObservableObject` inside another `ObservableObject`, which needed a separate `@ObservedObject` to observe. `FetchImage.progress` and `LazyImageState.progress` now return `ImageTask.Progress` – the same value type the pipeline reports – and `FetchImage` publishes the updates itself.
+
+| API | Nuke 13 | Nuke 14 |
+|---|---|---|
+| `FetchImage.progress`, `LazyImageState.progress` | `FetchImage.Progress`, a class | `ImageTask.Progress`, a struct |
+
+```swift
+// Nuke 13
+LazyImage(url: url) { state in
+    if state.isLoading {
+        DownloadProgressView(progress: state.progress)
+    }
+}
+
+struct DownloadProgressView: View {
+    @ObservedObject var progress: FetchImage.Progress
+
+    var body: some View {
+        ProgressView(value: progress.fraction)
+    }
+}
+
+// Nuke 14
+LazyImage(url: url) { state in
+    if state.isLoading {
+        ProgressView(value: state.progress.fraction)
+    }
+}
+```
+
+`FetchImage.Progress` is now a deprecated typealias for `ImageTask.Progress` and is removed in Nuke 15.
+
+The updates are still only published if you use them: reading `progress` opts the object into publishing them, so a view that doesn't display the progress isn't invalidated every time a chunk of data arrives.
+
 ## `NukeUI` surfaces `ImagePipeline.Error`
 
 The pipeline finishes every task with an `ImagePipeline.Error`, so `NukeUI` no longer erases it to `any Error`. Branching on a case no longer needs a cast.

--- a/Sources/NukeUI/Deprecated.swift
+++ b/Sources/NukeUI/Deprecated.swift
@@ -5,6 +5,13 @@
 import Combine
 import Nuke
 
+// MARK: - Deprecated in Nuke 14
+
+extension FetchImage {
+    @available(*, deprecated, message: "Renamed to `ImageTask.Progress`, which `FetchImage/progress` now returns. It's a struct, so a view that observed it with `@ObservedObject` now reads the value directly.")
+    public typealias Progress = ImageTask.Progress
+}
+
 // MARK: - Removed in Nuke 14
 //
 // Removed APIs are kept as unavailable stubs that name their replacement: the

--- a/Sources/NukeUI/FetchImage.swift
+++ b/Sources/NukeUI/FetchImage.swift
@@ -38,27 +38,24 @@ public final class FetchImage: ObservableObject, Identifiable {
     public var transaction = Transaction(animation: nil)
 
     /// The progress of the current image download.
-    public var progress: Progress {
-        if _progress == nil {
-            _progress = Progress()
-        }
-        return _progress!
+    ///
+    /// - note: The updates are only published to the observers if you read the
+    /// property, so the views that don't display the progress aren't
+    /// invalidated every time a chunk of data arrives.
+    public var progress: ImageTask.Progress {
+        isProgressObserved = true
+        return _progress
     }
 
-    private var _progress: Progress?
+    private static let noProgress = ImageTask.Progress(completed: 0, total: 0)
 
-    /// The download progress.
-    public final class Progress: ObservableObject {
-        /// The number of bytes that the task has received.
-        @Published public internal(set) var completed: Int64 = 0
+    // Set the first time `progress` is read; see the property for the reason.
+    private var isProgressObserved = false
 
-        /// A best-guess upper bound on the number of bytes of the resource.
-        @Published public internal(set) var total: Int64 = 0
-
-        /// Returns the fraction of the completion.
-        public var fraction: Float {
-            guard total > 0 else { return 0 }
-            return min(1, Float(completed) / Float(total))
+    private var _progress = FetchImage.noProgress {
+        willSet {
+            guard isProgressObserved else { return }
+            objectWillChange.send()
         }
     }
 
@@ -162,8 +159,7 @@ public final class FetchImage: ObservableObject, Identifiable {
                         self.handle(preview: response)
                     }
                 } else {
-                    self._progress?.completed = completed
-                    self._progress?.total = total
+                    self._progress = ImageTask.Progress(completed: completed, total: total)
                 }
             },
             completion: { [weak self] result in
@@ -250,6 +246,6 @@ public final class FetchImage: ObservableObject, Identifiable {
 
     private func clearLoadingState() {
         if isLoading { isLoading = false }
-        if _progress != nil { _progress = nil }
+        if _progress != Self.noProgress { _progress = Self.noProgress }
     }
 }

--- a/Sources/NukeUI/LazyImageState.swift
+++ b/Sources/NukeUI/LazyImageState.swift
@@ -23,7 +23,7 @@ public protocol LazyImageState {
     var isLoading: Bool { get }
 
     /// The progress of the image download.
-    var progress: FetchImage.Progress { get }
+    var progress: ImageTask.Progress { get }
 }
 
 extension LazyImageState {

--- a/Tests/NukeUITests/FetchImageTests.swift
+++ b/Tests/NukeUITests/FetchImageTests.swift
@@ -175,29 +175,9 @@ struct FetchImageTests {
 
     // MARK: - Progress
 
-    @Test func progressLazilyAllocatedAndStable() {
-        let progress1 = image.progress
-        let progress2 = image.progress
-        #expect(progress1 === progress2)
-    }
-
-    @Test func progressFractionWhenTotalIsZero() {
-        let progress = FetchImage.Progress()
-        #expect(progress.fraction == 0)
-    }
-
-    @Test func progressFractionMidLoad() {
-        let progress = FetchImage.Progress()
-        progress.total = 100
-        progress.completed = 25
-        #expect(progress.fraction == 0.25)
-    }
-
-    @Test func progressFractionClampedToOne() {
-        let progress = FetchImage.Progress()
-        progress.total = 100
-        progress.completed = 150
-        #expect(progress.fraction == 1)
+    @Test func progressStartsEmpty() {
+        #expect(image.progress == ImageTask.Progress(completed: 0, total: 0))
+        #expect(image.progress.fraction == 0)
     }
 
     @Test func progressIsReportedDuringLoad() async {
@@ -211,15 +191,56 @@ struct FetchImageTests {
         image.onCompletion = { _ in expectation.fulfill() }
         image.load(Test.request)
 
-        // Allocate progress after load() — the internal reset() clears any prior allocation.
-        _ = image.progress
-
         dataLoader.isSuspended = false
         await expectation.wait()
 
         #expect(image.progress.completed == 20)
         #expect(image.progress.total == 20)
         #expect(image.progress.fraction == 1)
+    }
+
+    /// The updates are published by `FetchImage` itself, but only if the
+    /// progress is read: the views that don't display it aren't invalidated.
+    @Test func progressUpdatesInvalidateTheObjectOnlyWhenObserved() async {
+        func countInvalidations(observingProgress: Bool) async -> Int {
+            let image = FetchImage()
+            image.pipeline = ImagePipeline {
+                $0.dataLoader = MockDataLoader()
+                $0.imageCache = nil
+            }
+            if observingProgress {
+                _ = image.progress
+            }
+
+            let count = OSAllocatedUnfairLock(initialState: 0)
+            let cancellable = image.objectWillChange.sink { _ in
+                count.withLock { $0 += 1 }
+            }
+
+            let expectation = TestExpectation()
+            image.onCompletion = { _ in expectation.fulfill() }
+            image.load(Test.request)
+            await expectation.wait()
+
+            _ = cancellable
+            return count.withLock { $0 }
+        }
+
+        let observed = await countInvalidations(observingProgress: true)
+        let ignored = await countInvalidations(observingProgress: false)
+        #expect(observed > ignored)
+    }
+
+    @Test func progressIsClearedOnReset() async {
+        let expectation = TestExpectation()
+        image.onCompletion = { _ in expectation.fulfill() }
+        image.load(Test.request)
+        await expectation.wait()
+        #expect(image.progress.completed > 0)
+
+        image.reset()
+
+        #expect(image.progress == ImageTask.Progress(completed: 0, total: 0))
     }
 
     // MARK: - Progressive Decoding
@@ -583,9 +604,6 @@ struct FetchImageTests {
 
         #expect(image.imageContainer != nil)
         #expect(image.result != nil)
-
-        // Touch progress so its allocation is exercised by reset.
-        _ = image.progress
 
         image.reset()
 


### PR DESCRIPTION
`NukeUI` had a progress type of its own:

```swift
Nuke.ImageTask.Progress      // struct, Hashable, Sendable
NukeUI.FetchImage.Progress   // final class : ObservableObject
```

`LazyImageState.progress` – the type every `LazyImage` content closure receives – returned the class one, so a user who learned `ImageTask.Progress` from the pipeline docs met a different, same-named type the moment they wrote a content closure. Being a nested `ObservableObject` inside an `ObservableObject`, it also needed its own `@ObservedObject` to observe: without one, the byte updates invalidated nothing.

`FetchImage` now stores an `ImageTask.Progress` value and publishes the updates itself. One type, value semantics, one invalidation path, and no allocation per load.

```swift
// Before
LazyImage(url: url) { state in
    if state.isLoading { DownloadProgressView(progress: state.progress) }
}

struct DownloadProgressView: View {
    @ObservedObject var progress: FetchImage.Progress

    var body: some View {
        ProgressView(value: progress.fraction)
    }
}

// After
LazyImage(url: url) { state in
    if state.isLoading {
        ProgressView(value: state.progress.fraction)
    }
}
```

The type was split off in Nuke 12 to keep the progress updates from reloading the `LazyImage` content, and that property is preserved: reading `progress` opts the object into publishing the updates, so a view that doesn't display them isn't invalidated every time a chunk of data arrives.

`FetchImage.Progress` remains as a deprecated typealias for `ImageTask.Progress`, scheduled for removal in Nuke 15.

## Testing

The `FetchImage` progress tests now cover the value, the reset, and the invalidation behavior – that the updates reach `FetchImage.objectWillChange` when the progress is observed, and don't when it isn't. Full CI passes (22 jobs, all platforms).
