### PR TITLE
Build the unit tests without warnings

### DIFF
--- a/Tests/Helpers/AnimatedImageFixtures.swift
+++ b/Tests/Helpers/AnimatedImageFixtures.swift
@@ -40,6 +40,23 @@ extension Test {
         )! // Image I/O writes GIF on every platform
     }
 
+    /// Builds an animated GIF and the source that reads it.
+    ///
+    /// The parameters are the ones ``animatedGIF(frameCount:delays:loopCount:size:)``
+    /// takes. The source is not optional because a fixture with more than one
+    /// frame always declares an animation: a caller can assign it straight into
+    /// an `AnimatedImageSource?` property without a `#require` that unwraps into
+    /// the contextual type and leaves the value optional anyway.
+    static func animatedGIFSource(
+        frameCount: Int = 4,
+        delays: [TimeInterval]? = nil,
+        loopCount: Int? = 0,
+        size: CGSize = CGSize(width: 8, height: 8)
+    ) -> AnimatedImageSource {
+        let data = animatedGIF(frameCount: frameCount, delays: delays, loopCount: loopCount, size: size)
+        return AnimatedImageSource(data: data)!
+    }
+
     /// Builds an animated PNG, or returns `nil` if Image I/O on this platform
     /// can't write one.
     ///

--- a/Tests/NukeTests/ImagePipelineTests/DeprecatedTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/DeprecatedTests.swift
@@ -163,6 +163,10 @@ struct DeprecationTests {
 
 /// `ImageTask.state` is no longer stored – it is derived from `status`. These
 /// tests pin the mapping to what the stored property used to report.
+///
+/// Each test is deprecated along with the property it reads, which is what
+/// keeps the compiler quiet: the attribute has to go on the tests rather than
+/// on the suite, which swift-testing refuses to mark deprecated.
 @Suite(.timeLimit(.minutes(5)))
 struct DeprecatedImageTaskStateTests {
     private let pipeline: ImagePipeline
@@ -177,18 +181,16 @@ struct DeprecatedImageTaskStateTests {
         }
     }
 
-    // The `state` reads are hoisted out of `#expect` on purpose: the macro
-    // re-expands its argument, which would report every deprecation twice.
-
+    @available(*, deprecated)
     @Test func stateIsRunningWhileInFlight() {
         dataLoader.isSuspended = true
         let task = pipeline.imageTask(with: Test.request)
 
-        let state = task.state
-        #expect(state == .running)
+        #expect(task.state == .running)
         task.cancel()
     }
 
+    @available(*, deprecated)
     @Test func stateIsCancelledAsSoonAsCancelIsCalled() {
         dataLoader.isSuspended = true
         let task = pipeline.imageTask(with: Test.request)
@@ -198,10 +200,10 @@ struct DeprecatedImageTaskStateTests {
         // Reads as `.cancelled` whether or not the pipeline has processed the
         // cancellation yet, matching the old stored state, which flipped
         // synchronously inside `cancel()`.
-        let state = task.state
-        #expect(state == .cancelled)
+        #expect(task.state == .cancelled)
     }
 
+    @available(*, deprecated)
     @Test func stateIsCancelledAfterThePipelineProcessesTheCancellation() async throws {
         dataLoader.isSuspended = true
         let task = pipeline.imageTask(with: Test.request)
@@ -210,27 +212,27 @@ struct DeprecatedImageTaskStateTests {
             try await task.response
         }
 
-        let state = task.state
-        #expect(state == .cancelled)
+        #expect(task.state == .cancelled)
     }
 
+    @available(*, deprecated)
     @Test func stateIsCompletedAfterSuccess() async throws {
         let task = pipeline.imageTask(with: Test.request)
         _ = try await task.response
 
-        let state = task.state
-        #expect(state == .completed)
+        #expect(task.state == .completed)
     }
 
+    @available(*, deprecated)
     @Test func stateIsCompletedWhenTheTaskFails() async throws {
         dataLoader.results[Test.url] = .failure(Foundation.URLError(.notConnectedToInternet) as NSError)
         let task = pipeline.imageTask(with: Test.request)
         _ = try? await task.response
 
-        let state = task.state
-        #expect(state == .completed)
+        #expect(task.state == .completed)
     }
 
+    @available(*, deprecated)
     @Test func stateStaysCompletedWhenAFinishedTaskIsCancelled() async throws {
         let task = pipeline.imageTask(with: Test.request)
         _ = try await task.response
@@ -239,8 +241,7 @@ struct DeprecatedImageTaskStateTests {
         // the outcome, which is what the stored state used to guarantee.
         task.cancel()
 
-        let state = task.state
         #expect(task.isCancelled)
-        #expect(state == .completed)
+        #expect(task.state == .completed)
     }
 }

--- a/Tests/NukeTests/ImageProcessorsTests/AnimatedImageDataTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/AnimatedImageDataTests.swift
@@ -14,7 +14,7 @@ struct ImageProcessorsAnimatedImageDataTests {
     @Test func processingDropsTheAttachedData() throws {
         // GIVEN an animated image, whose data describes the animation the
         // processor is about to replace with a single processed still
-        let container = try animatedContainer()
+        let container = animatedContainer()
         let processor = ImageProcessors.Resize(size: CGSize(width: 40, height: 40), unit: .pixels)
 
         let output = try processor.process(container, context: .mock)
@@ -30,7 +30,7 @@ struct ImageProcessorsAnimatedImageDataTests {
     @Test func coreImageFilterDropsTheAttachedData() throws {
         // GIVEN a processor that implements the container method itself and so
         // does not go through the default implementation
-        let container = try animatedContainer()
+        let container = animatedContainer()
         let processor = ImageProcessors.CoreImageFilter(name: "CISepiaTone")
 
         let output = try processor.process(container, context: .mock)
@@ -49,7 +49,7 @@ struct ImageProcessorsAnimatedImageDataTests {
             }
             var identifier: String { "test.keeps-data" }
         }
-        let container = try animatedContainer()
+        let container = animatedContainer()
 
         let output = try KeepsData().process(container, context: .mock)
 
@@ -59,8 +59,8 @@ struct ImageProcessorsAnimatedImageDataTests {
 
     /// A container shaped the way the pipeline hands one over: the encoded
     /// animation, and the metadata parsed out of it.
-    private func animatedContainer() throws -> ImageContainer {
-        let data = Test.animatedGIF()
-        return ImageContainer(image: Test.image, type: .gif, data: data, animation: try #require(AnimatedImageSource(data: data)))
+    private func animatedContainer() -> ImageContainer {
+        let source = Test.animatedGIFSource()
+        return ImageContainer(image: Test.image, type: .gif, data: source.data, animation: source)
     }
 }

--- a/Tests/NukeUITests/AnimatedImageViewTests.swift
+++ b/Tests/NukeUITests/AnimatedImageViewTests.swift
@@ -176,7 +176,7 @@ struct AnimatedImageViewTests {
     }
 #endif
 
-    @Test func settingAnImageStopsTheAnimation() async throws {
+    @Test func settingAnImageStopsTheAnimation() async {
         let host = TestWindow(view: view)
         display(Test.animatedGIF())
         #expect(view.isPlaying)
@@ -286,7 +286,7 @@ struct AnimatedImageViewTests {
         #expect(player.diagnostics.decodedFrameCount > 0)
     }
 
-    @Test func derivesTheSizeAtTheFirstLayoutWhenItHasNoneYet() async throws {
+    @Test func derivesTheSizeAtTheFirstLayoutWhenItHasNoneYet() async {
         // A cell hasn't been laid out when the image arrives, and a SwiftUI
         // view has no size at all when it is made.
         display(Test.animatedGIF(frameCount: 2, size: CGSize(width: 400, height: 400)))
@@ -397,23 +397,23 @@ struct AnimatedImageViewTests {
 
     // MARK: Playback and Visibility
 
-    @Test func doesNotPlayOutsideAWindow() throws {
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+    @Test func doesNotPlayOutsideAWindow() {
+        view.animatedImage = Test.animatedGIFSource()
 
         #expect(view.isPlaying == false)
     }
 
-    @Test func playsOnceItIsInAWindow() throws {
+    @Test func playsOnceItIsInAWindow() {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
 
         #expect(view.isPlaying)
         host.close()
     }
 
-    @Test func pausesWhenItLeavesTheWindow() throws {
+    @Test func pausesWhenItLeavesTheWindow() {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
         #expect(view.isPlaying)
 
         view.removeFromSuperview()
@@ -424,7 +424,7 @@ struct AnimatedImageViewTests {
 
     @Test func releasesTheBufferWhenItLeavesTheWindow() async throws {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF(frameCount: 8)))
+        view.animatedImage = Test.animatedGIFSource(frameCount: 8)
         let player = try #require(view.player)
         await player.waitUntilFull()
         #expect(player.diagnostics.bufferedFrameCount == 8)
@@ -438,7 +438,7 @@ struct AnimatedImageViewTests {
 
     @Test func keepsTheBufferWhenPlaybackIsPausedInPlace() async throws {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF(frameCount: 8)))
+        view.animatedImage = Test.animatedGIFSource(frameCount: 8)
         let player = try #require(view.player)
         await player.waitUntilFull()
 
@@ -450,9 +450,9 @@ struct AnimatedImageViewTests {
         host.close()
     }
 
-    @Test func pausesWhileHidden() throws {
+    @Test func pausesWhileHidden() {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
         #expect(view.isPlaying)
 
         view.isHidden = true
@@ -464,9 +464,9 @@ struct AnimatedImageViewTests {
         host.close()
     }
 
-    @Test func pausesWhileFullyTransparent() throws {
+    @Test func pausesWhileFullyTransparent() {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
         #expect(view.isPlaying)
 
         setOpacity(0)
@@ -478,9 +478,9 @@ struct AnimatedImageViewTests {
         host.close()
     }
 
-    @Test func keepsPlayingWhileBarelyVisible() throws {
+    @Test func keepsPlayingWhileBarelyVisible() {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
 
         setOpacity(0.01)
 
@@ -489,11 +489,11 @@ struct AnimatedImageViewTests {
         host.close()
     }
 
-    @Test func doesNotPlayAnAnimationItIsGivenWhileHidden() throws {
+    @Test func doesNotPlayAnAnimationItIsGivenWhileHidden() {
         let host = TestWindow(view: view)
         view.isHidden = true
 
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
 
         #expect(view.isPlaying == false)
         host.close()
@@ -501,7 +501,7 @@ struct AnimatedImageViewTests {
 
     @Test func releasesTheBufferWhenItIsHidden() async throws {
         let host = TestWindow(view: view)
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF(frameCount: 8)))
+        view.animatedImage = Test.animatedGIFSource(frameCount: 8)
         let player = try #require(view.player)
         await player.waitUntilFull()
         #expect(player.diagnostics.bufferedFrameCount == 8)
@@ -512,29 +512,29 @@ struct AnimatedImageViewTests {
         host.close()
     }
 
-    @Test func playsOutsideAWindowWhenAsked() throws {
+    @Test func playsOutsideAWindowWhenAsked() {
         layOut(CGSize(width: 100, height: 100))
         view.isPlaybackPausedWhenOffscreen = false
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
 
         #expect(view.isPlaying)
     }
 
-    @Test func playsWhileHiddenWhenAsked() throws {
+    @Test func playsWhileHiddenWhenAsked() {
         let host = TestWindow(view: view)
         view.isPlaybackPausedWhenOffscreen = false
         view.isHidden = true
 
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
 
         #expect(view.isPlaying)
         host.close()
     }
 
-    @Test func playbackCanBeDisabled() throws {
+    @Test func playbackCanBeDisabled() {
         let host = TestWindow(view: view)
         view.isPlaybackEnabled = false
-        view.animatedImage = try #require(AnimatedImageSource(data: Test.animatedGIF()))
+        view.animatedImage = Test.animatedGIFSource()
         #expect(view.isPlaying == false)
 
         view.isPlaybackEnabled = true

--- a/Tests/NukeUITests/FetchImageTests.swift
+++ b/Tests/NukeUITests/FetchImageTests.swift
@@ -499,7 +499,8 @@ struct FetchImageTests {
         let started = TestExpectation()
 
         var localImage: FetchImage? = FetchImage()
-        weak var weakImage = localImage
+        weak var weakImage: FetchImage?
+        weakImage = localImage
 
         localImage?.load {
             started.fulfill()

--- a/Tests/NukeUITests/LazyImageTests.swift
+++ b/Tests/NukeUITests/LazyImageTests.swift
@@ -353,11 +353,11 @@ struct LazyImageTests {
         await started.wait()
 
         let imageTask = try #require(task.value)
-        #expect(imageTask.state == .running)
+        #expect(!imageTask.isCancelled)
 
-        await host.hideContent(until: { imageTask.state == .cancelled })
+        await host.hideContent(until: { imageTask.isCancelled })
 
-        #expect(imageTask.state == .cancelled)
+        #expect(imageTask.isCancelled)
     }
 
     @Test func requestCancelledWhenViewIsRemovedFromHierarchy() async throws {
@@ -377,10 +377,10 @@ struct LazyImageTests {
         await started.wait()
 
         let imageTask = try #require(task.value)
-        await host.removeContent(until: { imageTask.state == .cancelled })
+        await host.removeContent(until: { imageTask.isCancelled })
 
         // The view model is released with the view, and its deinit cancels the task.
-        #expect(imageTask.state == .cancelled)
+        #expect(imageTask.isCancelled)
     }
 
     @Test func requestPriorityLoweredOnDisappear() async throws {
@@ -405,7 +405,7 @@ struct LazyImageTests {
         await host.hideContent(until: { imageTask.priority == .veryLow })
 
         #expect(imageTask.priority == .veryLow)
-        #expect(imageTask.state == .running)
+        #expect(!imageTask.isCancelled)
     }
 
     @Test func requestNotCancelledWhenDisappearBehaviorIsNil() async throws {
@@ -428,7 +428,7 @@ struct LazyImageTests {
         await host.hideContent()
 
         #expect(imageTask.priority == .normal)
-        #expect(imageTask.state == .running)
+        #expect(!imageTask.isCancelled)
     }
 
     @Test func priorityRestoredWhenViewReappears() async throws {


### PR DESCRIPTION
The test targets compiled with 28 warnings, in four groups. None of them change what a test asserts.

**Redundant `#require`** (14). `try #require(AnimatedImageSource(data:))` assigned straight into an `AnimatedImageSource?` property — `AnimatedImageView.animatedImage`, `ImageContainer.animation` — unwraps into the contextual type, so the value it produces is still optional and the macro reports itself as redundant. Those call sites wanted a source that isn't optional, which is now what `Test.animatedGIFSource()` hands back.

**Deprecated `ImageTask.state` in the suite that pins it** (6). swift-testing rejects `@available(*, deprecated)` on a suite — "Attribute 'Suite' cannot be applied to this structure because it has been marked '@available(*, deprecated)'" — so the attribute goes on each test instead, which it accepts and still runs. With the reads no longer reported, they move back inside `#expect`; they had been hoisted into a local only to keep the macro from expanding the argument and reporting the deprecation twice.

**Deprecated `ImageTask.state` in `LazyImageTests`** (7). These tests reach for `state` to ask whether the task was cancelled, which `isCancelled` answers directly. `state == .running` becomes `!isCancelled`: the data loader is suspended for the whole test, so the task can't finish, and cancellation is the only thing being asserted.

**One `weak var` that is never mutated** (1), which now declares its type and takes its value on the next line, the shape the other deallocation tests use. `weak let` says it better, but Xcode 26.0 — the oldest supported, and the only job that builds with it — rejects it. Also drops the `throws` left on `AnimatedImageViewTests` tests that no longer call anything throwing.

### To test

1. `xcodebuild build-for-testing -project Nuke.xcodeproj -scheme Nuke -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — and the same for `NukeUI` and `NukeExtensions`, on macOS and iOS. No warning from `Tests/`; the SwiftLint violations under `Sources/` are unchanged.
2. `xcodebuild test -project Nuke.xcodeproj -scheme Nuke -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — 1054 tests pass, including the six deprecated ones, which still run.
3. `xcodebuild test -project Nuke.xcodeproj -scheme NukeUI -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — 366 tests pass.

