### PR TITLE
Run queued operations at the priority they were scheduled with

### DIFF
--- a/Sources/Nuke/Internal/Extensions.swift
+++ b/Sources/Nuke/Internal/Extensions.swift
@@ -50,6 +50,17 @@ extension ImageRequest.Priority {
     }
 }
 
+extension TaskPriority {
+    var concurrencyPriority: _Concurrency.TaskPriority {
+        switch self {
+        case .veryLow: return .background
+        case .low: return .utility
+        case .normal: return .medium
+        case .high, .veryHigh: return .high
+        }
+    }
+}
+
 struct AnonymousCancellable: Cancellable {
     let onCancel: @Sendable () -> Void
 

--- a/Sources/Nuke/Pipeline/TaskQueue.swift
+++ b/Sources/Nuke/Pipeline/TaskQueue.swift
@@ -122,7 +122,7 @@ public final class TaskQueue: Sendable {
         // reference it weakly. The work is read _inside_ the task (instead of
         // being hoisted out of the operation) so that cancelling an operation
         // that was dequeued, but hasn't started yet, prevents it from running.
-        operation.task = Task { @ImagePipelineActor [weak self] in
+        operation.task = Task(priority: operation.priority.concurrencyPriority) { @ImagePipelineActor [weak self] in
             if let work = operation.work {
                 operation.work = nil
                 try? await work()


### PR DESCRIPTION
This resolves an Xcode warning about priority inversion.