### PR TITLE
Batch the data loader's callbacks instead of spawning a task for each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 - The default `ImagePipeline/Configuration-swift.struct/rateLimiter` rate goes from 80 to 100 requests per second – https://github.com/kean/Nuke/pull/960
 - `ImageTask` and `ImageDecoders/Video` are now `Sendable` instead of `@unchecked Sendable` – https://github.com/kean/Nuke/pull/965
 
+**Performance**
+
+- Batch the data loader's callbacks instead of spawning a `Task` for each: 15% faster when the response arrives in 16 chunks – https://github.com/kean/Nuke/pull/970
+
 **Bug Fixes**
 
 - Remove an unused `AVKit` import from `Nuke`, which linked AVKit, AVFoundation, and their dependencies into every app – https://github.com/kean/Nuke/pull/947

--- a/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+import os
 
 /// Fetches original image from the data loader (`DataLoading`) and stores it
 /// in the disk cache (`DataCaching`).
@@ -147,29 +148,40 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
     private func loadData(with urlRequest: URLRequest, dataLoader: any DataLoading) async throws {
         try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Void, Error>) in
             dataLoadContinuation = continuation
-            let didReceiveData: @Sendable (Data, URLResponse) -> Void = { [weak self] chunk, response in
-                Task { @ImagePipelineActor in
-                    self?.dataTaskDidReceive(chunk: chunk, response: response)
-                }
+            // The loader calls back on its own thread, once per chunk. The
+            // inbox batches the callbacks instead of paying for a `Task` each.
+            let inbox = DataLoadInbox { [weak self] events in
+                self?.apply(events)
+            }
+            let didReceiveData: @Sendable (Data, URLResponse) -> Void = { chunk, response in
+                inbox.post(.chunk(chunk, response))
             }
             // Each branch passes its own completion so that the common one
             // isn't wrapped in a closure that only exists to drop the metrics.
             if downloadStage != nil, let dataLoader = dataLoader as? DataLoader {
                 // The diagnostics are on: ask for what `URLSession` measured.
-                dataLoadCancellable = dataLoader.loadData(with: urlRequest, didReceiveData: didReceiveData) { [weak self] error, metrics in
-                    Task { @ImagePipelineActor in
-                        self?.finishDataLoad(error: error, urlSessionMetrics: metrics)
-                    }
+                dataLoadCancellable = dataLoader.loadData(with: urlRequest, didReceiveData: didReceiveData) { error, metrics in
+                    inbox.post(.finished(error, metrics))
                 }
                 if let handle = dataLoadCancellable as? URLSessionTaskCancellable {
                     diagnostics?.updateStage(downloadStage) { $0.urlSessionTaskID = handle.task.taskIdentifier }
                 }
             } else {
-                dataLoadCancellable = dataLoader.loadData(with: urlRequest, didReceiveData: didReceiveData) { [weak self] error in
-                    Task { @ImagePipelineActor in
-                        self?.finishDataLoad(error: error)
-                    }
+                dataLoadCancellable = dataLoader.loadData(with: urlRequest, didReceiveData: didReceiveData) { error in
+                    inbox.post(.finished(error, nil))
                 }
+            }
+        }
+    }
+
+    /// Applies the data loader's callbacks in the order it made them.
+    private func apply(_ events: [DataLoadInbox.Event]) {
+        for event in events {
+            switch event {
+            case let .chunk(chunk, response):
+                dataTaskDidReceive(chunk: chunk, response: response)
+            case let .finished(error, metrics):
+                finishDataLoad(error: error, urlSessionMetrics: metrics)
             }
         }
     }
@@ -349,6 +361,65 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
             // The request ended before the server responded – put the data that
             // `performDataLoad` took out of the storage back where it was.
             ResumableDataStorage.shared.storeResumableData(resumableData, for: request, pipeline: pipeline)
+        }
+    }
+}
+
+// MARK: - DataLoadInbox
+
+/// Carries the callbacks a ``DataLoading`` makes on its own thread over to
+/// ``ImagePipelineActor``, in the order it made them.
+///
+/// A response arrives in as many chunks as the transport decides to deliver,
+/// and spawning a `Task` for each one made the cost of reaching the actor
+/// scale with the chunk count. The inbox keeps at most one delivery scheduled
+/// at a time: callbacks that arrive while it waits for the actor, or runs on
+/// it, join its next batch instead of scheduling their own.
+private struct DataLoadInbox: Sendable {
+    enum Event {
+        case chunk(Data, URLResponse)
+        case finished((any Error)?, URLSessionTaskMetrics?)
+    }
+
+    private struct State {
+        var events: [Event] = []
+        /// A delivery is scheduled or running, and will pick up `events`.
+        var isDelivering = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let deliver: @ImagePipelineActor @Sendable ([Event]) -> Void
+
+    init(deliver: @escaping @ImagePipelineActor @Sendable ([Event]) -> Void) {
+        self.deliver = deliver
+    }
+
+    func post(_ event: Event) {
+        let needsDelivery: Bool = state.withLock {
+            $0.events.append(event)
+            guard !$0.isDelivering else { return false }
+            $0.isDelivering = true
+            return true
+        }
+        guard needsDelivery else { return }
+        Task { @ImagePipelineActor in
+            while let events = takeEvents() {
+                deliver(events)
+            }
+        }
+    }
+
+    /// Returns the events posted since the last call, or `nil` if there are
+    /// none, which ends the delivery.
+    private func takeEvents() -> [Event]? {
+        state.withLock {
+            guard !$0.events.isEmpty else {
+                $0.isDelivering = false
+                return nil
+            }
+            let events = $0.events
+            $0.events = []
+            return events
         }
     }
 }

--- a/Tests/Mocks/MockDataLoader.swift
+++ b/Tests/Mocks/MockDataLoader.swift
@@ -23,6 +23,8 @@ class MockDataLoader: DataLoading, @unchecked Sendable {
     private let _createdTaskCount = OSAllocatedUnfairLock(initialState: 0)
 
     var results = [URL: Result<(Data, URLResponse), NSError>]()
+    /// The number of chunks the default response is delivered in.
+    var chunkCount = 1
     let queue = OperationQueue()
     var isSuspended: Bool {
         get { queue.isSuspended }
@@ -36,7 +38,7 @@ class MockDataLoader: DataLoading, @unchecked Sendable {
         _createdTaskCount.withLock { $0 += 1 }
         NotificationCenter.default.post(name: MockDataLoader.DidStartTask, object: self)
 
-
+        let chunkCount = self.chunkCount
         let operation = BlockOperation {
             if let result = self.results[request.url!] {
                 switch result {
@@ -55,7 +57,19 @@ class MockDataLoader: DataLoading, @unchecked Sendable {
                     completion(err)
                 }
             } else {
-                didReceiveData(data, URLResponse(url: request.url ?? Test.url, mimeType: "jpeg", expectedContentLength: 22789, textEncodingName: nil))
+                let response = URLResponse(url: request.url ?? Test.url, mimeType: "jpeg", expectedContentLength: 22789, textEncodingName: nil)
+                if chunkCount > 1 {
+                    let chunkSize = data.count / chunkCount
+                    var offset = 0
+                    for index in 0..<chunkCount {
+                        // The last chunk takes the remainder.
+                        let end = index == chunkCount - 1 ? data.count : offset + chunkSize
+                        didReceiveData(data.subdata(in: offset..<end), response)
+                        offset = end
+                    }
+                } else {
+                    didReceiveData(data, response)
+                }
                 completion(nil)
             }
         }

--- a/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
@@ -25,6 +25,27 @@ struct ImagePipelinePerformanceTests {
     }
 
     @Test
+    func asyncAwaitPerformanceWithChunkedResponse() async {
+        // The transport decides how a response is sliced; a real download
+        // rarely arrives in one piece.
+        let pipeline = makePipeline {
+            let dataLoader = MockDataLoader()
+            dataLoader.chunkCount = 16
+            $0.dataLoader = dataLoader
+        }
+        let requests = (0..<5000).map { ImageRequest(url: URL(string: "http://test.com/\($0)")) }
+        await measure {
+            await withTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        _ = try? await pipeline.image(for: request)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     func asyncAwaitPerformanceWithDiagnostics() async {
         let pipeline = makePipeline { $0.isDiagnosticsEnabled = true }
         let requests = (0..<5000).map { ImageRequest(url: URL(string: "http://test.com/\($0)")) }

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineLoadDataTests.swift
@@ -4,6 +4,7 @@
 
 import Testing
 import Foundation
+import os
 @testable import Nuke
 
 @Suite(.timeLimit(.minutes(5)))
@@ -54,6 +55,160 @@ struct ImagePipelineLoadDataTests {
             ImageTask.Progress(completed: 10, total: 20),
             ImageTask.Progress(completed: 20, total: 20)
         ])
+    }
+
+    // MARK: - Chunked Responses
+
+    // The loader calls back on its own thread, and the pipeline applies the
+    // callbacks on its actor in batches. A batch must not reorder the chunks,
+    // let the completion overtake them, or apply them to a cancelled task.
+
+    @Test func chunksAreAppliedInOrder() async throws {
+        // GIVEN a loader that delivers each response in 1000 chunks back to
+        // back from a background queue, and then completes
+        dataLoader.chunkCount = 1000
+
+        // WHEN loading a number of responses at once
+        let pipeline = self.pipeline
+        try await withThrowingTaskGroup(of: Data.self) { group in
+            for index in 0..<20 {
+                group.addTask {
+                    try await pipeline.data(for: ImageRequest(url: URL(string: "http://test.com/\(index)"))).0
+                }
+            }
+            // THEN each response is its chunks concatenated in order; a chunk
+            // applied out of order, or dropped after the completion, breaks it
+            for try await data in group {
+                #expect(data == Test.data)
+            }
+        }
+    }
+
+    @Test func progressIsReportedForEveryChunkBeforeCompletion() async throws {
+        // GIVEN a loader that delivers the response in 1000 chunks
+        dataLoader.chunkCount = 1000
+        let observer = ImagePipelineObserver()
+        let pipeline = ImagePipeline(delegate: observer) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+
+        // WHEN
+        let completed = TestExpectation(notification: ImagePipelineObserver.didCompleteTask, object: observer)
+        _ = try await pipeline.imageTask(with: Test.request).response
+        await completed.wait()
+
+        // THEN progress is reported once per chunk, in order
+        let total = Int64(Test.data.count)
+        let chunkSize = total / 1000
+        let expected = (1...1000).map {
+            ImageTaskEvent.progressUpdated(completedUnitCount: $0 == 1000 ? total : Int64($0) * chunkSize, totalUnitCount: total)
+        }
+        #expect(observer.events.filter(\.isProgress) == expected)
+
+        // THEN the task completes after the last chunk
+        guard case .completed(result: .success) = observer.events.last else {
+            Issue.record("Expected the task to complete last, got \(String(describing: observer.events.last))")
+            return
+        }
+    }
+
+    @Test @ImagePipelineActor func failureIsReportedAfterTheChunksBeforeIt() async throws {
+        // GIVEN a loader that delivers part of the response and then fails
+        let dataLoader = ManualDataLoader()
+        let observer = ImagePipelineObserver()
+        let pipeline = ImagePipeline(delegate: observer) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+        let task = pipeline.imageTask(with: Test.request)
+        await dataLoader.started.wait()
+
+        // WHEN the chunks and the failure arrive while the test holds the
+        // actor, so the pipeline applies them in a single batch
+        let completed = TestExpectation(notification: ImagePipelineObserver.didCompleteTask, object: observer)
+        let chunks = _createChunks(for: Test.data, size: Test.data.count / 4).dropLast()
+        for chunk in chunks {
+            dataLoader.serve(chunk)
+        }
+        dataLoader.complete(with: URLError(.networkConnectionLost))
+
+        // THEN the task fails with the loader's error
+        do {
+            _ = try await task.response
+            Issue.record("Expected failure")
+        } catch {
+            #expect((error.dataLoadingError as? URLError)?.code == .networkConnectionLost)
+        }
+        await completed.wait()
+
+        // THEN progress is reported for every chunk before the failure
+        #expect(observer.events.filter(\.isProgress).count == chunks.count)
+        guard case .completed(result: .failure) = observer.events.last else {
+            Issue.record("Expected the task to fail last, got \(String(describing: observer.events.last))")
+            return
+        }
+    }
+
+    @Test @ImagePipelineActor func cancellingWhileChunksWaitForTheActor() async throws {
+        // GIVEN a load in progress, and a data loading queue with one slot
+        let dataLoader = ManualDataLoader()
+        let observer = ImagePipelineObserver()
+        let pipeline = ImagePipeline(delegate: observer) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+            $0.dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 1)
+        }
+        let task = pipeline.imageTask(with: Test.request)
+        await dataLoader.started.wait()
+
+        // WHEN chunks arrive while the test holds the actor, so they can't be
+        // applied yet, and the task is cancelled
+        for chunk in _createChunks(for: Test.data, size: Test.data.count / 4) {
+            dataLoader.serve(chunk)
+        }
+        task._cancelTask()
+
+        // THEN the task is cancelled without receiving any of them
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
+        #expect(observer.events == [.created, .started, .cancelled])
+        #expect(dataLoader.isCancelled)
+
+        // THEN the load still finishes, releasing its slot in the queue
+        await pipeline.configuration.dataLoadingQueue.waitUntilAllOperationsAreFinished()
+    }
+
+    @Test @ImagePipelineActor func cancellingInTheMiddleOfABatch() async throws {
+        // GIVEN a delegate that cancels the task when it reports progress
+        let dataLoader = ManualDataLoader()
+        let delegate = CancelOnProgressDelegate()
+        let pipeline = ImagePipeline(delegate: delegate) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+            $0.dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 1)
+        }
+        let task = pipeline.imageTask(with: Test.request)
+        await dataLoader.started.wait()
+
+        // WHEN the whole response arrives while the test holds the actor, so
+        // the pipeline applies it in a single batch
+        let chunks = _createChunks(for: Test.data, size: Test.data.count / 4)
+        for chunk in chunks {
+            dataLoader.serve(chunk)
+        }
+        dataLoader.complete(with: nil)
+
+        // THEN the task is cancelled on the first chunk and receives nothing
+        // from the rest of the batch
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
+        #expect(delegate.progress == [ImageTask.Progress(completed: Int64(chunks[0].count), total: Int64(Test.data.count))])
+
+        // THEN the load still finishes, releasing its slot in the queue
+        await pipeline.configuration.dataLoadingQueue.waitUntilAllOperationsAreFinished()
     }
 
     // MARK: - Errors
@@ -378,5 +533,57 @@ struct ImagePipelineLoadDataTests {
         #expect(dataCache.cachedData(for: Test.url.absoluteString) != nil)
         #expect(dataCache.writeCount == 1)
         #expect(dataCache.store.count == 1)
+    }
+}
+
+private extension ImageTaskEvent {
+    var isProgress: Bool {
+        if case .progressUpdated = self { true } else { false }
+    }
+}
+
+/// Hands the test the callbacks of the load it starts, so that the test
+/// decides when, and from which thread, the response arrives.
+private final class ManualDataLoader: DataLoading, Sendable {
+    private struct Callbacks: Sendable {
+        let didReceiveData: @Sendable (Data, URLResponse) -> Void
+        let completion: @Sendable ((any Error)?) -> Void
+    }
+
+    let started = TestExpectation()
+    var isCancelled: Bool { _isCancelled.withLock { $0 } }
+
+    private let _isCancelled = OSAllocatedUnfairLock(initialState: false)
+    private let callbacks = OSAllocatedUnfairLock<Callbacks?>(initialState: nil)
+
+    func loadData(with request: URLRequest, didReceiveData: @escaping @Sendable (Data, URLResponse) -> Void, completion: @escaping @Sendable ((any Error)?) -> Void) -> any Cancellable {
+        callbacks.withLock { $0 = Callbacks(didReceiveData: didReceiveData, completion: completion) }
+        started.fulfill()
+        return AnonymousCancellable { [self] in
+            _isCancelled.withLock { $0 = true }
+            // `URLSession` reports a cancelled load through its completion.
+            complete(with: URLError(.cancelled))
+        }
+    }
+
+    func serve(_ chunk: Data) {
+        callbacks.withLock { $0 }?.didReceiveData(chunk, Test.urlResponse)
+    }
+
+    /// Completes the load and, like `URLSession`, lets go of its callbacks.
+    func complete(with error: (any Error)?) {
+        callbacks.withLock { $0.take() }?.completion(error)
+    }
+}
+
+/// Cancels a task from inside the event that reports its progress.
+@ImagePipelineActor
+private final class CancelOnProgressDelegate: ImagePipeline.Delegate {
+    private(set) var progress: [ImageTask.Progress] = []
+
+    func imageTask(_ task: ImageTask, didReceiveEvent event: ImageTask.Event, pipeline: ImagePipeline) {
+        guard case .progress(let value) = event else { return }
+        progress.append(value)
+        task._cancelTask()
     }
 }


### PR DESCRIPTION
`TaskFetchOriginalData` reached `ImagePipelineActor` from the data loader's callbacks by spawning a `Task` for each one: one per chunk of the response, plus one for the completion. The hop onto the actor is cheap; creating and scheduling a `Task` to make it is not, and how many of them a download paid for was decided by how the transport sliced the response, not by the pipeline.

The callbacks now go through a `DataLoadInbox`. The loader's thread appends each event to a buffer under an `OSAllocatedUnfairLock` and schedules a delivery only if none is already scheduled or running. The delivery runs on the actor, takes everything posted so far, applies it in order, and repeats until it finds the buffer empty. A callback that arrives while a delivery waits for the actor, or runs on it, joins the next batch instead of paying for a `Task` of its own.

Order holds by construction: events enter the buffer under the lock in the order the loader posted them, at most one delivery exists at a time, and the completion is the last event posted, so it can't overtake a chunk. Before, the order relied on the actor running separately spawned tasks in the order they were created. What each event does on the actor is unchanged, including the checks for a cancelled task.

The inbox is a checked `Sendable` struct. Its only mutable state – the buffer and the delivery flag – is shared between the loader's thread and the actor, and lives inside a lock that takes a `Sendable` state, so there is no `@unchecked`.

The first commit adds `asyncAwaitPerformanceWithChunkedResponse`, which has the mock loader deliver its response in 16 chunks, so the gain is reproducible from the repo.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. Both sides alternate run by run, and the side that runs first alternates by round; median of the per-run averages, and the Δ of each round.

**Release rig** – `asyncAwait`: 5000 requests per sample, 5 samples per run, a mock loader that delivers a 22.8 KB body in N chunks from an `OperationQueue`, `ImageDecoders.Empty`; 7 rounds

| Chunks per response | `main` | This PR | Δ | Rounds |
|---|---|---|---|---|
| 16 | 97.3 ms | 82.8 ms | **−14.9%** | −15.5, −15.1, −15.4, −10.8, −14.9, −14.2, −13.4 |
| 8 | 74.9 ms | 67.4 ms | **−9.9%** | −6.4, −9.7, −13.5, −10.3, −10.2, −9.3, −9.3 |
| 1 | 47.6 ms | 47.2 ms | −0.7% | +0.1, −0.8, −0.9, −0.2, −1.7, −0.7, +8.7 |

One chunk is flat. The +8.7 round is three samples of one run; a separate 1-chunk session of 9 rounds measured 48.5 → 47.7 ms (−1.7%), faster in 8 of them.

Heap allocations per load, counted with `malloc_logger` over 5000 loads, median of 3:

| Chunks per response | `main` | This PR |
|---|---|---|
| 16 | 174.5 | 118.7 |
| 8 | 126.4 | 101.1 |
| 1 | 79.2 | 79.4 |

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel; "before" is the first commit of this PR; 5 rounds

| Test | Before | After | Δ | Rounds |
|---|---|---|---|---|
| `asyncAwaitPerformanceWithChunkedResponse` (16 chunks) | 135.1 ms | 114.6 ms | **−15.1%** | −15.5, −16.1, −13.9, −14.6, −15.5 |
| `asyncAwaitPerformance` (1 chunk) | 69.7 ms | 68.5 ms | −1.7% | −1.7, −2.4, −0.3, −0.1, −0.9 |

### Trade-offs

- A delivery doesn't give up the actor until it finds the buffer empty, so while a loader posts faster than the actor applies its events, other pipeline work waits for that burst to end instead of interleaving between chunks. Applying a chunk is an append, a progress event, and – with progressive decoding on – scheduling a decode.
- A response that arrives in one chunk still pays for one `Task`, and now also for the inbox's lock and buffer, which is why it doesn't get cheaper.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO` – 1097 tests pass, 3 of them skipped as on `main`. That is `main`'s 1093 plus the five new tests, less `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`: it aborts under ThreadSanitizer on a race inside the test mock `MockProgressiveDataLoader`, as it does on `main`, and the suite was re-run with `-skip-testing:` for it.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 tests pass.
3. The new tests in `ImagePipelineLoadDataTests` cover 20 concurrent loads of 1000 chunks each arriving intact, progress reported for every chunk before the completion, a failure that follows chunks in the same batch, a cancellation while a batch waits for the actor, and a cancellation from inside a batch. The last two check that the load still finishes and frees its slot in the data loading queue. Reversing the order within a batch fails four of them, plus the existing `progressClosureIsCalled`; `ImagePipelineProgressiveDecodingTests` still passes against that reversal, because its chunks arrive one batch at a time.
4. `NukePerformanceTests` builds with the same warnings as `main`; `swiftlint` reports nothing new in the changed files.

