### PR TITLE
Drop @unchecked Sendable from ImageTask and the video decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Add `ImageRequest/UserInfoKey/labelKey`: a short name for the role of a request in the app, such as `"feed"`, that the pipeline records in `ImageTask/Metrics/label` – https://github.com/kean/Nuke/pull/960
 - Add `ImageDiagnosticsStringEnum`: the `Codable` conformance the diagnostics enums share, which decodes a name it doesn't know as `unknown` – https://github.com/kean/Nuke/pull/960
 - The default `ImagePipeline/Configuration-swift.struct/rateLimiter` rate goes from 80 to 100 requests per second – https://github.com/kean/Nuke/pull/960
+- `ImageTask` and `ImageDecoders/Video` are now `Sendable` instead of `@unchecked Sendable` – https://github.com/kean/Nuke/pull/965
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -35,7 +35,7 @@ import AppKit
 /// The pipeline maintains a strong reference to the task until the request
 /// finishes or fails; you do not need to maintain a reference to the task unless
 /// it is useful for your app.
-public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @unchecked Sendable {
+public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, Sendable {
     /// An identifier that uniquely identifies the task within a given pipeline.
     public let taskId: UInt64
 
@@ -241,10 +241,13 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     /// The time the task was created, in seconds since 1970 on the clock of
     /// the recorder. `nil` unless diagnostics are on.
     let _createdAt: TimeInterval?
-    private let onEvent: ((Event, ImageTask) -> Void)?
-    private weak var pipeline: ImagePipeline?
+    private let onEvent: (@Sendable (Event, ImageTask) -> Void)?
+    @ImagePipelineActor private weak var pipeline: ImagePipeline?
 
-    // Set once during creation, then read-only from `response` getter.
+    /// Set once during creation, before the task is handed to anyone, then
+    /// read-only from the `response` getter, so it needs no synchronization.
+    /// `nonisolated(unsafe)` keeps that unchecked to this one property instead
+    /// of `@unchecked Sendable` waiving the check for the whole class.
     nonisolated(unsafe) var _task: Task<Result<ImageResponse, ImagePipeline.Error>, Never>!
     @ImagePipelineActor var _continuation: UnsafeContinuation<Result<ImageResponse, ImagePipeline.Error>, Never>?
     @ImagePipelineActor var _isFinished = false
@@ -253,7 +256,7 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, @
     @ImagePipelineActor var _diagnostics: ImagePipeline.Diagnostics.TaskRecord?
     @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
 
-    init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, isPrefetch: Bool = false, pipeline: ImagePipeline, onEvent: ((Event, ImageTask) -> Void)?, createdAt: TimeInterval? = nil) {
+    init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, isPrefetch: Bool = false, pipeline: ImagePipeline, onEvent: (@Sendable (Event, ImageTask) -> Void)?, createdAt: TimeInterval? = nil) {
         self.taskId = taskId
         self.request = request
         self._status = OSAllocatedUnfairLock(initialState: Status(priority: request.priority))

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -176,7 +176,7 @@ public final class ImagePipeline: Sendable {
 
     // MARK: - ImageTask (Internal)
 
-    nonisolated func makeStartedImageTask(with request: ImageRequest, isDataTask: Bool = false, isPrefetch: Bool = false, onEvent: ((ImageTask.Event, ImageTask) -> Void)? = nil) -> ImageTask {
+    nonisolated func makeStartedImageTask(with request: ImageRequest, isDataTask: Bool = false, isPrefetch: Bool = false, onEvent: (@Sendable (ImageTask.Event, ImageTask) -> Void)? = nil) -> ImageTask {
         // The creation time is the one thing the diagnostics read off the actor.
         let task = ImageTask(taskId: nextTaskId, request: request, isDataTask: isDataTask, isPrefetch: isPrefetch, pipeline: self, onEvent: onEvent, createdAt: recorder?.now)
         // Important to call it before `imageTaskStartCalled`

--- a/Sources/NukeVideo/AVDataAsset.swift
+++ b/Sources/NukeVideo/AVDataAsset.swift
@@ -28,7 +28,9 @@ private extension AssetType {
     }
 }
 
-// This class keeps strong pointer to DataAssetResourceLoader
+// This class keeps strong pointer to DataAssetResourceLoader.
+// Unchecked only because `AVURLAsset` is: a subclass has to restate what it
+// inherits. The delegate it adds is checked.
 final class AVDataAsset: AVURLAsset, @unchecked Sendable {
     private let resourceLoaderDelegate: DataAssetResourceLoader
 
@@ -47,7 +49,7 @@ final class AVDataAsset: AVURLAsset, @unchecked Sendable {
 }
 
 // This allows LazyImage to play video from memory.
-private final class DataAssetResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
+private final class DataAssetResourceLoader: NSObject, AVAssetResourceLoaderDelegate, Sendable {
     private let data: Data
     private let contentType: String
 

--- a/Sources/NukeVideo/ImageDecoders+Video.swift
+++ b/Sources/NukeVideo/ImageDecoders+Video.swift
@@ -5,6 +5,7 @@
 #if !os(watchOS) && !os(visionOS)
 
 import Foundation
+import os
 import AVKit
 import AVFoundation
 import Nuke
@@ -17,14 +18,12 @@ extension ImageDecoders {
     /// ```swift
     /// ImageDecoderRegistry.shared.register(ImageDecoders.Video.init)
     /// ```
-    public final class Video: ImageDecoding, @unchecked Sendable {
-        private var didProducePreview = false
+    public final class Video: ImageDecoding, Sendable {
+        private let didProducePreview = OSAllocatedUnfairLock(initialState: false)
         private let type: AssetType
 
         /// Always `true` — decoding is performed asynchronously to avoid blocking the pipeline.
         public var isAsynchronous: Bool { true }
-
-        private let lock = NSLock()
 
         /// Returns `nil` if the data is not a recognized video format (MP4, M4V, or MOV).
         public init?(context: ImageDecodingContext) {
@@ -44,17 +43,21 @@ extension ImageDecoders {
         /// Returns a single thumbnail preview for the first frame of partially downloaded
         /// video data, or `nil` if the data is not yet decodable or a preview was already produced.
         public func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer? {
-            lock.lock()
-            defer { lock.unlock() }
-
             guard let type = AssetType(data), type.isVideo else { return nil }
-            guard !didProducePreview else {
+            guard !didProducePreview.withLock({ $0 }) else {
                 return nil // We only need one preview
             }
             guard let preview = makePreview(for: data, type: type) else {
+                return nil // Not enough data to decode a frame yet; try again later
+            }
+            // Claim the slot only now: the flag marks a preview that was made,
+            // and the claim is what keeps two racing calls from both returning one.
+            guard didProducePreview.withLock({ isProduced in
+                defer { isProduced = true }
+                return !isProduced
+            }) else {
                 return nil
             }
-            didProducePreview = true
             return ImageContainer(image: preview, type: type, isPreview: true, data: data, userInfo: [
                 .videoAssetKey: AVDataAsset(data: data, type: type)
             ])


### PR DESCRIPTION
A sweep over the remaining `@unchecked Sendable` conformances in the library targets, keeping only the ones the language and the SDK actually force.

### `ImageTask`

`@unchecked Sendable` waived the check for every stored property, over two that needed it:

- `_task` is written once by `makeStartedImageTask` before the task is handed to anyone, then read from the `response` getter, so it needs no synchronization. It keeps its `nonisolated(unsafe)`, which satisfies the class-level check while scoping the unchecked part to that one property.
- `pipeline` is now declared on `ImagePipelineActor`, where all four use sites already touched it.

Everything else on the class is checked now. The `onEvent` closure had to become `@Sendable`; it is an internal parameter of `makeStartedImageTask`, so nothing public changes.

### `ImageDecoders.Video`

An `NSLock` guarded a single `Bool`. The lock now holds the `Bool`. The flag is still claimed only after a preview is actually produced, so data that isn't decodable yet doesn't burn the one preview the decoder gets.

### `AVDataAsset`

Keeps its `@unchecked`: `AVURLAsset` is unchecked and a subclass has to restate what it inherits. The delegate it adds is checked now.

### What stays unchecked, and why

- `Cache`, `ImageDecoders/Default`, `_DataLoader` — mutable state behind a bare lock or a serial queue. `Default` holds a `CGImageSource`, which can't go in an `OSAllocatedUnfairLock<State>`.
- `ImageContainer.Container`, `ImageRequest.Container` — copy-on-write boxes.
- `DataLoader` — the public mutable `delegate` of a non-`Sendable` type.
- `ImageProcessors/CoreImageFilter` — `Filter.custom(CIFilter)`, which the client owns and can mutate.

### Testing

`NukeTests` (1093), `NukeThreadSafetyTests` (8), and `NukeVideoTests` all pass.

Nothing here changes codegen: the `ImageTask` diff is annotations only, and the video decoder swaps one lock for another on a path that runs at most once per task. An earlier revision of this PR put `_task` in its own `OSAllocatedUnfairLock` — strictly more work than what landed — and even that measured flat against `main` over two alternating pairs of `ImagePipelinePerformanceTests` (`asyncImageTaskPerformance` 66.80/64.81 → 65.33/65.19 ms, `memoryHitPerformance` 12.49/12.40 → 12.63/12.35 ms).