### PR TITLE
Shrink the error enum and cache the task-pool key hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 **Performance**
 
-- `ImagePipeline/Error` is now 8 bytes instead of 97, and a memory cache hit is up to 21% faster – https://github.com/kean/Nuke/pull/967
+- `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 - The default `ImagePipeline/Configuration-swift.struct/rateLimiter` rate goes from 80 to 100 requests per second – https://github.com/kean/Nuke/pull/960
 - `ImageTask` and `ImageDecoders/Video` are now `Sendable` instead of `@unchecked Sendable` – https://github.com/kean/Nuke/pull/965
 
+**Performance**
+
+- `ImagePipeline/Error` is now 8 bytes instead of 97, and a memory cache hit is up to 21% faster – https://github.com/kean/Nuke/pull/967
+
 **Bug Fixes**
 
 - Remove an unused `AVKit` import from `Nuke`, which linked AVKit, AVFoundation, and their dependencies into every app – https://github.com/kean/Nuke/pull/947

--- a/Sources/Nuke/Diagnostics/DiagnosticsSummaries.swift
+++ b/Sources/Nuke/Diagnostics/DiagnosticsSummaries.swift
@@ -181,7 +181,19 @@ func diagnosticsDigest(of key: String) -> String {
         hash ^= UInt64(byte)
         hash &*= 0x0000_0100_0000_01b3
     }
-    return String(format: "%08x", UInt32(truncatingIfNeeded: hash &>> 32 ^ hash))
+    return diagnosticsHexString(of: UInt32(truncatingIfNeeded: hash &>> 32 ^ hash))
+}
+
+/// The value as eight lowercase hex digits, the same as `String(format: "%08x")`,
+/// written by hand: the format engine costs ten times as much as the hash.
+func diagnosticsHexString(of value: UInt32) -> String {
+    String(unsafeUninitializedCapacity: 8) { buffer in
+        for index in 0..<8 {
+            let nibble = UInt8(truncatingIfNeeded: value &>> (28 - 4 * index)) & 0xf
+            buffer[index] = nibble < 10 ? UInt8(ascii: "0") + nibble : UInt8(ascii: "a") + nibble - 10
+        }
+        return 8
+    }
 }
 
 /// The name of the type of the value without its module, such as

--- a/Sources/Nuke/Internal/ImageRequestKeys.swift
+++ b/Sources/Nuke/Internal/ImageRequestKeys.swift
@@ -57,26 +57,36 @@ final class TaskLoadImageKey: Hashable, Sendable {
     private let loadKey: TaskFetchOriginalImageKey
     private let options: ImageRequest.Options
     private let processors: [any ImageProcessing]
+    // Computed once: the pool hashes a key on lookup, on insert, and again when
+    // the task is disposed, and hashing the fields walks the image ID.
+    private let _hashValue: Int
 
     init(_ request: ImageRequest) {
         self.loadKey = TaskFetchOriginalImageKey(request)
         self.options = request.options
         self.processors = request.processors
-    }
 
-    func hash(into hasher: inout Hasher) {
+        var hasher = Hasher()
         hasher.combine(loadKey)
         hasher.combine(options)
         hasher.combine(processors.count)
+        self._hashValue = hasher.finalize()
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(_hashValue)
     }
 
     static func == (lhs: TaskLoadImageKey, rhs: TaskLoadImageKey) -> Bool {
-        lhs.loadKey == rhs.loadKey && lhs.options == rhs.options && lhs.processors == rhs.processors
+        lhs === rhs || (lhs._hashValue == rhs._hashValue && lhs.loadKey == rhs.loadKey && lhs.options == rhs.options && lhs.processors == rhs.processors)
     }
 }
 
 /// Uniquely identifies a task of retrieving the original image.
 struct TaskFetchOriginalImageKey: Hashable {
+    // Declared first, so the synthesized `==` rejects on it before it compares
+    // the image IDs.
+    private let _hashValue: Int
     private let dataLoadKey: TaskFetchOriginalDataKey
     private let scale: CGFloat
     private let thumbnail: ImageRequest.ThumbnailOptions?
@@ -85,11 +95,24 @@ struct TaskFetchOriginalImageKey: Hashable {
         self.dataLoadKey = TaskFetchOriginalDataKey(request)
         self.scale = request.scale
         self.thumbnail = request.thumbnail
+
+        var hasher = Hasher()
+        hasher.combine(dataLoadKey)
+        hasher.combine(scale)
+        hasher.combine(thumbnail)
+        self._hashValue = hasher.finalize()
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(_hashValue)
     }
 }
 
 /// Uniquely identifies a task of retrieving the original image data.
 struct TaskFetchOriginalDataKey: Hashable {
+    // Declared first, so the synthesized `==` rejects on it before it compares
+    // the image IDs.
+    private let _hashValue: Int
     private let imageId: String?
     private let cachePolicy: URLRequest.CachePolicy
     private let allowsCellularAccess: Bool
@@ -104,5 +127,15 @@ struct TaskFetchOriginalDataKey: Hashable {
             self.cachePolicy = urlRequest.cachePolicy
             self.allowsCellularAccess = urlRequest.allowsCellularAccess
         }
+
+        var hasher = Hasher()
+        hasher.combine(imageId)
+        hasher.combine(cachePolicy)
+        hasher.combine(allowsCellularAccess)
+        self._hashValue = hasher.finalize()
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(_hashValue)
     }
 }

--- a/Sources/Nuke/Pipeline/ImagePipeline+Error.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Error.swift
@@ -7,6 +7,10 @@ import Foundation
 extension ImagePipeline {
     /// Represents all possible image pipeline errors.
     public enum Error: Swift.Error, CustomStringConvertible, Sendable {
+        // The cases that carry a decoding or processing context are `indirect`:
+        // stored inline, the context would make every error – and every `Result`
+        // and task event that holds one – about a hundred bytes.
+
         /// Returned if data is not cached and ``ImageRequest/Options-swift.struct/returnCacheDataDontLoad`` option is specified.
         case dataMissingInCache
         /// Data loader failed to load image data with a wrapped error.
@@ -17,11 +21,11 @@ extension ImagePipeline {
         ///
         /// This error can only be thrown if the pipeline has custom decoders.
         /// By default, the pipeline uses ``ImageDecoders/Default`` as a catch-all.
-        case decoderNotRegistered(context: ImageDecodingContext)
+        indirect case decoderNotRegistered(context: ImageDecodingContext)
         /// Decoder failed to produce a final image.
-        case decodingFailed(decoder: any ImageDecoding, context: ImageDecodingContext, error: Swift.Error)
+        indirect case decodingFailed(decoder: any ImageDecoding, context: ImageDecodingContext, error: Swift.Error)
         /// Processor failed to produce a final image.
-        case processingFailed(processor: any ImageProcessing, context: ImageProcessingContext, error: Swift.Error)
+        indirect case processingFailed(processor: any ImageProcessing, context: ImageProcessingContext, error: Swift.Error)
         /// Load image method was called with no image request or no URL.
         case imageRequestMissing
         /// Image pipeline is invalidated and no requests can be made.

--- a/Sources/Nuke/Pipeline/TaskQueue.swift
+++ b/Sources/Nuke/Pipeline/TaskQueue.swift
@@ -97,7 +97,11 @@ public final class TaskQueue: Sendable {
 
     private func drain() {
         guard !isSuspended else { return }
-        while runningCount < maxConcurrentTaskCount && pendingCount > 0 {
+        // The limit is settable from any thread, so every read takes a lock.
+        // Read it once: a limit raised mid-drain schedules a drain of its own,
+        // and one lowered mid-drain is no different from one lowered right after.
+        let limit = maxConcurrentTaskCount
+        while runningCount < limit && pendingCount > 0 {
             guard let operation = dequeueHighestPriority() else { break }
             execute(operation)
         }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDiagnosticsTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDiagnosticsTests.swift
@@ -674,6 +674,36 @@ struct ImagePipelineDiagnosticsTests {
         }
     }
 
+    // MARK: - Cache Key Digests
+
+    @Test func digestIsTheSameInEveryProcess() {
+        // Records from different runs are compared on these
+        #expect(diagnosticsDigest(of: "") == "4fd0bfc1")
+        #expect(diagnosticsDigest(of: "custom-key") == "30c58e0d")
+        #expect(diagnosticsDigest(of: "http://test.com/example.jpeg") == "0dc5ca88")
+    }
+
+    @Test func hexStringMatchesStringFormat() {
+        let values: [UInt32] = [
+            // Edges
+            0, 0x7fff_ffff, 0x8000_0000, UInt32.max,
+            // Leading zeros
+            0x1, 0xf, 0x10, 0xabc, 0x00c0_ffee, 0x0dc5_ca88,
+            // Random
+            0x4f2a_91c3, 0x9b0e_6d27, 0x3a7f_c014, 0xe52d_08b9, 0x61d8_f35a
+        ]
+        for value in values {
+            #expect(diagnosticsHexString(of: value) == String(format: "%08x", value))
+        }
+        // Every digit in every position
+        for position in 0..<8 {
+            for digit in 0..<UInt32(16) {
+                let value = digit << (4 * position)
+                #expect(diagnosticsHexString(of: value) == String(format: "%08x", value))
+            }
+        }
+    }
+
     // MARK: - Description
 
     @Test func descriptionPrintsTheHeader() async throws {


### PR DESCRIPTION
Four small fixes on the path every image task takes. None of them changes behaviour or public API.

### `ImagePipeline.Error` is 8 bytes instead of 97

`decoderNotRegistered`, `decodingFailed`, and `processingFailed` carry an `ImageDecodingContext` or `ImageProcessingContext` inline, and the largest payload sets the size of the enum. Every `Result`, `ImageTask.Event`, and `ImageTask.Status` the pipeline creates, copies, and sends to subscribers inherited that size – the successful ones too. The three cases are now `indirect`.

| Type | `main` (size / stride) | This PR |
|---|---|---|
| `ImagePipeline.Error` | 97 / 104 B | 8 / 8 B |
| `Result<ImageResponse, ImagePipeline.Error>` | 98 / 104 B | 26 / 32 B |
| `ImageTask.Event` | 99 / 104 B | 26 / 32 B |
| `ImageTask.Status` | 128 / 128 B | 56 / 56 B |

The box is allocated only when one of those three errors is created, after a decode or a processor has already failed. `.cancelled` – the error that actually occurs at volume, once for every image view that scrolls offscreen – is a bare tag and never boxes; neither does `dataLoadingFailed`, whose payload is a single existential.

### The task pool keys hash once

`TaskPool` hashes a key on lookup, again on insert, and a third time when the task is disposed, and each of those walked the image ID string. `TaskLoadImageKey`, `TaskFetchOriginalImageKey`, and `TaskFetchOriginalDataKey` now compute the hash in `init`, the way `MemoryCacheKey` already does. In the two structs the stored hash is declared first, so the synthesized `==` rejects on one integer before it compares strings; the class gets the same `===` and hash short-circuit as `MemoryCacheKey`. A memory cache hit goes through the pool too, so this is on every path.

### `TaskQueue` reads its limit once per drain

`maxConcurrentTaskCount` sits behind an `OSAllocatedUnfairLock` because it's settable from any thread, and the loop condition took that lock on every turn. It's now read once per drain. A limit raised mid-drain already schedules a drain of its own; one lowered mid-drain behaves as if it had landed right after. Not measured on its own – it's at most one lock per drain.

### The diagnostics digest skips `String(format:)`

With diagnostics on, every memory and disk cache lookup records a digest of its key, and `String(format: "%08x")` spent 602 ns and 8 allocations printing eight characters – ten times what hashing the key costs. The digits are now written straight into the string's storage, which for eight bytes is inline: 7 ns, no allocations. A new test checks the output against `String(format:)` on the edges, leading zeros, random values, and every digit in every position, and pins three digests so records from different runs stay comparable.

### Measurements

18-core M-series Mac, macOS 26.6, Xcode 26.5. `main` and this branch alternate run by run, and the side that runs first alternates by round; 3 rounds, median of the per-run averages, and the Δ of each round.

**Release rig** – 5000 requests per sample, 5 samples per run, mock data loader, `ImageDecoders.Empty`

| Benchmark | `main` | This PR | Δ | Rounds |
|---|---|---|---|---|
| `asyncAwait` | 68.1 ms | 68.7 ms | +0.8% | −21.0, −13.6, +7.5 |
| `memoryHit` | 23.6 ms | 20.6 ms | **−12.5%** | −18.0, −9.5, −20.9 |
| `memoryHit`, diagnostics on | 100.8 ms | 79.6 ms | **−21.0%** | −21.0, −13.0, −21.7 |
| `asyncImageTask` | 69.1 ms | 62.4 ms | −9.7% | +4.2, −13.6, −9.7 |

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel

| Test | `main` | This PR | Δ | Rounds |
|---|---|---|---|---|
| `asyncAwaitPerformance` | 111.2 ms | 85.1 ms | −23.5% | −24.2, +19.4, −24.9 |
| `asyncAwaitPerformanceWithDiagnostics` | 139.2 ms | 120.5 ms | −13.4% | −13.4, +19.0, −26.5 |
| `memoryHitPerformance` | 20.3 ms | 17.4 ms | −14.5% | −5.8, +3.6, −21.3 |
| `memoryHitPerformanceWithDiagnostics` | 43.0 ms | 29.7 ms | **−30.8%** | −23.3, −16.9, −38.5 |
| `asyncImageTaskPerformance` | 110.0 ms | 93.3 ms | **−15.2%** | −9.6, −4.4, −23.6 |

`memoryHit` with diagnostics on is faster in every round in both tools, and plain `memoryHit` in every round of the release rig; `asyncAwait` doesn't resolve in either.

Neither `memoryHit` benchmark measures pure memory cache hits. Both store a 640×480 image under 5000 keys, 1.2 MB each, which overflows the 768 MB default cost limit: only about 655 entries survive the setup, and the other requests go through the load path, which this PR also changes. Those rows measure that mix, so this PR makes no claim about cache hits on their own.

**Digest formatting** – release, 1M calls, median of 9; allocations counted with `malloc_logger`

| | ns / call | Allocations / call |
|---|---|---|
| `String(format: "%08x")` (`main`) | 602 | 8 |
| `[UInt8]`, then `String(decoding:as:)` | 64 | 1 |
| Written into the string (this PR) | 7 | 0 |
| Whole digest of a 45-byte key, `main` → this PR | 664 → 64 | 8 → 0 |

The new formatter matched `String(format:)` on 1M random values.

### Trade-offs and risks

- Creating `decoderNotRegistered`, `decodingFailed`, or `processingFailed` now allocates a box. All three end a task that has already paid for a decode or a processor.
- `ImagePipeline.Error` isn't `@frozen`, so for the framework targets built with library evolution the layout change is binary-compatible. Source is unaffected: the cases are constructed and matched the same way.
- Each task pool key stores 8 more bytes.
- If the limit is lowered from another thread while a drain is running, that drain can still start tasks up to the old limit – the same outcome as the setter landing a moment later. Running tasks were never preempted by a lower limit either way.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO` – 1091 passed, 3 skipped, 1 known pre-existing failure; 1095 in all, which is `main`'s suite plus the two new tests in `ImagePipelineDiagnosticsTests`. The failure is a ThreadSanitizer abort inside the test mock, not the pipeline: `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress` calls `MockProgressiveDataLoader.serveNextChunk()` from the test body while the mock's main-queue block is still serving the first chunk. It reproduces on `main` within two iterations of `ImageTaskTests`. The abort kills the test process; xcodebuild relaunches it and the remaining tests run, so the counts cover the whole suite.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 tests pass.
3. `NukePerformanceTests` builds with the same warnings as `main`; `swiftlint` reports nothing new in the changed files.
