### PR TITLE
Document nil URL behavior in ImageRequest.init(url:)

### DIFF
--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -152,6 +152,11 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     ///     priority: .high
     /// )
     /// ```
+    ///
+    /// - note: The URL is optional as a convenience: `URL(string:)` returns an
+    /// optional that can be passed directly without unwrapping. A `nil` URL
+    /// produces a request that fails with `URLError(.badURL)` — to skip loading
+    /// entirely, pass a `nil` request to `LazyImage` or `FetchImage` instead.
     public init(
         url: URL?,
         processors: [any ImageProcessing] = [],


### PR DESCRIPTION
`ImageRequest.init(url:)` takes a `URL?`, but the documentation never said what a `nil` URL actually does. This adds a note: the optionality exists so `URL(string:)` can be passed directly without unwrapping, and a `nil` URL produces a request that fails with `URLError(.badURL)` — it is not a way to skip loading. For that, pass a `nil` request to `LazyImage` or `FetchImage`, which short-circuit before a request is ever built.

Documentation only, no behavior change.

### To test

1. Option-click `ImageRequest(url:)` in Xcode and confirm the note renders in Quick Help.