### PR TITLE
Call ImagePrefetcher.didComplete when the last request is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Fix `DataCache/sweep()` not recording the sweep date, so the next scheduled sweep ran again within `DataCache/sweepInterval` – https://github.com/kean/Nuke/pull/932
 - Fix `DataCache` writing entries non-atomically, so a read that arrived while the same key was being overwritten could return a truncated file – https://github.com/kean/Nuke/pull/937
 - Fix `VideoPlayerView` not resuming a looping video on macOS when the view is added back to a window – https://github.com/kean/Nuke/pull/951
+- Fix `ImagePrefetcher/didComplete` not being called when stopping prefetching cancels the last outstanding request – https://github.com/kean/Nuke/pull/968
 
 **Documentation**
 

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -62,7 +62,8 @@ public final class ImagePrefetcher: Sendable {
     /// The closure runs every time the prefetcher runs out of outstanding work,
     /// which includes the batches that finish without starting a single task:
     /// an empty list of requests, or one where every image is already in the
-    /// memory cache.
+    /// memory cache. Stopping the last outstanding requests runs it too, but a
+    /// stop that finds nothing to cancel doesn't.
     nonisolated public var didComplete: (@MainActor @Sendable () -> Void)? {
         get { _didComplete.withLock { $0 } }
         set { _didComplete.withLock { $0 = newValue } }
@@ -187,10 +188,20 @@ public final class ImagePrefetcher: Sendable {
     /// See also ``stopPrefetching(with:)-2tcyq`` that works with `URL`.
     nonisolated public func stopPrefetching(with requests: [ImageRequest]) {
         Task { @ImagePipelineActor in
-            for request in requests {
-                self._stopPrefetching(with: request)
-            }
+            self._stopPrefetching(with: requests)
         }
+    }
+
+    private func _stopPrefetching(with requests: [ImageRequest]) {
+        // A stop that finds nothing outstanding doesn't run the prefetcher out
+        // of work, so there is no completion to report.
+        guard !tasks.isEmpty else {
+            return
+        }
+        for request in requests {
+            _stopPrefetching(with: request)
+        }
+        sendCompletionIfNeeded()
     }
 
     private func _stopPrefetching(with request: ImageRequest) {
@@ -202,8 +213,12 @@ public final class ImagePrefetcher: Sendable {
     /// Stops all prefetching tasks.
     nonisolated public func stopPrefetching() {
         Task { @ImagePipelineActor in
+            guard !self.tasks.isEmpty else {
+                return
+            }
             self.tasks.values.forEach { $0.cancel() }
             self.tasks.removeAll()
+            self.sendCompletionIfNeeded()
         }
     }
 

--- a/Tests/NukeTests/ImagePrefetcherTests.swift
+++ b/Tests/NukeTests/ImagePrefetcherTests.swift
@@ -463,8 +463,131 @@ struct ImagePrefetcherTests {
         #expect(count.withLock { $0 } == 1)
     }
 
+    @Test @ImagePipelineActor func didCompleteIsCalledOnceWhenEveryRequestLoads() async {
+        // GIVEN more requests than the prefetcher loads at a time
+        let count = OSAllocatedUnfairLock(initialState: 0)
+        let completed = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            completed.fulfill()
+        }
+
+        // WHEN every one of them loads
+        prefetcher.startPrefetching(with: Self.batch)
+        await completed.wait()
+
+        // THEN the closure is called once for the batch, not once per request
+        await prefetcher.queue.waitUntilIdle()
+        await waitForDelivery()
+        #expect(count.withLock { $0 } == 1)
+        #expect(observer.startedTaskCount == Self.batch.count)
+    }
+
+    @Test @ImagePipelineActor func didCompleteIsCalledWhenEveryRequestIsStopped() async {
+        // GIVEN requests that can't finish on their own: two are loading, and
+        // the rest wait in the prefetcher's queue
+        dataLoader.isSuspended = true
+        let count = OSAllocatedUnfairLock(initialState: 0)
+        let completed = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            completed.fulfill()
+        }
+        _ = await prefetcher.queue.waitForOperations(count: Self.batch.count) {
+            prefetcher.startPrefetching(with: Self.batch)
+        }
+
+        // WHEN every one of them is stopped
+        prefetcher.stopPrefetching(with: Self.batch)
+
+        // THEN the prefetcher reports that it ran out of work, and doesn't
+        // report it again when the loads it cancelled unwind
+        await completed.wait()
+        await prefetcher.queue.waitUntilIdle()
+        await waitForDelivery()
+        #expect(count.withLock { $0 } == 1)
+    }
+
+    @Test @ImagePipelineActor func didCompleteIsCalledWhenAllPrefetchingIsStopped() async {
+        // GIVEN requests that can't finish on their own: two are loading, and
+        // the rest wait in the prefetcher's queue
+        dataLoader.isSuspended = true
+        let count = OSAllocatedUnfairLock(initialState: 0)
+        let completed = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            completed.fulfill()
+        }
+        _ = await prefetcher.queue.waitForOperations(count: Self.batch.count) {
+            prefetcher.startPrefetching(with: Self.batch)
+        }
+
+        // WHEN all prefetching is stopped
+        prefetcher.stopPrefetching()
+
+        // THEN the prefetcher reports that it ran out of work, and doesn't
+        // report it again when the loads it cancelled unwind
+        await completed.wait()
+        await prefetcher.queue.waitUntilIdle()
+        await waitForDelivery()
+        #expect(count.withLock { $0 } == 1)
+    }
+
+    @Test @ImagePipelineActor func didCompleteIsNotCalledUntilTheLastRequestIsStopped() async {
+        // GIVEN requests that can't finish on their own
+        dataLoader.isSuspended = true
+        let count = OSAllocatedUnfairLock(initialState: 0)
+        let completed = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            completed.fulfill()
+        }
+        _ = await prefetcher.queue.waitForOperations(count: Self.batch.count) {
+            prefetcher.startPrefetching(with: Self.batch)
+        }
+
+        // WHEN all but one of them are stopped
+        prefetcher.stopPrefetching(with: Array(Self.batch.dropLast()))
+        await waitForDelivery()
+
+        // THEN the closure isn't called while there is work outstanding
+        #expect(count.withLock { $0 } == 0)
+
+        // WHEN the last one is stopped too
+        prefetcher.stopPrefetching(with: Array(Self.batch.suffix(1)))
+
+        // THEN it is
+        await completed.wait()
+        #expect(count.withLock { $0 } == 1)
+    }
+
+    @Test @ImagePipelineActor func didCompleteIsNotCalledWhenThereIsNothingToStop() async {
+        // GIVEN a batch that already completed
+        let count = OSAllocatedUnfairLock(initialState: 0)
+        let completed = TestExpectation()
+        prefetcher.didComplete = { @MainActor @Sendable in
+            count.withLock { $0 += 1 }
+            completed.fulfill()
+        }
+        prefetcher.startPrefetching(with: [Test.url])
+        await completed.wait()
+        await prefetcher.queue.waitUntilIdle()
+
+        // WHEN prefetching is stopped with nothing left to cancel, as a list
+        // does when it scrolls past rows that were already prefetched
+        prefetcher.stopPrefetching(with: [Test.url])
+        prefetcher.stopPrefetching()
+        await waitForDelivery()
+
+        // THEN the closure isn't called again: a stop that cancels nothing
+        // doesn't run the prefetcher out of work, it had none left
+        #expect(count.withLock { $0 } == 1)
+    }
+
     private static let otherURL = URL(string: "http://test.com/example-2.jpeg")!
     private static let thirdURL = URL(string: "http://test.com/example-3.jpeg")!
+    /// Twice as many as the prefetcher loads at a time.
+    private static let batch = (0..<4).map { URL(string: "http://test.com/batch-\($0).jpeg")! }
 
     // MARK: Empty Inputs
 
@@ -513,5 +636,31 @@ struct ImagePrefetcherTests {
                 localPrefetcher = nil
             }
         }
+    }
+}
+
+/// Waits until the calls made so far reach the prefetcher, then for the main
+/// queue to run the `didComplete` they scheduled, if any.
+private func waitForDelivery() async {
+    await Task { @ImagePipelineActor in }.value
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        DispatchQueue.main.async { continuation.resume() }
+    }
+}
+
+private extension TaskQueue {
+    /// Waits until no operation is pending or running. An operation runs until
+    /// its work returns, and the prefetcher's work ends by removing its task –
+    /// the point where it reports completion.
+    func waitUntilIdle() async {
+        guard operationCount > 0 else { return }
+        let idle = TestExpectation()
+        let previous = onEvent
+        onEvent = { event in
+            previous?(event)
+            if self.operationCount == 0 { idle.fulfill() }
+        }
+        await idle.wait()
+        onEvent = previous
     }
 }


### PR DESCRIPTION
`ImagePrefetcher/didComplete` is documented to run every time the prefetcher runs out of outstanding work, but it only ran when the last request finished loading. `stopPrefetching(with:)` and `stopPrefetching()` removed their tasks without checking whether any were left, so a prefetcher emptied by cancellation went quiet. Anything waiting on the closure after the scroll-away pattern – start, stop, wait – waited forever. It came up while profiling: the first prefetch benchmark stalled at 0% CPU on exactly this.

Both stop paths now end with the same `sendCompletionIfNeeded()` that a finished batch and a finished load already call. The closure is still read from its lock on the pipeline actor and delivered with `DispatchQueue.main.async`, so the threading from #929 doesn't change. The loads a stop cancels don't report a second time when they unwind: `_remove` already ignores a task that is no longer in `tasks`.

A stop that finds nothing outstanding returns early and reports nothing. The prefetcher didn't run out of work – it had none – and a collection view cancels prefetching for rows that already finished all the time, so reporting it would turn a no-op into a main-queue callback. The doc comment on `didComplete` now says both.

`stopPrefetching` is on the scroll-away path, and the check costs it nothing measurable: in the release benchmark, 5,000 starts followed by a stop by URL take 5.13 ms before and 5.14 ms after (median of 5 interleaved rounds, `didComplete` unset; 18-core M-series Mac, macOS 26.6, Xcode 26.5).

Two things change for apps that set `didComplete`. An app that reads it as "every image loaded" now also hears from it after a stop cancels the rest – which is what the documentation already promised. And each of those deliveries is a `DispatchQueue.main.async` call: in a burst of 5,000 start-one, stop-one pairs, where every stop empties the prefetcher, that comes to about 28 µs per stop with an otherwise idle main thread. A single stop call empties the prefetcher at most once, however many requests it cancels.

### Testing

1. `NukeTests` – 1094 tests pass and 3 are skipped, including 5 new `ImagePrefetcherTests`. Stopping every request by URL, stopping all prefetching, and stopping the last of a partially stopped batch each call the closure once; all three time out on `main`. A batch that loads calls it once rather than once per request, and a stop with nothing outstanding doesn't call it at all. The one failure is known and fails on `main` too: `ImageTaskTests/subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress()` aborts under the thread sanitizer on a race inside the test mock `MockProgressiveDataLoader`, and xcodebuild relaunches to run the rest of the suite.
2. `NukeThreadSafetyTests` with the thread sanitizer – 8 tests pass.
