### PR TITLE
Make TaskSubscription noncopyable so it can't be unsubscribed twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Minimum required platforms: iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, visionOS 1.0 – https://github.com/kean/Nuke/pull/904
 - Replace the hand-rolled `os_unfair_lock_t` allocations with `OSAllocatedUnfairLock` – https://github.com/kean/Nuke/pull/908
+- The internal `TaskSubscription` is now `~Copyable`, so the compiler rejects unsubscribing twice – https://github.com/kean/Nuke/pull/961
 
 **API Changes**
 

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -213,8 +213,7 @@ public final class ImagePipeline: Sendable {
 
     func imageTaskCancelCalled(_ task: ImageTask) {
         removeTask(task)
-        task._subscription?.unsubscribe()
-        task._subscription = nil
+        task._subscription.take()?.unsubscribe()
         task._cancel()
     }
 
@@ -232,6 +231,8 @@ public final class ImagePipeline: Sendable {
         switch event {
         case .finished:
             removeTask(task)
+            // The worker is already done, so the subscription is dropped
+            // rather than unsubscribed – there is nothing left to cancel.
             task._subscription = nil
         default: break
         }

--- a/Sources/Nuke/Tasks/AsyncTask.swift
+++ b/Sources/Nuke/Tasks/AsyncTask.swift
@@ -205,7 +205,7 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
 
         if reason == .cancelled {
             operation?.cancel()
-            dependency?.unsubscribe()
+            dependency.take()?.unsubscribe()
             onCancelled?()
         }
         onDisposed?()
@@ -298,8 +298,13 @@ extension AsyncTask.Event: Equatable where Value: Equatable, Error: Equatable {}
 
 /// Represents a subscription to a task. The observer must retain a strong
 /// reference to a subscription.
+///
+/// The subscription is a unique handle: it can't be copied, so it has exactly
+/// one owner, and ``unsubscribe()`` consumes it. Dropping one instead is
+/// deliberate – it means the task already finished and there is nothing left
+/// to cancel.
 @ImagePipelineActor
-struct TaskSubscription: Sendable {
+struct TaskSubscription: ~Copyable, Sendable {
     private let task: any AsyncTaskSubscriptionDelegate
     private let key: TaskSubscriptionKey
 
@@ -314,7 +319,7 @@ struct TaskSubscription: Sendable {
     /// If there are no more subscriptions attached to the task, the task gets
     /// cancelled along with its dependencies. The cancelled task is
     /// marked as disposed.
-    func unsubscribe() {
+    consuming func unsubscribe() {
         task.unsubsribe(key: key)
     }
 

--- a/Tests/NukeTests/TaskTests.swift
+++ b/Tests/NukeTests/TaskTests.swift
@@ -131,7 +131,8 @@ struct TaskTests {
         await Task.yield()
 
         // Then
-        #expect(task.subscribe { _ in } == nil)
+        let subscriptionWasRejected = task.subscribe { _ in }.isNil
+        #expect(subscriptionWasRejected)
     }
 
     @Test func cantSubscribeToAlreadySucceededTask() {
@@ -143,7 +144,8 @@ struct TaskTests {
         task.send(value: 1, isCompleted: true)
 
         // Then
-        #expect(task.subscribe { _ in } == nil)
+        let subscriptionWasRejected = task.subscribe { _ in }.isNil
+        #expect(subscriptionWasRejected)
     }
 
     @Test func cantSubscribeToAlreadyFailedTasks() {
@@ -155,7 +157,8 @@ struct TaskTests {
         task.send(error: .init(raw: "1"))
 
         // Then
-        #expect(task.subscribe { _ in } == nil)
+        let subscriptionWasRejected = task.subscribe { _ in }.isNil
+        #expect(subscriptionWasRejected)
     }
 
     @Test func subscribeToTaskWithSynchronousCompletionReturnsNil() async {
@@ -171,7 +174,8 @@ struct TaskTests {
             }
 
             // Then
-            #expect(subscription == nil)
+            let subscriptionWasRejected = subscription.isNil
+            #expect(subscriptionWasRejected)
         }
     }
 
@@ -243,12 +247,12 @@ struct TaskTests {
         let operation = TaskQueue.Operation()
         let dependency = SimpleTask<Int, MyError>(starter: { $0.operation = operation })
         let task = SimpleTask<Int, MyError>(starter: { $0.dependency = dependency.subscribe { _ in } })
-        let subscription = task.subscribe { _ in }
+        var subscription = task.subscribe { _ in }
         #expect(!operation.isCancelled)
 
         // When
         await waitForCancellation(of: operation) {
-            subscription?.unsubscribe()
+            subscription.take()?.unsubscribe()
         }
 
         // Then
@@ -548,5 +552,16 @@ private final class SimpleTask<T, E>: AsyncTask<T, E>, @unchecked Sendable {
 extension AsyncTask {
     func subscribe(priority: TaskPriority = .normal, _ observer: @escaping (Event) -> Void) -> TaskSubscription? {
         publisher.subscribe(priority: priority, subscriber: "" as AnyObject, observer)
+    }
+}
+
+extension Optional where Wrapped: ~Copyable {
+    /// `#expect(subscription == nil)` needs `Equatable`, which a noncopyable
+    /// subscription can't conform to.
+    var isNil: Bool {
+        switch self {
+        case .none: true
+        case .some: false
+        }
     }
 }


### PR DESCRIPTION
`TaskSubscription` is the textbook unique handle: each one is minted once by `subscribe`, lives in exactly one place, and is meant to be unsubscribed at most once. The type couldn't express that, so the call sites did it by convention – unsubscribe, then nil the field in a separate statement.

Making it `~Copyable` with a `consuming func unsubscribe()` collapses the pair into `take()?.unsubscribe()` and lets the compiler enforce the rest: the tempting `_subscription?.unsubscribe()` now fails ownership diagnostics, because it consumes a stored field without reinitialising it.

```
error: noncopyable 'task._subscription' cannot be consumed when captured by
an escaping closure or borrowed by a non-Escapable type
```

The finish path in `imageTask(_:didProcessEvent:isDataTask:)` still drops the handle rather than unsubscribing – the worker is already done, so there is nothing left to cancel. That is now the one place a subscription is deliberately destroyed, and it says so.

The other half of the guarantee isn't available: asserting on a leaked handle needs a `deinit` with `discard self` on the happy path, and `discard` is rejected for a struct holding a class reference. So this buys "at most once, never copied", not "exactly once".

No public API change – `TaskSubscription` is internal.

**Testing**

- `NukeTests` (1054 tests) and `NukeThreadSafetyTests` pass; `NukeUITests`, `NukeExtensionsTests`, and `NukePerformanceTests` build.
- `asyncAwaitPerformance` and `asyncImageTaskPerformance` measured three times against `main` back to back: 65.2–65.8 ms on the branch versus 63.7–67.7 ms on `main`, inside the run-to-run drift on this machine.