### PR TITLE
Compare the LazyImage request by identity first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 **Performance**
 
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
+- `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
 
 **Bug Fixes**
 

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -996,6 +996,7 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nukeui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Debug;
 		};
@@ -1013,6 +1014,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nukeui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Release;
 		};
@@ -1452,6 +1454,7 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nuke;
 				PRODUCT_NAME = Nuke;
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Debug;
 		};
@@ -1469,6 +1472,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nuke;
 				PRODUCT_NAME = Nuke;
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Release;
 		};

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -493,6 +493,12 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     /// where the actual URL determines what gets fetched.
     var originalImageID: String? { ref.originalImageID }
 
+    /// Returns `true` if both requests share the same storage, which makes them
+    /// equal. `false` doesn't mean they are different.
+    package func isIdentical(to other: ImageRequest) -> Bool {
+        ref === other.ref
+    }
+
     static var _containerInstanceSize: Int { class_getInstanceSize(Container.self) }
 }
 

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -206,10 +206,14 @@ private struct LazyImageContext: Equatable {
     static func == (lhs: LazyImageContext, rhs: LazyImageContext) -> Bool {
         let lhs = lhs.request
         let rhs = rhs.request
+        // A view that keeps its request passes a copy of the same one on every
+        // update, and that is equal without comparing the processors.
+        if lhs.isIdentical(to: rhs) {
+            return true
+        }
         return lhs.imageID == rhs.imageID &&
         lhs.priority == rhs.priority &&
         lhs.processors == rhs.processors &&
-        lhs.priority == rhs.priority &&
         lhs.options == rhs.options
     }
 }

--- a/Tests/NukePerformanceTests/LazyImagePerformanceTests.swift
+++ b/Tests/NukePerformanceTests/LazyImagePerformanceTests.swift
@@ -1,0 +1,51 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import Foundation
+import Nuke
+import NukeUI
+
+/// SwiftUI compares the request of every visible `LazyImage` on each body
+/// evaluation, so the comparison runs on the main thread once per cell per update.
+@Suite(.serialized)
+@MainActor
+struct LazyImagePerformanceTests {
+    @Test
+    func requestComparisonWithSameRequest() throws {
+        let request = ImageRequest(url: URL(string: "http://test.com/1"), processors: [ImageProcessors.Resize(width: 320)])
+
+        try measureRequestComparison(LazyImage(request: request), LazyImage(request: request))
+    }
+
+    @Test
+    func requestComparisonWithRebuiltRequest() throws {
+        let url = URL(string: "http://test.com/1")
+
+        try measureRequestComparison(
+            LazyImage(request: ImageRequest(url: url, processors: [ImageProcessors.Resize(width: 320)])),
+            LazyImage(request: ImageRequest(url: url, processors: [ImageProcessors.Resize(width: 320)]))
+        )
+    }
+
+    /// The comparison is private to `NukeUI`, so the test reaches it the way
+    /// `onChange(of:)` does: through the `Equatable` conformance of the value
+    /// the view stores.
+    private func measureRequestComparison<Content>(_ lhs: LazyImage<Content>, _ rhs: LazyImage<Content>, name: String = #function) throws {
+        let lhs = try #require(Mirror(reflecting: lhs).descendant("context") as? any Equatable)
+        let rhs = try #require(Mirror(reflecting: rhs).descendant("context"))
+        measureComparison(lhs, rhs, name: name)
+    }
+
+    private func measureComparison<T: Equatable>(_ lhs: T, _ rhs: Any, name: String) {
+        let rhs = rhs as! T
+        measure(name) {
+            var count = 0
+            for _ in 0..<1_000_000 where lhs == rhs {
+                count += 1
+            }
+            return count
+        }
+    }
+}

--- a/Tests/NukeTests/ImageRequestTests.swift
+++ b/Tests/NukeTests/ImageRequestTests.swift
@@ -44,6 +44,19 @@ struct ImageRequestTests {
         #expect(copy.priority == .low)
     }
 
+    @Test func copyIsIdenticalUntilMutated() {
+        let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        var copy = request
+        #expect(copy.isIdentical(to: request))
+
+        copy.priority = .high
+        #expect(!copy.isIdentical(to: request))
+    }
+
+    @Test func equalRequestsCreatedSeparatelyAreNotIdentical() {
+        #expect(!ImageRequest(url: Test.url).isIdentical(to: ImageRequest(url: Test.url)))
+    }
+
     // MARK: - Misc
 
     // Just to make sure that comparison works as expected.


### PR DESCRIPTION
`LazyImage` passes its request to `onChange(of:)` wrapped in a private `LazyImageContext`, so SwiftUI calls `LazyImageContext.==` on the main thread on every body evaluation of every visible `LazyImage`. With one processor that costs ~210 ns, almost all of it NukeUI's copy of the processors `==`, which boxes both identifiers in `AnyHashable`. It never checks whether the two sides are the same request, and for a view that keeps its request they are: copies sharing one copy-on-write container.

The operator now returns `true` when both requests share the container. It also drops a duplicated `lhs.priority == rhs.priority` line.

The container is private to `Nuke`, so the check is a new `package func isIdentical(to:)` on `ImageRequest` – `true` means equal, `false` means nothing, like the standard library's `isIdentical(to:)`. `package` keeps it out of the public and SPI interfaces. SwiftPM gives every target in the package a package name; `Nuke.xcodeproj` now sets `SWIFT_PACKAGE_NAME` on `Nuke` and `NukeUI`.

### Measurements

Release rig (SwiftPM, `-c release`), 1M comparisons per row, 5 interleaved rounds, median per side, ns per call. NukeUI's operator is called the way `onChange(of:)` calls it, through the `Equatable` witness of the stored context; the first row is that harness on its own.

| `LazyImageContext.==` | before | after | Δ | per-round sign |
|---|---|---|---|---|
| harness floor (`Int? ==`) | 37.9 | 38.6 | +1.7% | ++-++ |
| same container, no processors | 62.0 | 44.7 | -27.9% | ----- |
| same container, 1 `Resize` | 254.2 | 44.5 | -82.5% | ----- |
| rebuilt request, no processors | 61.6 | 61.3 | -0.4% | +-+-- |
| rebuilt request, 1 `Resize` | 253.1 | 249.9 | -1.3% | --++- |
| different URL, 1 `Resize` | 57.8 | 57.2 | -1.0% | +-+-- |

Net of the harness, a copy of the same request goes from ~216 ns to ~6 ns. The rig's rows that time a fixed copy of the old operator stayed within noise. The changelog's "up to 5×" is the same-container, one-`Resize` row.

Machine: 18-core M-series Mac, macOS 26.6, Xcode 26.5.

### Trade-offs

- Only requests that share a container benefit. A request built in `body` – `LazyImage(url:)`, or `.processors(_:)` / `.priority(_:)` applied to a stored request, which copies it – still pays the full comparison: the flat "rebuilt" rows.
- `package` is new to the codebase. A build that compiles `Nuke` and `NukeUI` without a shared package name won't compile `NukeUI`. SwiftPM and `Nuke.xcodeproj` both set one, and there is no podspec.

Follow-up: once processors carry a precomputed identity (not on `main` yet), rebuilt requests can compare that instead of NukeUI's private `==` for `[any ImageProcessing]`, and that operator can go.

### Testing

1. `NukeTests` (macOS): 1095 tests – 1091 pass, 3 skipped, 1 known failure. `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress()` aborts under Thread Sanitizer on a race inside the test mock `MockProgressiveDataLoader`; it fails on `main` too.
2. `NukeUITests` (macOS): 366 pass, including the existing request-change tests that cover the not-equal path.
3. New `ImageRequestTests` for `isIdentical(to:)`.
4. `swift build` and `xcodebuild build-for-testing -scheme NukePerformanceTests` (Release) build with no new warnings.
