### PR TITLE
Fix documentation drift and compile the article samples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - group: macos
             name: Tests (macOS)
           - group: platforms
-            name: Build (watchOS, visionOS, NukeVideo) + Tests (SPM)
+            name: Build (watchOS, visionOS, NukeVideo, Snippets) + Tests (SPM)
     steps:
       - uses: actions/checkout@v7
       - name: Run ${{ matrix.group }}

--- a/.scripts/ci.sh
+++ b/.scripts/ci.sh
@@ -58,6 +58,7 @@ JOBS=(
     "build-nukevideo-macos|platforms|build|NukeVideo|macOS"
     "build-nukevideo-tvos|platforms|build|NukeVideo|tvOS"
     "spm-test|platforms|spm|Package|SPM"
+    "snippets-ios|platforms|snippets|DocumentationSnippets|iOS"
 
     "lint|lint|lint|SwiftLint|—"
 )
@@ -428,6 +429,8 @@ run_job() {
     DEST=""; DEST_NAME=""
     case "$action" in
         build|test) set_destination "$action" "$platform" ;;
+        # Compile-only, like build: a generic destination, no simulator boot.
+        snippets)   set_destination "build" "$platform" ;;
     esac
 
     if $PROGRESS; then
@@ -466,6 +469,18 @@ run_job() {
             run_streamed "$id" xcodebuild \
                 xcodebuild build \
                     -project "$PROJECT" \
+                    -scheme "$scheme" \
+                    -destination "$DEST" \
+                    -resultBundlePath "$OUTPUT_DIR/$id.xcresult" || exit_code=$?
+            ;;
+        snippets)
+            # The samples from the DocC articles, as their own package. Built for
+            # iOS rather than through the root package's `swift build`, which only
+            # covers macOS — the UIKit and Objective-C samples are compiled out
+            # there, and those are exactly the ones that drifted.
+            run_streamed "$id" xcodebuild \
+                env -C "$PROJECT_ROOT/Tests/DocumentationSnippets" \
+                xcodebuild build \
                     -scheme "$scheme" \
                     -destination "$DEST" \
                     -resultBundlePath "$OUTPUT_DIR/$id.xcresult" || exit_code=$?
@@ -521,7 +536,7 @@ if $LIST_MODE; then
             printf "\n  %s%s%s\n" "$DIM" "$group" "$RESET"
             last_group="$group"
         fi
-        printf "    %-32s %-6s %s\n" "$id" "$action" "$scheme · $platform"
+        printf "    %-32s %-8s %s\n" "$id" "$action" "$scheme · $platform"
     done
     echo
     exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 **Documentation**
 
 - Add an article on using Nuke from Objective-C – https://github.com/kean/Nuke/pull/948
+- Fix the code samples in the SwiftUI, UIKit, Objective-C, and Performance articles, and compile them in CI – https://github.com/kean/Nuke/pull/955
 
 # Nuke 13
 

--- a/Documentation/Nuke.docc/Customization/ImageFormats/image-decoding.md
+++ b/Documentation/Nuke.docc/Customization/ImageFormats/image-decoding.md
@@ -8,7 +8,7 @@ At the core of the decoding infrastructure is the ``ImageDecoding`` protocol.
 public protocol ImageDecoding: Sendable {
     /// Returns `true` if you want the decoding to be performed on the
     /// decoding queue. If `false`, decoding is performed synchronously
-    /// on the pipeline operation queue. By default, `true`.
+    /// on the pipeline's actor. By default, `true`.
     var isAsynchronous: Bool { get }
 
     /// Produces an image from the given image data.
@@ -48,7 +48,7 @@ The pipeline uses ``ImageDecoderRegistry`` to find the decoder.  The decoder is 
 >
 > You can also take advantage of ``ImageRequest/userInfo``. For example, you may pass the target image view size to the SVG decoder to let it know the size of the image to create.
 
-The decoding is performed in the background on the operation queue provided in ``ImagePipeline/Configuration-swift.struct``. There is always only one decoding request at a time. The pipeline doesn't call ``ImageDecoding/decodePartiallyDownloadedData(_:)-9budu`` again until you are finished with the previous chunk.
+The decoding is performed in the background on ``ImagePipeline/Configuration-swift.struct/imageDecodingQueue``. There is always only one decoding request at a time. The pipeline doesn't call ``ImageDecoding/decodePartiallyDownloadedData(_:)-9budu`` again until you are finished with the previous chunk.
 
 ## Registering Decoders
 

--- a/Documentation/Nuke.docc/Essentials/objective-c.md
+++ b/Documentation/Nuke.docc/Essentials/objective-c.md
@@ -16,7 +16,7 @@ Add a Swift file to your app target. Mark the entry points `@objc` and give them
 import Foundation
 import UIKit
 import Nuke
-import NukeExtensions
+import NukeUI
 
 /// An Objective-C facade over the parts of Nuke this app uses.
 ///
@@ -29,7 +29,7 @@ public final class NKImageLoader: NSObject {
     @objc(loadImageWithURL:intoView:)
     @discardableResult
     public static func loadImage(with url: URL, into view: UIImageView) -> NKImageTask? {
-        NukeExtensions.loadImage(with: url, into: view).map(NKImageTask.init)
+        NukeUI.loadImage(with: url, into: view).map(NKImageTask.init)
     }
 
     /// Loads an image with a placeholder and a fade-in, reporting the outcome.
@@ -43,7 +43,7 @@ public final class NKImageLoader: NSObject {
         var options = ImageLoadingOptions()
         options.placeholder = placeholder
         options.transition = .fadeIn(duration: 0.25)
-        NukeExtensions.loadImage(with: url, options: options, into: view) { result in
+        NukeUI.loadImage(with: url, options: options, into: view) { result in
             switch result {
             case .success(let response): completion?(response.image, nil)
             case .failure(let error): completion?(nil, error.asNSError)
@@ -54,7 +54,7 @@ public final class NKImageLoader: NSObject {
     /// Cancels the outstanding request associated with the view.
     @objc(cancelRequestForView:)
     public static func cancelRequest(for view: UIImageView) {
-        NukeExtensions.cancelRequest(for: view)
+        NukeUI.cancelRequest(for: view)
     }
 
     /// Fetches an image without displaying it in a view.

--- a/Documentation/Nuke.docc/Essentials/swiftui.md
+++ b/Documentation/Nuke.docc/Essentials/swiftui.md
@@ -4,7 +4,7 @@ Display images in SwiftUI using the NukeUI module.
 
 ## Overview
 
-[NukeUI](https://github.com/kean/NukeUI) is a companion module that provides SwiftUI components built on top of ``ImagePipeline``. Add it to your project via Swift Package Manager alongside Nuke.
+NukeUI provides SwiftUI components built on top of ``ImagePipeline``. It ships in the same package as Nuke, so there is nothing extra to install – add the `NukeUI` library to your target and `import NukeUI`.
 
 ## LazyImage
 
@@ -28,46 +28,37 @@ struct AvatarView: View {
 
 ## Handling Loading and Failure States
 
-Use the `content` closure to customize how each phase is displayed.
+Use the `content` closure to customize what is displayed for each state. The closure receives a `LazyImageState` with `image`, `error`, `isLoading`, `progress`, and the underlying `result`.
 
 ```swift
-LazyImage(url: url) { phase in
-    switch phase {
-    case .success(let image):
+LazyImage(url: url) { state in
+    if let image = state.image {
         image.resizable().scaledToFill()
-    case .failure:
+    } else if state.error != nil {
         Image(systemName: "photo")
             .foregroundStyle(.secondary)
-    case .empty:
+    } else {
         ProgressView()
-    @unknown default:
-        EmptyView()
     }
 }
 .frame(width: 320, height: 200)
 .clipped()
 ```
 
+> Note: Unlike `AsyncImage`, `LazyImage` doesn't pass a phase enum to the closure – it passes the state itself, so you can read the download progress or the underlying ``ImageResponse`` while the view is on screen.
+
 ## Transitions
 
-Apply transitions to the displayed image using the `.transition` modifier.
+To animate the state changes, pass a `Transaction`. It's applied when the image is displayed.
 
 ```swift
-LazyImage(url: url)
-    .transition(.opacity)
-```
-
-For a cross-fade from a placeholder, use `.animation` on the phase view:
-
-```swift
-LazyImage(url: url) { phase in
-    if let image = phase.image {
+LazyImage(url: url, transaction: Transaction(animation: .easeInOut(duration: 0.33))) { state in
+    if let image = state.image {
         image.resizable().scaledToFill()
     } else {
         Color.secondary.opacity(0.2)
     }
 }
-.animation(.easeInOut(duration: 0.3), value: phase.image != nil)
 ```
 
 ## Image Processors
@@ -81,18 +72,26 @@ LazyImage(request: ImageRequest(
 ))
 ```
 
+You can also set them on the view, in which case they only apply if the request doesn't define its own.
+
+```swift
+LazyImage(url: url)
+    .processors([.resize(width: 320)])
+    .priority(.high)
+```
+
 > Tip: Using `processors` ensures the resized image is stored in the memory cache at the display size, reducing memory pressure. See <doc:image-processing> to learn more.
 
 ## Using a Custom Pipeline
 
-To use a pipeline other than ``ImagePipeline/shared``, pass it via the environment.
+To use a pipeline other than ``ImagePipeline/shared``, set it on the view.
 
 ```swift
-ContentView()
-    .environment(\.imagePipeline, myPipeline)
+LazyImage(url: url)
+    .pipeline(myPipeline)
 ```
 
-All `LazyImage` views in that subtree will use `myPipeline` automatically.
+> Tip: There is no environment-based mechanism for this – `pipeline(_:)` is set per view. If most of your app uses a single custom pipeline, assign it to ``ImagePipeline/shared`` at launch instead of passing it to every view.
 
 ## FetchImage for Custom Views
 
@@ -119,4 +118,4 @@ struct CustomImageView: View {
 }
 ```
 
-`FetchImage` automatically cancels the in-flight request when the view disappears and restarts it when the view reappears.
+`reset()` cancels the in-flight request and clears the loaded image. Use `cancel()` instead if you want to stop the download but keep displaying what was already loaded.

--- a/Documentation/Nuke.docc/Essentials/uikit.md
+++ b/Documentation/Nuke.docc/Essentials/uikit.md
@@ -1,19 +1,21 @@
 # UIKit and AppKit
 
-Load images into UIImageView, NSImageView, and UIButton using the NukeExtensions module.
+Load images into UIImageView and NSImageView using the NukeUI module.
 
 ## Overview
 
-[NukeExtensions](https://github.com/kean/NukeExtensions) is a companion module that provides free functions for loading images into `UIImageView`, `NSImageView`, and `UIButton`. Add it to your project via Swift Package Manager alongside Nuke.
+NukeUI provides free functions for loading images into `UIImageView` and `NSImageView`. It ships in the same package as Nuke, so there is nothing extra to install – add the `NukeUI` library to your target and `import NukeUI`.
+
+> Note: These functions were part of a separate `NukeExtensions` module before Nuke 14. That module still exists as a shim that re-exports `NukeUI`, but it's scheduled for removal in Nuke 15. See the [Nuke 14 Migration Guide](https://github.com/kean/Nuke/tree/main/Documentation/Migrations) for the details.
 
 ## Loading Images into UIImageView
 
 The most common use case is loading an image into a `UIImageView`.
 
 ```swift
-import NukeExtensions
+import NukeUI
 
-NukeExtensions.loadImage(with: url, into: imageView)
+NukeUI.loadImage(with: url, into: imageView)
 ```
 
 This uses ``ImagePipeline/shared`` and handles caching automatically. The previous request for that image view is cancelled when a new one starts — so it's safe to call from `cellForItemAt` without extra bookkeeping.
@@ -26,7 +28,7 @@ In collection and table views, cells are reused. Nuke handles cancellation autom
 func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as! ImageCell
     // Any previous request on this cell's imageView is cancelled automatically.
-    NukeExtensions.loadImage(with: items[indexPath.item].imageURL, into: cell.imageView)
+    NukeUI.loadImage(with: items[indexPath.item].imageURL, into: cell.imageView)
     return cell
 }
 ```
@@ -40,7 +42,7 @@ var options = ImageLoadingOptions()
 options.placeholder = UIImage(named: "placeholder")
 options.failureImage = UIImage(named: "error")
 
-NukeExtensions.loadImage(with: url, options: options, into: imageView)
+NukeUI.loadImage(with: url, options: options, into: imageView)
 ```
 
 ## Transitions
@@ -51,7 +53,7 @@ Apply a cross-fade or a custom transition when the image loads.
 var options = ImageLoadingOptions()
 options.transition = .fadeIn(duration: 0.3)
 
-NukeExtensions.loadImage(with: url, options: options, into: imageView)
+NukeUI.loadImage(with: url, options: options, into: imageView)
 ```
 
 To set a global default for all image views, configure `ImageLoadingOptions.shared`.
@@ -69,7 +71,7 @@ let request = ImageRequest(
     url: url,
     processors: [.resize(width: 320)]
 )
-NukeExtensions.loadImage(with: request, into: imageView)
+NukeUI.loadImage(with: request, into: imageView)
 ```
 
 ## Tracking Progress and Completion
@@ -77,7 +79,7 @@ NukeExtensions.loadImage(with: request, into: imageView)
 Use the completion closure to respond to success or failure.
 
 ```swift
-NukeExtensions.loadImage(with: url, into: imageView) { result in
+NukeUI.loadImage(with: url, into: imageView) { result in
     switch result {
     case .success(let response):
         print("Loaded image from: \(response.urlResponse?.url?.absoluteString ?? "cache")")
@@ -87,12 +89,16 @@ NukeExtensions.loadImage(with: url, into: imageView) { result in
 }
 ```
 
-## Loading into UIButton
+## Custom Views
 
-NukeExtensions also supports loading images into `UIButton`.
+The extensions work with any view that conforms to `Nuke_ImageDisplaying`, not just `UIImageView` and `NSImageView`.
 
 ```swift
-NukeExtensions.loadImage(with: url, into: button, for: .normal)
+extension MyImageView: Nuke_ImageDisplaying {
+    func nuke_display(image: UIImage?, data: Data?) {
+        self.image = image
+    }
+}
 ```
 
-> For full NukeExtensions documentation, see the [NukeExtensions repository](https://github.com/kean/NukeExtensions) and its [documentation site](https://kean-docs.github.io/nukeextensions/documentation/nukeextensions/).
+> For the complete list of options and the `LazyImageView` alternative, see the [NukeUI documentation](https://kean-docs.github.io/nukeui/documentation/nukeui/).

--- a/Documentation/Nuke.docc/Nuke.md
+++ b/Documentation/Nuke.docc/Nuke.md
@@ -12,7 +12,7 @@ The framework is lean and compiles in under 2 seconds. Nuke has an automated tes
 
 Start learning with <doc:getting-started> and review the rest of the articles in the documentation as needed. Check out the [demo project](https://github.com/kean/NukeDemo) to see Nuke in action.
 
-Upgrading from the previous version? Use a [Migration Guide](https://github.com/kean/Nuke/tree/master/Documentation/Migrations).
+Upgrading from the previous version? Use a [Migration Guide](https://github.com/kean/Nuke/tree/main/Documentation/Migrations).
 
 To install Nuke, use Swift Package Manager.
 

--- a/Documentation/Nuke.docc/Performance/performance-guide.md
+++ b/Documentation/Nuke.docc/Performance/performance-guide.md
@@ -34,10 +34,13 @@ This response is cacheable, and will be *fresh* for 1 hour. When the response be
 
 If your server uses unique URLs for images for which the contents never change, consider enabling ``DataCache`` (see ``ImagePipeline/Configuration-swift.struct/withDataCache`` that also takes care of disabling the default `URLCache`). It's a fast persistent cache with non-blocking writes that allows reads to be parallel to writes and each other. It also works offline and reduces pressure on `URLSession`.
 
-> Tip: By default, ``DataCache`` stores only the original image data. To also cache processed images, set a data cache policy that enables it. ``ImagePipeline/DataCachePolicy/automatic`` is a good default: it stores original data for unprocessed requests and processed images for requests with processors.
+> Tip: By default, ``DataCache`` stores only the original image data (``ImagePipeline/DataCachePolicy/storeOriginalData``). To also cache processed images, set ``ImagePipeline/Configuration-swift.struct/dataCachePolicy`` on the configuration. ``ImagePipeline/DataCachePolicy/automatic`` is a good default: it stores original data for unprocessed requests and processed images for requests with processors.
 
 ```swift
-ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(dataCachePolicy: .automatic))
+var configuration = ImagePipeline.Configuration.withDataCache()
+configuration.dataCachePolicy = .automatic
+
+ImagePipeline.shared = ImagePipeline(configuration: configuration)
 ```
 
 > Tip: To save disk space, see `ImageEncoders.ImageIO` and `ImageEncoder.isHEIFPreferred` option for HEIF support.
@@ -89,11 +92,11 @@ Thanks to coalescing (enabled by default), the pipeline avoids doing any duplica
 let url = URL(string: "https://example.com/image")
 
 // Only one network request is made for both of these
-pipeline.loadImage(with: ImageRequest(url: url, processors: [
+let blurred = pipeline.imageTask(with: ImageRequest(url: url, processors: [
     .resize(size: CGSize(width: 44, height: 44)),
     .gaussianBlur(radius: 8)
 ]))
-pipeline.loadImage(with: ImageRequest(url: url, processors: [
+let thumbnail = pipeline.imageTask(with: ImageRequest(url: url, processors: [
     .resize(size: CGSize(width: 44, height: 44))
 ]))
 ```
@@ -116,7 +119,7 @@ Once enabled, you’ll first see a blurry low-quality version of the full image,
 
 ## Request Priorities
 
-Nuke is fully asynchronous and performs well under stress. ``ImagePipeline`` distributes its work on [operation queues](https://developer.apple.com/documentation/foundation/operationqueue) dedicated to a specific type of work, such as processing and decoding. Each queue limits the number of concurrent tasks, respects the request priorities, and cancels the work as soon as possible.
+Nuke is fully asynchronous and performs well under stress. ``ImagePipeline`` distributes its work on ``TaskQueue`` instances dedicated to a specific type of work, such as processing and decoding. Each queue limits the number of concurrent tasks, respects the request priorities, and cancels the work as soon as possible.
 
 Cancelling an ``ImageTask`` frees its associated network and CPU resources immediately. Thanks to coalescing, the underlying work is only cancelled when all requests sharing it have been cancelled — so cancelling one request doesn't affect others loading the same image.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci ci-list test build lint spm help
+.PHONY: ci ci-list test build lint spm snippets help
 
 CI := bash .scripts/ci.sh
 
@@ -29,6 +29,10 @@ lint:
 ## Run the SPM package tests (NukeVideo)
 spm:
 	@$(CI) spm
+
+## Compile the code samples from the DocC articles
+snippets:
+	@$(CI) snippets
 
 ## Show available targets
 help:

--- a/Sources/Nuke/Decoding/ImageDecoding.swift
+++ b/Sources/Nuke/Decoding/ImageDecoding.swift
@@ -13,7 +13,7 @@ import Foundation
 public protocol ImageDecoding: Sendable {
     /// Returns `true` if you want the decoding to be performed on the decoding
     /// queue (see ``ImagePipeline/Configuration-swift.struct/imageDecodingQueue``). If `false`, the decoding will be
-    /// performed synchronously on the pipeline operation queue. By default, `true`.
+    /// performed synchronously on the pipeline's actor. By default, `true`.
     var isAsynchronous: Bool { get }
 
     /// Produces an image from the given image data.

--- a/Tests/DocumentationSnippets/Package.swift
+++ b/Tests/DocumentationSnippets/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+// The hand-written samples from the DocC articles, verbatim.
+//
+// This is a separate package rather than a target in the root one so that it can
+// be built for iOS – the UIKit and Objective-C samples don't compile on macOS,
+// which is the only platform the root package's `swift build` covers. CI builds
+// it with `.scripts/ci.sh snippets`; nothing links against it.
+let package = Package(
+    name: "DocumentationSnippets",
+    platforms: [
+        .iOS(.v16),
+        .tvOS(.v16),
+        .macOS(.v13),
+        .watchOS(.v9),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(name: "DocumentationSnippets", targets: ["DocumentationSnippets"])
+    ],
+    dependencies: [
+        .package(name: "Nuke", path: "../..")
+    ],
+    targets: [
+        // The dependency is named explicitly: a path dependency otherwise takes
+        // its identity from the directory it sits in, which is "Nuke" in a clone
+        // but not in a git worktree or a renamed checkout.
+        .target(
+            name: "DocumentationSnippets",
+            dependencies: [
+                .product(name: "Nuke", package: "Nuke"),
+                .product(name: "NukeUI", package: "Nuke")
+            ],
+            path: "Snippets"
+        )
+    ]
+)

--- a/Tests/DocumentationSnippets/Snippets/ObjectiveCSnippets.swift
+++ b/Tests/DocumentationSnippets/Snippets/ObjectiveCSnippets.swift
@@ -1,0 +1,123 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+// Snippets from `Documentation/Nuke.docc/Essentials/objective-c.md`.
+
+#if canImport(UIKit) && !os(watchOS)
+
+import Foundation
+import UIKit
+import Nuke
+import NukeUI
+
+/// An Objective-C facade over the parts of Nuke this app uses.
+///
+/// The class is `@MainActor`, so call it from the main thread.
+@objc(NKImageLoader)
+@MainActor
+public final class NKImageLoader: NSObject {
+
+    /// Loads an image into a view, cancelling any previous request on that view.
+    @objc(loadImageWithURL:intoView:)
+    @discardableResult
+    public static func loadImage(with url: URL, into view: UIImageView) -> NKImageTask? {
+        NukeUI.loadImage(with: url, into: view).map(NKImageTask.init)
+    }
+
+    /// Loads an image with a placeholder and a fade-in, reporting the outcome.
+    @objc(loadImageWithURL:placeholder:intoView:completion:)
+    public static func loadImage(
+        with url: URL,
+        placeholder: UIImage?,
+        into view: UIImageView,
+        completion: (@MainActor @Sendable (UIImage?, Error?) -> Void)?
+    ) {
+        var options = ImageLoadingOptions()
+        options.placeholder = placeholder
+        options.transition = .fadeIn(duration: 0.25)
+        NukeUI.loadImage(with: url, options: options, into: view) { result in
+            switch result {
+            case .success(let response): completion?(response.image, nil)
+            case .failure(let error): completion?(nil, error.asNSError)
+            }
+        }
+    }
+
+    /// Cancels the outstanding request associated with the view.
+    @objc(cancelRequestForView:)
+    public static func cancelRequest(for view: UIImageView) {
+        NukeUI.cancelRequest(for: view)
+    }
+
+    /// Fetches an image without displaying it in a view.
+    @objc(fetchImageWithURL:completion:)
+    public static func image(for url: URL, completion: @escaping @MainActor @Sendable (UIImage?, Error?) -> Void) {
+        Task {
+            do {
+                let image = try await ImagePipeline.shared.image(for: url)
+                completion(image, nil)
+            } catch {
+                completion(nil, error.asNSError)
+            }
+        }
+    }
+
+    /// Returns an image from the memory cache, if there is one.
+    @objc(cachedImageForURL:)
+    public static func cachedImage(for url: URL) -> UIImage? {
+        ImagePipeline.shared.cache[url]?.image
+    }
+
+    /// Removes everything from the memory and disk caches.
+    @objc(removeAllCachedImages)
+    public static func removeAllCachedImages() {
+        ImagePipeline.shared.cache.removeAll()
+    }
+}
+
+@objc(NKImageTask)
+public final class NKImageTask: NSObject {
+    private let task: ImageTask
+
+    init(_ task: ImageTask) {
+        self.task = task
+    }
+
+    @objc public func cancel() {
+        task.cancel()
+    }
+
+    @objc public var isCancelled: Bool {
+        task.isCancelled
+    }
+}
+
+@objc(NKImagePrefetcher)
+public final class NKImagePrefetcher: NSObject {
+    private let prefetcher = ImagePrefetcher()
+
+    @objc(startPrefetchingWithURLs:)
+    public func startPrefetching(with urls: [URL]) {
+        prefetcher.startPrefetching(with: urls)
+    }
+
+    @objc(stopPrefetchingWithURLs:)
+    public func stopPrefetching(with urls: [URL]) {
+        prefetcher.stopPrefetching(with: urls)
+    }
+}
+
+private extension Error {
+    var asNSError: NSError {
+        guard let error = self as? ImagePipeline.Error else {
+            return self as NSError
+        }
+        return NSError(domain: "com.github.kean.Nuke", code: 0, userInfo: [
+            NSLocalizedDescriptionKey: error.description,
+            NSUnderlyingErrorKey: error as NSError
+        ])
+    }
+}
+
+#endif

--- a/Tests/DocumentationSnippets/Snippets/PerformanceSnippets.swift
+++ b/Tests/DocumentationSnippets/Snippets/PerformanceSnippets.swift
@@ -1,0 +1,58 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+// Snippets from `Documentation/Nuke.docc/Performance/performance-guide.md`.
+
+import Foundation
+import Nuke
+
+private func aggressiveDiskCache() {
+    var configuration = ImagePipeline.Configuration.withDataCache()
+    configuration.dataCachePolicy = .automatic
+
+    ImagePipeline.shared = ImagePipeline(configuration: configuration)
+}
+
+private func downsampleImages() {
+    let url = URL(string: "https://example.com/image")!
+    // Target size is in points
+    let request = ImageRequest(url: url, processors: [.resize(width: 320)])
+    _ = request
+}
+
+private func coalescing(pipeline: ImagePipeline) {
+    let url = URL(string: "https://example.com/image")
+
+    // Only one network request is made for both of these
+    let blurred = pipeline.imageTask(with: ImageRequest(url: url, processors: [
+        .resize(size: CGSize(width: 44, height: 44)),
+        .gaussianBlur(radius: 8)
+    ]))
+    let thumbnail = pipeline.imageTask(with: ImageRequest(url: url, processors: [
+        .resize(size: CGSize(width: 44, height: 44))
+    ]))
+    _ = (blurred, thumbnail)
+}
+
+private func progressiveDecoding() {
+    ImagePipeline.shared = ImagePipeline {
+        $0.isProgressiveDecodingEnabled = true
+    }
+}
+
+#if canImport(UIKit) && !os(watchOS)
+
+import UIKit
+
+private final class ImageView: UIView {
+    private var task: ImageTask?
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+
+        task?.priority = newWindow == nil ? .low : .high
+    }
+}
+
+#endif

--- a/Tests/DocumentationSnippets/Snippets/SwiftUISnippets.swift
+++ b/Tests/DocumentationSnippets/Snippets/SwiftUISnippets.swift
@@ -1,0 +1,116 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+// Snippets from `Documentation/Nuke.docc/Essentials/swiftui.md`.
+//
+// This target exists only to make the hand-written samples in the articles
+// compile. If a snippet here stops building, the article is out of date.
+
+import SwiftUI
+import NukeUI
+
+// MARK: - LazyImage
+
+private struct AvatarView: View {
+    let url: URL
+
+    var body: some View {
+        LazyImage(url: url)
+            .frame(width: 80, height: 80)
+            .clipShape(Circle())
+    }
+}
+
+// MARK: - Handling Loading and Failure States
+
+private struct StatesView: View {
+    let url: URL
+
+    var body: some View {
+        LazyImage(url: url) { state in
+            if let image = state.image {
+                image.resizable().scaledToFill()
+            } else if state.error != nil {
+                Image(systemName: "photo")
+                    .foregroundStyle(.secondary)
+            } else {
+                ProgressView()
+            }
+        }
+        .frame(width: 320, height: 200)
+        .clipped()
+    }
+}
+
+// MARK: - Transitions
+
+private struct TransitionView: View {
+    let url: URL
+
+    var body: some View {
+        LazyImage(url: url, transaction: Transaction(animation: .easeInOut(duration: 0.33))) { state in
+            if let image = state.image {
+                image.resizable().scaledToFill()
+            } else {
+                Color.secondary.opacity(0.2)
+            }
+        }
+    }
+}
+
+// MARK: - Image Processors
+
+private struct ProcessorsView: View {
+    let url: URL
+
+    var body: some View {
+        LazyImage(request: ImageRequest(
+            url: url,
+            processors: [.resize(width: 320)]
+        ))
+    }
+}
+
+private struct ViewProcessorsView: View {
+    let url: URL
+
+    var body: some View {
+        LazyImage(url: url)
+            .processors([.resize(width: 320)])
+            .priority(.high)
+    }
+}
+
+// MARK: - Using a Custom Pipeline
+
+private struct CustomPipelineView: View {
+    let url: URL
+    let myPipeline: ImagePipeline
+
+    var body: some View {
+        LazyImage(url: url)
+            .pipeline(myPipeline)
+    }
+}
+
+// MARK: - FetchImage for Custom Views
+
+private struct CustomImageView: View {
+    let url: URL
+    @StateObject private var fetchImage = FetchImage()
+
+    var body: some View {
+        ZStack {
+            fetchImage.image?
+                .resizable()
+                .scaledToFill()
+
+            if fetchImage.isLoading {
+                ProgressView()
+            }
+        }
+        .onAppear { fetchImage.load(url) }
+        .onDisappear { fetchImage.reset() }
+    }
+}

--- a/Tests/DocumentationSnippets/Snippets/UIKitSnippets.swift
+++ b/Tests/DocumentationSnippets/Snippets/UIKitSnippets.swift
@@ -1,0 +1,100 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+// Snippets from `Documentation/Nuke.docc/Essentials/uikit.md`.
+
+#if canImport(UIKit) && !os(watchOS)
+
+import UIKit
+import NukeUI
+
+private struct Item {
+    var imageURL: URL
+}
+
+private final class ImageCell: UICollectionViewCell {
+    let imageView = UIImageView()
+}
+
+@MainActor
+private final class UIKitSnippets {
+    let url = URL(string: "https://example.com/image")!
+    let imageView = UIImageView()
+    let items: [Item] = []
+
+    // MARK: - Loading Images into UIImageView
+
+    func loadingIntoImageView() {
+        NukeUI.loadImage(with: url, into: imageView)
+    }
+
+    // MARK: - Cell Reuse
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as! ImageCell
+        // Any previous request on this cell's imageView is cancelled automatically.
+        NukeUI.loadImage(with: items[indexPath.item].imageURL, into: cell.imageView)
+        return cell
+    }
+
+    // MARK: - Placeholder and Failure Images
+
+    func placeholderAndFailureImage() {
+        var options = ImageLoadingOptions()
+        options.placeholder = UIImage(named: "placeholder")
+        options.failureImage = UIImage(named: "error")
+
+        NukeUI.loadImage(with: url, options: options, into: imageView)
+    }
+
+    // MARK: - Transitions
+
+    func transitions() {
+        var options = ImageLoadingOptions()
+        options.transition = .fadeIn(duration: 0.3)
+
+        NukeUI.loadImage(with: url, options: options, into: imageView)
+    }
+
+    func sharedTransition() {
+        ImageLoadingOptions.shared.transition = .fadeIn(duration: 0.25)
+    }
+
+    // MARK: - Processors and Request Options
+
+    func processors() {
+        let request = ImageRequest(
+            url: url,
+            processors: [.resize(width: 320)]
+        )
+        NukeUI.loadImage(with: request, into: imageView)
+    }
+
+    // MARK: - Tracking Progress and Completion
+
+    func completion() {
+        NukeUI.loadImage(with: url, into: imageView) { result in
+            switch result {
+            case .success(let response):
+                print("Loaded image from: \(response.urlResponse?.url?.absoluteString ?? "cache")")
+            case .failure(let error):
+                print("Failed to load image: \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - Custom Views
+
+private final class MyImageView: UIView {
+    var image: UIImage?
+}
+
+extension MyImageView: Nuke_ImageDisplaying {
+    func nuke_display(image: UIImage?, data: Data?) {
+        self.image = image
+    }
+}
+
+#endif


### PR DESCRIPTION
Every high-severity item was in `Essentials/` or the Performance Guide — the prose articles a new user reads first. The API reference, which DocC generates from source, was accurate throughout. The drift lived exactly where hand-written samples aren't compiled.

## Corrections

| Article | Documented | Actual |
|---|---|---|
| `Essentials/swiftui.md` | `LazyImage(url:) { phase in switch phase { case .success … } }` | No `phase` in NukeUI. The closure receives `LazyImageState`. That sample was `AsyncImage`'s API. |
| `Essentials/swiftui.md` | `.environment(\.imagePipeline, myPipeline)` | No `EnvironmentKey` in the module. The mechanism is `pipeline(_:)`, per view. |
| `Essentials/swiftui.md` | Cross-fade via `.animation(_:value: phase.image != nil)` | `phase` is out of scope there. The API is the `transaction:` parameter. |
| `Essentials/swiftui.md` | "NukeUI is a companion module … Add it via SPM alongside Nuke" | Same package, same repo. |
| `Essentials/uikit.md` | `loadImage(with: url, into: button, for: .normal)` | No `UIButton` support — it appears in zero source files. Replaced with the `Nuke_ImageDisplaying` section, which is the real extension point. |
| `Essentials/uikit.md` | "NukeExtensions is a companion module", linking `github.com/kean/NukeExtensions` | Folded into NukeUI in Nuke 14; what remains is an 8-line `@_exported import NukeUI` shim slated for removal in 15. |
| `Essentials/objective-c.md` | `import NukeExtensions` | Same, adjacent to the row above. It still compiles through the shim, but documents a module being removed. |
| `Performance/performance-guide.md` | `.withDataCache(dataCachePolicy: .automatic)` | Signature is `withDataCache(name:sizeLimit:)`. `dataCachePolicy` is a separate property defaulting to `.storeOriginalData` — not the `.automatic` the same paragraph recommends. |
| `Performance/performance-guide.md` | "distributes its work on *operation queues*" | `TaskQueue` since Nuke 13. Same wording in `image-decoding.md` twice, and in `ImageDecoding.isAsynchronous`'s own doc comment, which that article quotes verbatim. |
| `Nuke.docc/Nuke.md` | Migration guides at `/tree/master/…` | Default branch is `main`. |

One row was **not** in the original audit — the snippets target found it on its first build:

```swift
// performance-guide.md, "Coalescing"
pipeline.loadImage(with: ImageRequest(url: url, processors: [...]))
// error: missing argument for parameter 'completion' in call
```

The only `loadImage(with:)` left is the soft-deprecated completion-based one. Now uses `imageTask(with:)`.

## Stopping it recurring

`Tests/DocumentationSnippets` holds all nine samples verbatim, and `.scripts/ci.sh snippets-ios` builds them.

It's a **separate package** rather than a target in the root one, because the root package's `swift build` only covers macOS — where the UIKit and Objective-C samples are behind `#if canImport(UIKit)` and compile out. Those are exactly the samples that drifted furthest, so the guard has to run on iOS to be worth anything.

Verified in both directions: the job is green as committed, and introducing a deliberate type error into `UIKitSnippets.swift` turns it red.

```
▸ snippets DocumentationSnippets · iOS
  destination: generic/platform=iOS
  ✅  DocumentationSnippets · iOS    (1s)
```

## Not included

The audit's suggestion that a `\.imagePipeline` environment key is "worth building rather than deleting" is a separate change — this PR documents the mechanism that exists today and notes that assigning `ImagePipeline.shared` at launch covers the app-wide case.

## Verification

- `.scripts/ci.sh snippets-ios` — passes (iOS)
- `.scripts/ci.sh spm-build` — passes; root `Package.swift` is untouched
- `xcodebuild docbuild -scheme Nuke` — succeeds with no unresolved-reference warnings, so the new symbol links (`TaskQueue`, `imageDecodingQueue`, `dataCachePolicy`, `storeOriginalData`) all resolve
- `.scripts/ci.sh lint` — no new violations
