### PR TITLE
Decode two thumbnails at a time instead of one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - `ImageDecoders/Default` now parses every animated image it recognizes, once per image on the decoding queue, and attaches the result to the new `ImageContainer/animation` along with the encoded `ImageContainer/data` – which was previously attached to GIFs only. Processing an image, or requesting a thumbnail, clears both. `AnimatedImageSource` moves from `NukeUI` to `Nuke`. Adds `ImagePipeline/Configuration/isAnimatedImageParsingEnabled` – https://github.com/kean/Nuke/pull/958
 - An animated format Image I/O can't read can be played too: a decoder registered with `ImageDecoderRegistry` attaches an `AnimatedImageSource` it describes itself, along with the `AnimatedImageFrameDecoding` that produces its frames – https://github.com/kean/Nuke/pull/958
 - `Nuke_ImageDisplaying` is renamed to `ImageDisplaying`, is no longer `@objc`, and takes an `ImageContainer`: `nuke_display(image:data:)` becomes `nuke_display(_:)`. A conformance declared in an extension can no longer be overridden by a subclass – https://github.com/kean/Nuke/pull/958
+- `ImagePipeline/Configuration/imageDecodingQueue` now runs 2 concurrent tasks instead of 1, matching `imageDecompressingQueue`. It carries the pixel work of a thumbnail request, which decodes and downsamples in one step and skips decompression – https://github.com/kean/Nuke/pull/962
 
 **Bug Fixes**
 

--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -182,8 +182,15 @@ extension ImagePipeline {
         /// Data loading queue. Default maximum concurrent task count is 6.
         public var dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 6)
 
-        /// Image decoding queue. Default maximum concurrent task count is 1.
-        public var imageDecodingQueue = TaskQueue(maxConcurrentTaskCount: 1)
+        /// Image decoding queue. Default maximum concurrent task count is 2.
+        ///
+        /// Only the decoders that ask for it run here – see
+        /// ``ImageDecoding/isAsynchronous``. ``ImageDecoders/Default`` asks for
+        /// it for a thumbnail request, where the decode also downsamples the
+        /// image and no decompression follows it, so the count matches
+        /// ``imageDecompressingQueue``: the pixel work of a request costs the
+        /// same whichever of the two paths it takes.
+        public var imageDecodingQueue = TaskQueue(maxConcurrentTaskCount: 2)
 
         /// Image encoding queue. Default maximum concurrent task count is 1.
         public var imageEncodingQueue = TaskQueue(maxConcurrentTaskCount: 1)


### PR DESCRIPTION
`imageDecodingQueue` runs only the decoders that ask for it – `ImageDecoding/isAsynchronous`. `ImageDecoders.Default` asks for it for a thumbnail request, and that decode also downsamples the image; `makeImageResponse` doesn't mark a thumbnail for decompression, so the entire pixel cost of the request sits in a queue one task wide. The same work on the non-thumbnail path is split across a lazy decode on the actor and `imageDecompressingQueue`, which is two wide. Downsampling – the approach the docs recommend for memory – got half the parallelism for strictly more work.

The count of 1 dates from when every decode ran on this queue, back when a decode was the lazy `CGImageSourceCreateImageAtIndex` that now runs inline on the pipeline actor. This raises it to 2 to match `imageDecompressingQueue`.

Third-party decoders benefit too: they get `isAsynchronous == true` from the protocol's default implementation, so a WebP or AVIF decoder was fully serialized.

### Measurements

Image I/O has no internal lock to serialize around. A 3000x2000 JPEG on an M5 Max, amortized wall-clock per image:

| concurrency | thumbnail decode+scale | full decompress | lazy decode |
|---|---|---|---|
| 1 | 6.4 ms | 12.2 ms | 0.03 ms |
| 2 | 3.2 ms | 7.0 ms | 0.02 ms |
| 4 | 1.6 ms | 3.9 ms | – |
| 6 | 1.1 ms | 3.0 ms | – |
| 8 | 0.9 ms | 3.0 ms | – |

Thumbnail generation is compute-bound and scales nearly linearly; decompression is bandwidth-bound and plateaus around 4–6, which is why `imageDecompressingQueue` stays at 2. Lazy decode is ~30 µs, confirming it belongs on the actor and that this queue is near-idle on the default path.

### To test

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 1054 tests pass.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeUITests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – passes.
3. Load a screen of `ImageRequest(url:, thumbnail:)` requests with a cold cache and confirm two decodes overlap in Instruments (`DecodeImageData` signposts).