### PR TITLE
Walk the subscribers instead of materializing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 - The default `ImagePipeline/Configuration-swift.struct/rateLimiter` rate goes from 80 to 100 requests per second – https://github.com/kean/Nuke/pull/960
 - `ImageTask` and `ImageDecoders/Video` are now `Sendable` instead of `@unchecked Sendable` – https://github.com/kean/Nuke/pull/965
 
+**Performance**
+
+- Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
+
 **Bug Fixes**
 
 - Remove an unused `AVKit` import from `Nuke`, which linked AVKit, AVFoundation, and their dependencies into every app – https://github.com/kean/Nuke/pull/947

--- a/Sources/Nuke/Tasks/AsyncPipelineTask.swift
+++ b/Sources/Nuke/Tasks/AsyncPipelineTask.swift
@@ -19,24 +19,26 @@ class AsyncPipelineTask<Value: Sendable>: AsyncTask<Value, ImagePipeline.Error> 
     }
 }
 
-// Returns all image tasks subscribed to the current pipeline task.
-// A suboptimal approach just to make the new DiskCachPolicy.automatic work.
+/// An image task, or a task that image tasks are subscribed to, directly or
+/// through the tasks that depend on it.
 @ImagePipelineActor
-protocol ImageTaskSubscribers {
-    var imageTasks: [ImageTask] { get }
+protocol ImageTaskSubscribers: AnyObject {
+    /// Returns `true` if `predicate` returns `true` for any of the image tasks.
+    ///
+    /// The callers only ask whether there is one, so the walk stops at the
+    /// first match instead of collecting the image tasks into an array.
+    func containsImageTask(where predicate: (ImageTask) -> Bool) -> Bool
 }
 
 extension ImageTask: ImageTaskSubscribers {
-    var imageTasks: [ImageTask] {
-        [self]
+    func containsImageTask(where predicate: (ImageTask) -> Bool) -> Bool {
+        predicate(self)
     }
 }
 
-extension AsyncPipelineTask: ImageTaskSubscribers {
-    var imageTasks: [ImageTask] {
-        subscribers.flatMap { subscribers -> [ImageTask] in
-            (subscribers as? ImageTaskSubscribers)?.imageTasks ?? []
-        }
+extension AsyncTask: ImageTaskSubscribers {
+    func containsImageTask(where predicate: (ImageTask) -> Bool) -> Bool {
+        containsSubscriber { $0.containsImageTask(where: predicate) }
     }
 }
 

--- a/Sources/Nuke/Tasks/AsyncTask.swift
+++ b/Sources/Nuke/Tasks/AsyncTask.swift
@@ -18,10 +18,13 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
 
     private final class Subscription {
         let closure: (Event) -> Void
-        weak var subscriber: AnyObject?
+        // The protocol and not `AnyObject`: walking the subscribers is then a
+        // witness call rather than a conditional cast, which has the runtime
+        // search the protocol conformance tables.
+        weak var subscriber: (any ImageTaskSubscribers)?
         var priority: TaskPriority
 
-        init(closure: @escaping (Event) -> Void, subscriber: AnyObject, priority: TaskPriority) {
+        init(closure: @escaping (Event) -> Void, subscriber: any ImageTaskSubscribers, priority: TaskPriority) {
             self.closure = closure
             self.subscriber = subscriber
             self.priority = priority
@@ -36,13 +39,15 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
     private var subscriptions: ContiguousArray<(key: TaskSubscriptionKey, sub: Subscription)>? // Create lazily
     private var nextSubscriptionKey = 0
 
-    var subscribers: [AnyObject] {
-        var output = [AnyObject?]()
-        output.append(inlineSubscription?.subscriber)
+    /// Returns `true` if `predicate` returns `true` for any of the subscribers.
+    func containsSubscriber(where predicate: (any ImageTaskSubscribers) -> Bool) -> Bool {
+        if let subscriber = inlineSubscription?.subscriber, predicate(subscriber) { return true }
         if let subscriptions {
-            for entry in subscriptions { output.append(entry.sub.subscriber) }
+            for entry in subscriptions {
+                if let subscriber = entry.sub.subscriber, predicate(subscriber) { return true }
+            }
         }
-        return output.compactMap { $0 }
+        return false
     }
 
     func hasSubscriber<T>(of type: T.Type) -> Bool {
@@ -105,7 +110,7 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
     // MARK: - Managing Observers
 
     /// - note: Returns `nil` if the task was disposed.
-    private func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
+    private func subscribe(priority: TaskPriority = .normal, subscriber: any ImageTaskSubscribers, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
         guard !isDisposed else { return nil }
 
         let subscriptionKey = nextSubscriptionKey
@@ -260,7 +265,7 @@ extension AsyncTask {
 
         /// Attaches the subscriber to the task.
         /// - note: Returns `nil` if the task is already disposed.
-        func subscribe(priority: TaskPriority = .normal, subscriber: AnyObject, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
+        func subscribe(priority: TaskPriority = .normal, subscriber: any ImageTaskSubscribers, _ closure: @escaping (Event) -> Void) -> TaskSubscription? {
             task.subscribe(priority: priority, subscriber: subscriber, closure)
         }
 

--- a/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
@@ -383,8 +383,7 @@ extension AsyncPipelineTask where Value == (Data, URLResponse?) {
     }
 
     private func shouldStoreDataInDiskCache() -> Bool {
-        let imageTasks = imageTasks
-        guard imageTasks.contains(where: { !$0.request.options.contains(.disableDiskCacheWrites) }) else {
+        guard containsImageTask(where: { !$0.request.options.contains(.disableDiskCacheWrites) }) else {
             return false
         }
         guard !(request.url?.isLocalResource ?? false) else {
@@ -392,7 +391,7 @@ extension AsyncPipelineTask where Value == (Data, URLResponse?) {
         }
         switch pipeline.configuration.dataCachePolicy {
         case .automatic:
-            return imageTasks.contains { $0.request.processors.isEmpty }
+            return containsImageTask { $0.request.processors.isEmpty }
         case .storeOriginalData:
             return true
         case .storeEncodedImages:

--- a/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
@@ -94,6 +94,33 @@ struct ImagePipelinePerformanceTests {
             }
         }
     }
+
+    /// Up to a hundred image tasks coalesced onto each download, with a data
+    /// cache configured: every completed download asks the tasks waiting on it
+    /// whether to store the data.
+    @Test
+    func coalescedLoadsWithDataCachePerformance() async {
+        let pipeline = makePipeline { $0.dataCache = DataCacheMiss() }
+        let requests = (0..<5000).map { ImageRequest(url: URL(string: "http://test.com/\($0 % 50)")) }
+        await measure {
+            await withTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        _ = try? await pipeline.image(for: request)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Never has the data, so every iteration downloads it again.
+private struct DataCacheMiss: DataCaching {
+    func cachedData(for key: String) -> Data? { nil }
+    func containsData(for key: String) -> Bool { false }
+    func storeData(_ data: Data, for key: String) {}
+    func removeData(for key: String) {}
+    func removeAll() {}
 }
 
 private func makePipeline(_ configure: (inout ImagePipeline.Configuration) -> Void = { _ in }) -> ImagePipeline {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDataCacheTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDataCacheTests.swift
@@ -601,6 +601,77 @@ struct ImagePipelineDataCachePolicyTests {
         #expect(dataCache.store.count == 2)
     }
 
+    // MARK: Coalesced Requests
+
+    @Test(arguments: [ImagePipeline.DataCachePolicy.automatic, .storeOriginalData], CoalescedRequest.mixes)
+    func policyGivenCoalescedRequests(policy: ImagePipeline.DataCachePolicy, requests: [CoalescedRequest]) async throws {
+        // GIVEN
+        let pipeline = pipeline.reconfigured {
+            $0.dataCachePolicy = policy
+        }
+
+        // WHEN the requests wait for the same download
+        let loads = await withSuspendedDataLoading(for: pipeline, expectedCount: requests.count) {
+            requests.map { request in
+                Task {
+                    if request.isDataTask {
+                        _ = try await pipeline.data(for: request.imageRequest)
+                    } else {
+                        _ = try await pipeline.image(for: request.imageRequest)
+                    }
+                }
+            }
+        }
+        for load in loads {
+            try await load.value
+        }
+        await pipeline.configuration.imageEncodingQueue.waitUntilAllOperationsAreFinished()
+
+        // THEN the original data is stored if any of the requests allows disk
+        // cache writes and, with `.automatic`, any of them has no processors –
+        // not necessarily the same one
+        let isStored = requests.contains { !$0.disablesDiskCacheWrites } &&
+            (policy == .storeOriginalData || requests.contains { !$0.hasProcessor })
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(dataCache.containsData(for: Test.url.absoluteString) == isStored)
+    }
+
+    /// A request that waits for the same download as the others in its test case.
+    struct CoalescedRequest: Sendable, CustomStringConvertible {
+        var isDataTask = false
+        var hasProcessor = false
+        var disablesDiskCacheWrites = false
+
+        var imageRequest: ImageRequest {
+            ImageRequest(
+                url: Test.url,
+                processors: hasProcessor ? [MockImageProcessor(id: "p1")] : [],
+                options: disablesDiskCacheWrites ? [.disableDiskCacheWrites] : []
+            )
+        }
+
+        var description: String {
+            [isDataTask ? "data" : "image", hasProcessor ? "p1" : nil, disablesDiskCacheWrites ? "disableDiskCacheWrites" : nil]
+                .compactMap { $0 }
+                .joined(separator: " ")
+        }
+
+        /// Every kind of request on its own, and every pair of them.
+        static var mixes: [[CoalescedRequest]] {
+            let kinds = [
+                CoalescedRequest(),
+                CoalescedRequest(disablesDiskCacheWrites: true),
+                CoalescedRequest(hasProcessor: true),
+                CoalescedRequest(hasProcessor: true, disablesDiskCacheWrites: true),
+                CoalescedRequest(isDataTask: true),
+                CoalescedRequest(isDataTask: true, disablesDiskCacheWrites: true)
+            ]
+            return kinds.indices.flatMap { i in
+                [[kinds[i]]] + kinds[i...].map { [kinds[i], $0] }
+            }
+        }
+    }
+
     // MARK: Local Resources
 
     @Test func imagesFromLocalStorageNotCached() async throws {

--- a/Tests/NukeTests/TaskTests.swift
+++ b/Tests/NukeTests/TaskTests.swift
@@ -179,6 +179,29 @@ struct TaskTests {
         }
     }
 
+    // MARK: - Subscribers
+
+    @Test func containsImageTaskVisitsEverySubscriber() {
+        // Given a task with no subscribers
+        let pipeline = ImagePipeline()
+        let imageTask = ImageTask(taskId: 1, request: ImageRequest(url: Test.url), isDataTask: false, pipeline: pipeline, onEvent: nil)
+        let task = SimpleTask<Int, MyError>()
+        #expect(!task.containsImageTask { _ in true })
+
+        // When the first subscriber isn't an image task
+        _ = task.subscribe { _ in }
+        #expect(!task.containsImageTask { _ in true })
+
+        // When an image task is subscribed through another task
+        let child = SimpleTask<Int, MyError>()
+        _ = task.publisher.subscribe(child) { _, _ in }
+        _ = child.publisher.subscribe(subscriber: imageTask) { _ in }
+
+        // Then the walk finds it past the first subscriber
+        #expect(task.containsImageTask { $0 === imageTask })
+        #expect(!task.containsImageTask { $0 !== imageTask })
+    }
+
     // MARK: - Unsubscribe
 
     @Test func whenSubscriptionIsRemovedNoEventsAreSent() async {
@@ -548,10 +571,21 @@ private final class SimpleTask<T, E>: AsyncTask<T, E>, @unchecked Sendable {
     }
 }
 
+/// A subscriber that isn't an image task. The tasks hold their subscribers
+/// weakly, so the tests share one that stays alive.
+@ImagePipelineActor
+private final class Observer: ImageTaskSubscribers {
+    static let shared = Observer()
+
+    func containsImageTask(where predicate: (ImageTask) -> Bool) -> Bool {
+        false
+    }
+}
+
 @ImagePipelineActor
 extension AsyncTask {
     func subscribe(priority: TaskPriority = .normal, _ observer: @escaping (Event) -> Void) -> TaskSubscription? {
-        publisher.subscribe(priority: priority, subscriber: "" as AnyObject, observer)
+        publisher.subscribe(priority: priority, subscriber: Observer.shared, observer)
     }
 }
 


### PR DESCRIPTION
When a download finishes and a data cache is configured, `TaskFetchOriginalData` asks whether any image task waiting on it wants the data stored. `shouldStoreDataInDiskCache()` answered by materializing them: `imageTasks` flat-mapped the subscribers of every task up the chain – `TaskFetchOriginalData` ← `TaskFetchOriginalImage` ← `TaskLoadImage` (one more per processor) ← `ImageTask` – and cast each one with `as? ImageTaskSubscribers`. Every task on the way allocated three arrays (`subscribers`, its `compactMap`, and the `flatMap` result), every image task a fourth, and every cast from `AnyObject` to a protocol went through the runtime's conformance lookup. Both questions asked of the result were `contains`.

- `ImageTaskSubscribers` has `containsImageTask(where:)` instead of `imageTasks`: a walk that stops at the first match and allocates nothing. `ImageTask` applies the predicate to itself; `AsyncTask` asks its subscribers through `containsSubscriber(where:)`, the same shape as `hasSubscriber(of:)` next to it.
- `Subscription` stores the subscriber as `any ImageTaskSubscribers` instead of `AnyObject`, so each step is a witness call rather than a cast. Both kinds of subscriber already conformed; the conformance moves from `AsyncPipelineTask` to `AsyncTask`, because `Publisher.subscribe(_:onValue:)` passes a plain `AsyncTask`.
- `AsyncTask.subscribers` had no other callers and is removed. Nothing public changes.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. `main` and this branch alternate run by run, and the side that runs first alternates by round; median per side, and the Δ of each round. The release rig uses a mock data loader, a data cache that always misses, and `ImageDecoders.Empty`.

**Allocations per download** – release rig, counted through `malloc_logger`, 5 loads per run, 3 rounds

| Configuration | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| 2000 URLs, no processors | 91.4 | 81.3 | **−10** | −11.3, −10.9, −11.1 |
| 2000 URLs, one `Resize` | 136.9 | 123.9 | **−13** | −9.5, −9.5, −9.5 |
| 100 URLs, 20 requests each | 451 | 410 | −41 | −9.1, −9.0, −9.1 |
| 50 URLs, 100 requests each | 1707 | 1591 | −116 | −6.8, −6.8, −6.8 |

Ten is three arrays for each of the three tasks plus one for the image task; a processor adds a task, so three more. Malloc'd bytes per load go down 2.5% in the first row (17,149 → 16,712), the larger `Subscription` included.

**Time Profiler** – `hotprocess` (2000 URLs, one `Resize`), 8 s, inclusive share of the profile

| Frame | `main` | This PR |
|---|---|---|
| `shouldStoreDataInDiskCache()` | 5.32% | 0.19% |
| `AsyncPipelineTask.imageTasks.getter` | 4.79% | – |
| `swift_conformsToProtocol…` | 2.47% | 0.96% |

On `main`, `closure #1 in AsyncPipelineTask.imageTasks.getter` takes 2.17% of self time, top leaf `swift_conformsToProtocolMaybeInstantiateSuperclasses`. On this branch no frame of the walk ranks in the top 40.

**Timing** – release rig, `storewalk`: 2000 loads with a data cache

| Benchmark | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| 2000 URLs | 22.40 ms | 20.01 ms | **−10.7%** | −10.2, −11.5, −11.3, −11.2, −10.7 |
| 2000 URLs, 10 samples per run | 21.92 ms | 19.82 ms | **−9.6%** | −6.1, −9.6, −10.1, −9.9, −9.0 |
| 100 URLs, 20 requests each | 5.45 ms | 4.75 ms | −12.9% | −25.7, −20.1, −3.7, −15.6, −12.1 |
| 20 URLs, 100 requests each | 4.91 ms | 4.29 ms | −12.7% | −28.2, −2.0, −14.8, −10.9, −9.1 |
| `asyncAwait`, no data cache | 47.75 ms | 47.93 ms | +0.4% | −0.9, +1.5, +0.9, +4.3, +0.3 |

One sample per run unless noted. The coalesced rows swing by 20% run to run at 5 ms; with 10 samples per run they are −6.4% and −7.1%, with one positive round. `asyncAwait` subscribes on every load but never walks, so it's the control.

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel, 5 rounds

| Test | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `coalescedLoadsWithDataCachePerformance` | 29.74 ms | 27.27 ms | −8.3% | −7.8, −9.8, +2.5, +10.2, −2.3 |

This one doesn't resolve: the sign flips in two rounds. The test is new, in the first commit – none of the existing ones configures a data cache, so none of them reached this path.

### Trade-offs

- `Subscription` grows from 48 to 64 malloc'd bytes: a weak protocol reference keeps the witness table next to the object. There's one per subscription; `asyncAwait`, which only subscribes, is within the noise.
- The walk now also descends into a plain `AsyncTask` subscriber, where the cast used to skip anything that wasn't an `AsyncPipelineTask`. Every task the pipeline creates is one, so only `TaskTests`' `SimpleTask` sees the difference.
- The new policy test pins today's answers, including one that looks accidental: with `.automatic`, a request with a processor coalesced with a processor-less request that sets `.disableDiskCacheWrites` stores the original data, because the two questions don't need the same request to answer yes. It passes on `main` too; this PR doesn't change it.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` – the only failure is the known ThreadSanitizer abort inside the test mock, `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`, which fails on `main` too. With it skipped, 1094 pass: `main`'s 1093, less that one, plus two new tests.
   - `ImagePipelineDataCachePolicyTests.policyGivenCoalescedRequests` – 54 cases: `.automatic` and `.storeOriginalData`, times every kind of request (an image with or without a processor, with or without `.disableDiskCacheWrites`, and a data task with or without it) on its own and in every pair, all waiting on one download. It also passes against `main`'s sources.
   - `TaskTests.containsImageTaskVisitsEverySubscriber` – no subscribers, a subscriber that isn't an image task, and an image task one task down, past it.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 pass.
3. `swiftlint` reports nothing new in the changed files.
