### PR TITLE
Surface typed errors and the concurrency model in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@
 
 - Add an article on using Nuke from Objective-C – https://github.com/kean/Nuke/pull/948
 - Fix the code samples in the SwiftUI, UIKit, Objective-C, and Performance articles, and compile them in CI – https://github.com/kean/Nuke/pull/955
+- Add an "Errors" article covering the `ImagePipeline/Error` cases, `isCancelled`, and unwrapping `dataLoadingError` – https://github.com/kean/Nuke/pull/957
+- Add a "Where Nuke's Work Runs" article covering `ImagePipelineActor`, the five task queues, and the delegate isolation, and add `ImagePipelineActor` and `TaskQueue` to the topic tree – https://github.com/kean/Nuke/pull/957
+- Open the Performance Guide with a "Do This First" checklist – https://github.com/kean/Nuke/pull/957
 
 # Nuke 13
 

--- a/Documentation/Nuke.docc/Customization/where-work-runs.md
+++ b/Documentation/Nuke.docc/Customization/where-work-runs.md
@@ -1,0 +1,85 @@
+# Where Nuke's Work Runs
+
+Learn which thread runs what, and how to change the limits.
+
+## Overview
+
+Nuke has exactly two places where work happens: ``ImagePipelineActor``, which serializes all coordination, and the cooperative thread pool, where the expensive CPU work runs. The five ``TaskQueue`` instances on the configuration decide how much of the latter runs at once.
+
+You don't need any of this to load an image. You need it when you're writing a custom ``ImageProcessing``, an ``ImageDecoding``, or an ``ImagePipeline/Delegate-swift.protocol`` – or when the CPU work is competing with your app.
+
+## ImagePipelineActor
+
+``ImagePipelineActor`` is a global actor. Everything that touches the pipeline's task graph runs on it: starting and cancelling tasks, coalescing equivalent requests, updating priorities, reading and writing the memory cache, and delivering the delegate callbacks that report progress.
+
+```swift
+@ImagePipelineActor
+final class RequestLog {
+    private var started: [ImageTask.ID: Date] = [:]
+
+    func record(_ task: ImageTask) {
+        started[task.id] = Date() // No lock needed: the actor serializes access
+    }
+}
+```
+
+What does *not* run on it is the expensive part. Decoding, processing, decompression, and encoding all hop to the cooperative pool; the pipeline never blocks its own coordination on a Core Graphics call. Data loading doesn't run on it either – it's `URLSession` I/O.
+
+The practical consequence: a custom ``ImageProcessing/process(_:context:)`` is called off the actor and off the main thread, and it can take as long as it needs without stalling other requests. A delegate method marked `@ImagePipelineActor`, on the other hand, is on the pipeline's critical path – keep it short.
+
+## The Task Queues
+
+Each stage has a ``TaskQueue`` that limits how many units of work run concurrently. The queues are priority-aware: the highest-priority pending work is dequeued first, and changing an ``ImageTask/priority`` reorders the work that hasn't started.
+
+| Queue | Default | What it limits |
+|---|---|---|
+| ``ImagePipeline/Configuration-swift.struct/dataLoadingQueue`` | 6 | Concurrent `URLSession` data tasks. |
+| ``ImagePipeline/Configuration-swift.struct/imageDecodingQueue`` | 1 | Concurrent decodes. Decoding is memory-hungry, so it's serialized by default. |
+| ``ImagePipeline/Configuration-swift.struct/imageProcessingQueue`` | 2 | Concurrent ``ImageProcessing`` runs. |
+| ``ImagePipeline/Configuration-swift.struct/imageDecompressingQueue`` | 2 | Concurrent decompressions (bitmapping). |
+| ``ImagePipeline/Configuration-swift.struct/imageEncodingQueue`` | 1 | Concurrent encodes when writing processed images to ``DataCache``. |
+
+The defaults are deliberately below the core count. Saturating every core with image work is the fastest way to make scrolling stutter – the goal is to leave headroom for the rest of the app.
+
+```swift
+let pipeline = ImagePipeline {
+    $0.imageProcessingQueue.maxConcurrentTaskCount = 4
+}
+```
+
+``ImagePrefetcher`` has a queue of its own, limited to 2 concurrent requests by default, on top of the pipeline's.
+
+> Important: ``ImagePipeline/Configuration-swift.struct`` is a struct, but ``TaskQueue`` is a class. Copying a configuration *shares* its queues rather than duplicating them, so mutating a queue on a copy also changes it for the pipeline the copy came from. Start from a fresh `Configuration()` to get your own queues.
+
+## Delegate Isolation
+
+``ImagePipeline/Delegate-swift.protocol`` declares where each method runs in its own signature, rather than describing it in prose.
+
+| Isolation | Methods |
+|---|---|
+| `@ImagePipelineActor` | ``ImagePipeline/Delegate/willLoadData(for:urlRequest:pipeline:)``, ``ImagePipeline/Delegate/willCache(data:image:for:pipeline:)``, ``ImagePipeline/Delegate/imageTaskDidStart(_:pipeline:)``, ``ImagePipeline/Delegate/imageTask(_:didReceiveEvent:pipeline:)`` |
+| `nonisolated` | Everything else: the factories, ``ImagePipeline/Delegate/cacheKey(for:pipeline:)``, the policies, ``ImagePipeline/Delegate/decompress(response:request:pipeline:)``, and ``ImagePipeline/Delegate/imageTaskCreated(_:pipeline:)`` |
+
+The split follows the question each method answers. The `nonisolated` ones *return a customization* – a decoder, a cache key, a policy – and the pipeline needs the answer wherever it happens to be, including from the synchronous ``ImagePipeline/Cache-swift.struct`` API. The isolated ones *report* something, so a delegate can accumulate state on the actor without a lock.
+
+``ImagePipeline/Delegate/imageTaskCreated(_:pipeline:)`` is the exception among the reporting methods: it's `nonisolated` and called immediately, in whatever context created the task, so that you can see a task before it's scheduled.
+
+A plain, non-isolated method still satisfies an isolated requirement, so most delegates need no annotations at all. Only a *conflicting* isolation is rejected – and a `@MainActor` delegate, which couldn't conform at all before Nuke 14, now works.
+
+```swift
+@MainActor
+final class PipelineObserver: ImagePipeline.Delegate {
+    var inFlight = 0
+
+    nonisolated func imageTaskCreated(_ task: ImageTask, pipeline: ImagePipeline) {
+        Task { @MainActor in self.inFlight += 1 }
+    }
+}
+```
+
+## Topics
+
+### Concurrency
+
+- ``ImagePipelineActor``
+- ``TaskQueue``

--- a/Documentation/Nuke.docc/Essentials/errors.md
+++ b/Documentation/Nuke.docc/Essentials/errors.md
@@ -1,0 +1,92 @@
+# Errors
+
+Handle the typed errors the pipeline throws.
+
+## Overview
+
+Every image request finishes with either an ``ImageResponse`` or an ``ImagePipeline/Error``. That's not a convention – it's in the signature. ``ImagePipeline/image(for:)-(URL)``, ``ImageTask/image``, and ``ImageTask/response`` are declared `throws(ImagePipeline.Error)`, so the error you catch is already the concrete type.
+
+```swift
+do {
+    imageView.image = try await ImagePipeline.shared.image(for: url)
+} catch {
+    // `error` is an `ImagePipeline.Error` – no cast, no `as?`
+    switch error {
+    case .dataDownloadExceededMaximumSize:
+        showTooLargeMessage()
+    default:
+        showFailureImage()
+    }
+}
+```
+
+The type reaches the views too. `NukeUI` doesn't erase it: `LazyImageState.error`, `FetchImage.result`, and the `onCompletion` closures all carry `ImagePipeline.Error`, so a view can branch on a case directly.
+
+```swift
+LazyImage(url: url) { state in
+    if case .dataDownloadExceededMaximumSize = state.error {
+        Text("Image too large")
+    } else if let image = state.image {
+        image.resizable()
+    }
+}
+```
+
+## Cancellation Is Not a Failure
+
+``ImagePipeline/Error/cancelled`` is by far the most common case, and it almost never deserves an error message. Every image view that scrolls offscreen cancels its request; so does every `LazyImage` whose URL changes. Filter it out before you report anything.
+
+```swift
+do {
+    imageView.image = try await ImagePipeline.shared.image(for: url)
+} catch {
+    guard !error.isCancelled else { return }
+    logger.error("Failed to load image: \(error)")
+}
+```
+
+``ImagePipeline/Error/isCancelled`` is the check to use. Reaching for `Task.isCancelled` instead misses the cancellations that come from ``ImageTask/cancel()``, and treating cancellation as a failure fills your logs and your UI with noise that isn't a bug.
+
+> Tip: ``ImageTask/isCancelled`` answers a different question: it records whether cancellation was *requested*, which can happen after a task has already succeeded. Use the error to learn how the task actually ended.
+
+## The Error Cases
+
+| Case | When it happens |
+|---|---|
+| ``ImagePipeline/Error/cancelled`` | The task was cancelled, either by ``ImageTask/cancel()`` or by cancelling the Swift concurrency task awaiting it. |
+| ``ImagePipeline/Error/dataLoadingFailed(error:)`` | The data loader failed. Wraps the underlying error – usually a `URLError`, or a ``DataLoader/Error`` for an unacceptable status code. |
+| ``ImagePipeline/Error/dataIsEmpty`` | The download finished successfully but produced no bytes. |
+| ``ImagePipeline/Error/dataMissingInCache`` | ``ImageRequest/Options-swift.struct/returnCacheDataDontLoad`` was set and the data wasn't in the cache. |
+| ``ImagePipeline/Error/dataDownloadExceededMaximumSize`` | The response grew past ``ImagePipeline/Configuration-swift.struct/maximumResponseDataSize``. The download is cancelled as soon as the limit is crossed. |
+| ``ImagePipeline/Error/decoderNotRegistered(context:)`` | No decoder matched the downloaded data. Only reachable with custom decoders – ``ImageDecoders/Default`` is a catch-all otherwise. |
+| ``ImagePipeline/Error/decodingFailed(decoder:context:error:)`` | The decoder ran but couldn't produce a final image, typically because the data is corrupt or truncated. |
+| ``ImagePipeline/Error/processingFailed(processor:context:error:)`` | An ``ImageProcessing`` in the request failed. The failing processor is attached. |
+| ``ImagePipeline/Error/imageRequestMissing`` | A view or ``ImagePipeline`` method was asked to load with no request – most often a `nil` URL reaching `LazyImage` or `loadImage(with:into:)`. |
+| ``ImagePipeline/Error/pipelineInvalidated`` | The pipeline was invalidated with ``ImagePipeline/invalidate()``; it accepts no further requests. |
+
+Every case is `CustomStringConvertible`, so `"\(error)"` gives you a description that already includes the underlying error where there is one.
+
+## Unwrapping the Underlying Error
+
+``ImagePipeline/Error/dataLoadingFailed(error:)`` is the only case that wraps something else, and it's the one you usually need to look inside – to tell "the device is offline" apart from "the server said 404". ``ImagePipeline/Error/dataLoadingError`` unwraps it for you, returning `nil` for every other case.
+
+```swift
+func message(for error: ImagePipeline.Error) -> String? {
+    guard !error.isCancelled else { return nil }
+    switch error.dataLoadingError {
+    case let urlError as URLError where urlError.code == .notConnectedToInternet:
+        return "You're offline"
+    case let loaderError as DataLoader.Error:
+        if case let .statusCodeUnacceptable(statusCode) = loaderError {
+            return "Server returned \(statusCode)"
+        }
+        return "Couldn't load the image"
+    default:
+        return "Couldn't load the image"
+    }
+}
+```
+
+A `URLError` is what you get for the ordinary networking failures: no connection, a timeout, a TLS failure, a cancelled `URLSession` task. A ``DataLoader/Error`` is produced by ``DataLoader/validate(response:)``, which rejects any HTTP status code outside `2xx`.
+
+An error thrown from ``ImagePipeline/Delegate/willLoadData(for:urlRequest:pipeline:)`` or from an async ``ImageRequest`` source is wrapped the same way, so a failed token refresh arrives as `dataLoadingFailed` carrying your own error type.

--- a/Documentation/Nuke.docc/Essentials/getting-started.md
+++ b/Documentation/Nuke.docc/Essentials/getting-started.md
@@ -88,6 +88,8 @@ Learn more in NukeUI [documentation](https://kean-docs.github.io/nukeui/document
 
 - **<doc:swiftui>** — Use `LazyImage` and `FetchImage` in SwiftUI apps
 - **<doc:uikit>** — Load images into `UIImageView` and handle cell reuse
+- **<doc:errors>** — Handle the typed `ImagePipeline.Error` and filter out cancellations
 - **<doc:caching>** — Understand the three cache layers and how to configure them
 - **<doc:performance-guide>** — Prefetching, decompression, coalescing, and more
 - **<doc:image-processing>** — Resize, blur, and apply custom processors
+- **<doc:where-work-runs>** — `ImagePipelineActor`, the task queues, and delegate isolation

--- a/Documentation/Nuke.docc/Extensions/ImagePipeline-Extension.md
+++ b/Documentation/Nuke.docc/Extensions/ImagePipeline-Extension.md
@@ -105,6 +105,8 @@ do {
 }
 ```
 
+> Tip: See <doc:errors> for what every case means and how to unwrap the underlying `URLError`.
+
 ## Topics
 
 ### Getting a Pipeline

--- a/Documentation/Nuke.docc/Extensions/ImagePipelineDelegate-Extension.md
+++ b/Documentation/Nuke.docc/Extensions/ImagePipelineDelegate-Extension.md
@@ -1,5 +1,9 @@
 # ``Nuke/ImagePipeline/Delegate-swift.protocol``
 
+## Overview
+
+Every method declares its isolation in its own signature. The methods that return a customization are `nonisolated`; the ones that report to the delegate run on ``ImagePipelineActor``. See <doc:where-work-runs> for the full table and what it means for a `@MainActor` delegate.
+
 ## Topics
 
 ### Data Loading
@@ -24,3 +28,9 @@
 
 - ``shouldDecompress(response:for:pipeline:)``
 - ``decompress(response:request:pipeline:)``
+
+### Observing Tasks
+
+- ``imageTaskCreated(_:pipeline:)``
+- ``imageTaskDidStart(_:pipeline:)``
+- ``imageTask(_:didReceiveEvent:pipeline:)``

--- a/Documentation/Nuke.docc/Nuke.md
+++ b/Documentation/Nuke.docc/Nuke.md
@@ -6,7 +6,7 @@ A powerful image loading system for Apple platforms.
 
 Nuke provides an efficient way to download and display images in your app. It's easy to learn and use. Its architecture enables many powerful features while offering virtually unlimited possibilities for customization.
 
-The framework is lean and compiles in under 2 seconds. Nuke has an automated test suite 2x the codebase size, ensuring excellent reliability. Every feature is carefully designed and optimized for performance.
+The framework is lean – 31 public types in the core module – and has an automated test suite 2x the codebase size, ensuring excellent reliability. Every feature is carefully designed and optimized for performance.
 
 ## Getting Started
 
@@ -32,17 +32,22 @@ To install Nuke, use Swift Package Manager.
 - <doc:swiftui>
 - <doc:uikit>
 - <doc:objective-c>
+- <doc:errors>
 - ``ImagePipeline``
 - ``ImageRequest``
 - ``ImageResponse``
 - ``ImageTask``
+- ``ImagePipeline/Error``
 
 ### Customization
 
 - <doc:image-processing>
 - <doc:loading-data>
 - <doc:image-formats>
+- <doc:where-work-runs>
 - ``ImagePipeline/Delegate-swift.protocol``
+- ``ImagePipelineActor``
+- ``TaskQueue``
 
 ### Performance
 

--- a/Documentation/Nuke.docc/Performance/performance-guide.md
+++ b/Documentation/Nuke.docc/Performance/performance-guide.md
@@ -2,6 +2,16 @@
 
 Learn about the performance features in Nuke and how to make the most of them.
 
+## Do This First
+
+Most of what makes Nuke fast is already on: coalescing, background decompression, resumable downloads, and rate limiting all work without configuration. Five things are worth doing deliberately, and the rest of this guide explains why.
+
+1. **Enable the aggressive disk cache.** ``DataCache`` is faster than `URLCache`, works offline, and doesn't need the server to send `cache-control` – see <doc:caching> and the *Caching* section below.
+2. **Downsample before you decode.** A 6000×4000 bitmap costs 92 MB of memory. ``ImageRequest/ThumbnailOptions`` gets you a thumbnail straight out of the decoder, up to 4x faster than ``ImageProcessors/Resize`` – see *Downsample Images* below.
+3. **Prefetch ahead of the scroll.** ``ImagePrefetcher`` turns "loading" into "already there" for lists and grids – see <doc:prefetching>.
+4. **Prefetch with the same processors you display with.** Otherwise the memory cache fills with images you'll never show – see *Prefetching* below.
+5. **Measure before tuning anything else.** Turn on ``ImagePipeline/Configuration-swift.struct/isSignpostLoggingEnabled`` and look at the `os_signpost` Instrument – see *Measure* below.
+
 ## Caching
 
 Images can take a lot of space. By using Nuke, you can ensure that when you download an image, it will be cached so that you don't have to download it again. Nuke provides three different caching layers.
@@ -119,7 +129,7 @@ Once enabled, you’ll first see a blurry low-quality version of the full image,
 
 ## Request Priorities
 
-Nuke is fully asynchronous and performs well under stress. ``ImagePipeline`` distributes its work on ``TaskQueue`` instances dedicated to a specific type of work, such as processing and decoding. Each queue limits the number of concurrent tasks, respects the request priorities, and cancels the work as soon as possible.
+Nuke is fully asynchronous and performs well under stress. ``ImagePipeline`` distributes its work on ``TaskQueue`` instances dedicated to a specific type of work, such as processing and decoding. Each queue limits the number of concurrent tasks, respects the request priorities, and cancels the work as soon as possible. See <doc:where-work-runs> for the five queues, their defaults, and how to change them.
 
 Cancelling an ``ImageTask`` frees its associated network and CPU resources immediately. Thanks to coalescing, the underlying work is only cancelled when all requests sharing it have been cancelled — so cancelling one request doesn't affect others loading the same image.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 Load images from different sources and display them in your app using simple and flexible APIs. Take advantage of the powerful image processing capabilities and a robust caching system.
 
-The framework is lean and compiles in under 2 seconds[¹](#footnote-1). It has an automated test suite 2x the codebase size, ensuring excellent reliability. Nuke is optimized for [performance](https://kean-docs.github.io/nuke/documentation/nuke/performance-guide), and its advanced architecture enables virtually unlimited possibilities for customization.
+The framework is lean – 31 public types in the core module – and has an automated test suite 2x the codebase size, ensuring excellent reliability. Nuke is optimized for [performance](https://kean-docs.github.io/nuke/documentation/nuke/performance-guide), and its advanced architecture enables virtually unlimited possibilities for customization.
 
-> **Memory and Disk Cache** · **Image Processing & Decompression** · **Request Coalescing & Priority** · **Prefetching** · **Resumable Downloads** · **Progressive JPEG** · **HEIF, WebP, GIF** · **SwiftUI** · **Async/Await**
+> **Typed Errors** · **Memory and Disk Cache** · **Image Processing & Decompression** · **Request Coalescing & Priority** · **Prefetching** · **Resumable Downloads** · **Progressive JPEG** · **HEIF, WebP, GIF** · **SwiftUI** · **Async/Await**
 
 ## Sponsors
 
@@ -43,12 +43,14 @@ func loadImage() async throws {
 }
 ```
 
-Or use the built-in UI components from [**NukeUI**](https://kean-docs.github.io/nukeui/documentation/nukeui/):
+Or use the built-in UI components from [**NukeUI**](https://kean-docs.github.io/nukeui/documentation/nukeui/). `LazyImage(url:)` covers the common case, and the `state` closure hands you the typed `ImagePipeline.Error` the pipeline threw:
 
 ```swift
-struct ContentView: View {
-    var body: some View {
-        LazyImage(url: URL(string: "https://example.com/image.jpeg"))
+LazyImage(url: url) { state in
+    if case .dataDownloadExceededMaximumSize = state.error {
+        Text("Image too large")   // no cast, no `as?`
+    } else if let image = state.image {
+        image.resizable()
     }
 }
 ```
@@ -63,13 +65,14 @@ The [**Getting Started**](https://kean-docs.github.io/nuke/documentation/nuke/ge
 
 Nuke supports [Swift Package Manager](https://www.swift.org/package-manager/), which is the recommended option. If that doesn't work for you, you can use binary frameworks attached to the [releases](https://github.com/kean/Nuke/releases).
 
-The package ships with three modules that you can install depending on your needs:
+The package ships with four modules that you can install depending on your needs:
 
 |Module|Description|
 |--|--|
 |[**Nuke**](https://kean-docs.github.io/nuke/documentation/nuke)|The lean core framework with `ImagePipeline`, `ImageRequest`, and more|
 |[**NukeUI**](https://kean-docs.github.io/nukeui/documentation/nukeui/)|The UI components: `LazyImage` (SwiftUI), `LazyImageView` and `UIImageView` extensions (UIKit, AppKit)|
 |[**NukeVideo**](https://kean-docs.github.io/nukevideo/documentation/nukevideo/)|The components for decoding and playing short videos|
+|**NukeExtensions**|**Deprecated**. An empty shim that re-exports `NukeUI`, where the image view extensions moved in Nuke 14. Scheduled for removal in Nuke 15|
 
 ## Extensions
 
@@ -84,6 +87,14 @@ The image pipeline is easy to customize and extend. Check out the following firs
 |[**RxNuke**](https://github.com/kean/RxNuke)|[RxSwift](https://github.com/ReactiveX/RxSwift) extensions for Nuke with examples|
 
 > Looking for a way to log your network requests, including image requests? Check out [**Pulse**](https://github.com/kean/Pulse).
+
+## What's New in Nuke 14
+
+- **Typed errors, end to end.** `ImagePipeline` and `ImageTask` are declared `throws(ImagePipeline.Error)`, and `NukeUI` surfaces the same type instead of erasing it: `LazyImageState.error`, `FetchImage.result`, and `onCompletion` all carry it, so branching on a case needs no cast.
+- **`NukeExtensions` folded into `NukeUI`.** `loadImage(with:into:)` and friends now live alongside the other UIKit and AppKit views. `NukeExtensions` remains as a shim that re-exports `NukeUI` and is removed in Nuke 15.
+- **Combine APIs removed.** `ImagePipeline.imagePublisher(with:)` and the publisher-based `FetchImage.load(_:)` are gone – use the Async/Await APIs.
+
+The [**Nuke 14 Migration Guide**](https://github.com/kean/Nuke/blob/main/Documentation/Migrations/Nuke%2014%20Migration%20Guide.md) covers these and the rest of the changes.
 
 ## Minimum Requirements
 
@@ -100,7 +111,3 @@ The image pipeline is easy to customize and extend. Check out the following firs
 ## License
 
 Nuke is available under the MIT license. See the LICENSE file for more info.
-
-----
-
-> <a name="footnote-1">¹</a> Measured on MacBook Pro 14" 2021 (10-core M1 Pro)

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -50,6 +50,15 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     }
 
     /// The download progress.
+    ///
+    /// This is the only progress type in Nuke: the pipeline, ``ImageTask``, and
+    /// the `NukeUI` views all report this struct. Read the latest value from
+    /// ``ImageTask/Status/progress``, observe the updates as a stream with
+    /// ``ImageTask/progress-swift.property``, or, in `NukeUI`, read
+    /// `FetchImage.progress`, `LazyImageState.progress`, or
+    /// `LazyImageView.onProgress`.
+    ///
+    /// - seealso: ``ImageTask/progress-swift.property``
     public struct Progress: Hashable, Sendable {
         /// The number of bytes that the task has received.
         public let completed: Int64
@@ -112,6 +121,8 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
 
         /// The download progress. Contains zeros until the download starts and
         /// the total resource size is known.
+        ///
+        /// - seealso: ``ImageTask/Progress-swift.struct``
         public internal(set) var progress = Progress(completed: 0, total: 0)
 
         /// Initializes the status describing a task that has just started.
@@ -167,6 +178,10 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     /// The stream of progress updates.
     ///
     /// A convenience over ``events``: every access creates a new subscription.
+    /// Each element is an ``ImageTask/Progress-swift.struct``; for the latest
+    /// value as a snapshot instead of a stream, read ``Status/progress``.
+    ///
+    /// - seealso: ``ImageTask/Progress-swift.struct``
     public var progress: AsyncCompactMapSequence<AsyncStream<Event>, Progress> {
         events.compactMap {
             if case .progress(let value) = $0 { return value }

--- a/Sources/NukeUI/FetchImage.swift
+++ b/Sources/NukeUI/FetchImage.swift
@@ -39,6 +39,10 @@ public final class FetchImage: ObservableObject, Identifiable {
 
     /// The progress of the current image download.
     ///
+    /// Returns `ImageTask.Progress`, the same struct the pipeline reports.
+    /// `NukeUI` no longer has a progress type of its own: `FetchImage.Progress`
+    /// is a deprecated typealias for it.
+    ///
     /// - note: The updates are only published to the observers if you read the
     /// property, so the views that don't display the progress aren't
     /// invalidated every time a chunk of data arrives.

--- a/Sources/NukeUI/LazyImageState.swift
+++ b/Sources/NukeUI/LazyImageState.swift
@@ -23,6 +23,10 @@ public protocol LazyImageState {
     var isLoading: Bool { get }
 
     /// The progress of the image download.
+    ///
+    /// Returns `ImageTask.Progress`, the same struct the pipeline reports.
+    /// `NukeUI` no longer has a progress type of its own: `FetchImage.Progress`
+    /// is a deprecated typealias for it.
     var progress: ImageTask.Progress { get }
 }
 

--- a/Sources/NukeUI/LazyImageView.swift
+++ b/Sources/NukeUI/LazyImageView.swift
@@ -151,6 +151,8 @@ public final class LazyImageView: _PlatformBaseView {
     public var onPreview: (@MainActor @Sendable (ImageResponse) -> Void)?
 
     /// Gets called when the request progress is updated.
+    ///
+    /// Receives `ImageTask.Progress`, the same struct the pipeline reports.
     public var onProgress: (@MainActor @Sendable (ImageTask.Progress) -> Void)?
 
     /// Gets called when the request finishes successfully.

--- a/Tests/DocumentationSnippets/Snippets/ConcurrencySnippets.swift
+++ b/Tests/DocumentationSnippets/Snippets/ConcurrencySnippets.swift
@@ -1,0 +1,39 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+// Snippets from `Documentation/Nuke.docc/Customization/where-work-runs.md`.
+
+import Foundation
+import Nuke
+
+// MARK: - ImagePipelineActor
+
+@ImagePipelineActor
+private final class RequestLog {
+    private var started: [ImageTask.ID: Date] = [:]
+
+    func record(_ task: ImageTask) {
+        started[task.id] = Date() // No lock needed: the actor serializes access
+    }
+}
+
+// MARK: - The Task Queues
+
+private func customQueueLimits() {
+    let pipeline = ImagePipeline {
+        $0.imageProcessingQueue.maxConcurrentTaskCount = 4
+    }
+    _ = pipeline
+}
+
+// MARK: - Delegate Isolation
+
+@MainActor
+private final class PipelineObserver: ImagePipeline.Delegate {
+    var inFlight = 0
+
+    nonisolated func imageTaskCreated(_ task: ImageTask, pipeline: ImagePipeline) {
+        Task { @MainActor in self.inFlight += 1 }
+    }
+}

--- a/Tests/DocumentationSnippets/Snippets/ErrorsSnippets.swift
+++ b/Tests/DocumentationSnippets/Snippets/ErrorsSnippets.swift
@@ -1,0 +1,87 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+// Snippets from `Documentation/Nuke.docc/Essentials/errors.md`.
+
+import Foundation
+import SwiftUI
+import Nuke
+import NukeUI
+
+// MARK: - Overview
+
+private struct TypedErrorView: View {
+    let url: URL
+
+    var body: some View {
+        LazyImage(url: url) { state in
+            if case .dataDownloadExceededMaximumSize = state.error {
+                Text("Image too large")
+            } else if let image = state.image {
+                image.resizable()
+            }
+        }
+    }
+}
+
+// MARK: - Unwrapping the Underlying Error
+
+private func message(for error: ImagePipeline.Error) -> String? {
+    guard !error.isCancelled else { return nil }
+    switch error.dataLoadingError {
+    case let urlError as URLError where urlError.code == .notConnectedToInternet:
+        return "You're offline"
+    case let loaderError as DataLoader.Error:
+        if case let .statusCodeUnacceptable(statusCode) = loaderError {
+            return "Server returned \(statusCode)"
+        }
+        return "Couldn't load the image"
+    default:
+        return "Couldn't load the image"
+    }
+}
+
+#if canImport(UIKit) && !os(watchOS)
+
+import UIKit
+import os
+
+@MainActor
+private final class ErrorsSnippets {
+    let url = URL(string: "https://example.com/image")!
+    let imageView = UIImageView()
+    let logger = Logger()
+
+    // MARK: - Overview
+
+    func typedCatch() async {
+        do {
+            imageView.image = try await ImagePipeline.shared.image(for: url)
+        } catch {
+            // `error` is an `ImagePipeline.Error` – no cast, no `as?`
+            switch error {
+            case .dataDownloadExceededMaximumSize:
+                showTooLargeMessage()
+            default:
+                showFailureImage()
+            }
+        }
+    }
+
+    // MARK: - Cancellation Is Not a Failure
+
+    func filteringCancellation() async {
+        do {
+            imageView.image = try await ImagePipeline.shared.image(for: url)
+        } catch {
+            guard !error.isCancelled else { return }
+            logger.error("Failed to load image: \(error)")
+        }
+    }
+
+    private func showTooLargeMessage() {}
+    private func showFailureImage() {}
+}
+
+#endif


### PR DESCRIPTION
Addresses the "Surfacing it better" review section: the README and the docs under-sold typed throws and the concurrency model, and over-indexed on install instructions.

## README

- **Lead with typed throws.** The feature strip led with "Async/Await", true of every image library shipped since 2021. `throws(ImagePipeline.Error)` reaching into `LazyImage`'s state is the differentiator, so it's first in the strip and it's the second snippet.
- **Replace the compile-time claim.** "Compiles in under 2 seconds" was footnoted to one machine. It's now "31 public types in the core module", which anyone can check; the footnote is gone.
- **Fix the module table.** It said "three modules" while `Package.swift` ships four products. `NukeExtensions` now has a row marked as a deprecated shim — the row someone upgrading from 13 goes looking for.
- **Add "What's New in Nuke 14".** Three bullets — typed errors end to end, `NukeExtensions` folded into `NukeUI`, Combine removed — linking the migration guide from where the reader already is.

## DocC

- **New "Errors" article** (Essentials): what the ten cases mean, why `.cancelled` is not a failure worth reporting, and how `dataLoadingError` unwraps a `URLError` or a `DataLoader.Error`. `ImagePipeline.Error` is added to the topic tree.
- **New "Where Nuke's Work Runs" article** (Customization): `ImagePipelineActor`, the five `TaskQueue`s and their defaults, and the delegate isolation table that was stranded in the migration guide. Both `ImagePipelineActor` and `TaskQueue` are public and were absent from the topic tree; they're in it now, and the delegate reference page links to the article.
- **Performance Guide "Do This First" opener**: a five-item checklist so `DataCache`, `ThumbnailOptions`, and prefetching aren't spread across a long article.
- **Cross-linked the `Progress` symbols**: `ImageTask.Progress` now names the properties that report it (`ImageTask.progress`, `Status.progress`, `FetchImage.progress`, `LazyImageState.progress`, `LazyImageView.onProgress`), and each of those says it's the same struct.

## Two notes on the review

- **`uikit.md` was already rewritten against NukeUI** in #955, along with the `loadImage(with:into:for:)` section for an API that never existed. Nothing left to do there; its samples compile in CI.
- **The type count is 31, not 33.** Counting top-level public nominal types in `Sources/Nuke` gives 31; adding the `PlatformImage` and `PlatformColor` typealiases gets to 33. Since the point of the claim is that it's checkable, the README uses the number a reader gets from counting types.

## Verification

- `make ci-snippets-ios` passes — the samples from both new articles are in `Tests/DocumentationSnippets`, so they compile like the rest.
- `xcodebuild docbuild -scheme Nuke` succeeds with no DocC diagnostics; both new pages are in the archive with every symbol link resolved.
