### PR TITLE
Box each processor's identity once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
-- Memory cache lookups for requests with `ImageProcessors/Resize` are 2× faster – https://github.com/kean/Nuke/pull/972
+- Memory cache lookups are up to 2× faster – https://github.com/kean/Nuke/pull/972
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 **Performance**
 
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
+- Memory cache lookups for requests with `ImageProcessors/Resize` are 2× faster – https://github.com/kean/Nuke/pull/972
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -493,6 +493,15 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     /// where the actual URL determines what gets fetched.
     var originalImageID: String? { ref.originalImageID }
 
+    /// ``processors``, each boxed into its identity when they were set.
+    var processorsIdentity: [ProcessorID] { ref.processorsIdentity }
+
+    /// The hash of ``imageID``, computed when it was set.
+    var idHash: Int { ref.idHash }
+
+    /// The hash of ``originalImageID``, computed once.
+    var originalIDHash: Int { ref.originalIDHash }
+
     static var _containerInstanceSize: Int { class_getInstanceSize(Container.self) }
 }
 
@@ -510,9 +519,23 @@ extension ImageRequest {
         var scale: Float = 1.0
 
         // It is stored partially for performance reasons (`absoluteString` can be expensive to compute)
-        var originalImageID: String?
-        var customImageID: String?
-        var processors: [any ImageProcessing]
+        let originalImageID: String?
+        var customImageID: String? {
+            didSet { idHash = Container.makeIDHash(customImageID ?? originalImageID) }
+        }
+        var processors: [any ImageProcessing] {
+            didSet { processorsIdentity = Container.makeIdentity(processors) }
+        }
+
+        // Derived when the fields above are set, so that the keys the pipeline
+        // builds for the request don't derive them again: hashing an ID walks
+        // the string, and comparing processors boxes each of them on both
+        // sides. Eager rather than lazy: the container is only mutated while
+        // uniquely referenced, so there is nothing to synchronize.
+        private(set) var processorsIdentity: [ProcessorID]
+        private(set) var idHash: Int
+        let originalIDHash: Int
+
         var userInfo: [UserInfoKey: any Sendable]?
         var thumbnail: ThumbnailOptions?
 
@@ -522,6 +545,10 @@ extension ImageRequest {
             self.priority = priority
             self.options = options
             self.originalImageID = originalImageID
+            self.processorsIdentity = Container.makeIdentity(processors)
+            let idHash = Container.makeIDHash(originalImageID)
+            self.idHash = idHash
+            self.originalIDHash = idHash
         }
 
         /// Creates a copy.
@@ -535,6 +562,21 @@ extension ImageRequest {
             self.customImageID = ref.customImageID
             self.scale = ref.scale
             self.thumbnail = ref.thumbnail
+            self.processorsIdentity = ref.processorsIdentity
+            self.idHash = ref.idHash
+            self.originalIDHash = ref.originalIDHash
+        }
+
+        private static func makeIdentity(_ processors: [any ImageProcessing]) -> [ProcessorID] {
+            processors.isEmpty ? [] : processors.map(ProcessorID.init)
+        }
+
+        // `init` and both observers must agree, or a request whose `imageID`
+        // is reset would no longer find its own cache entries.
+        private static func makeIDHash(_ id: String?) -> Int {
+            var hasher = Hasher()
+            hasher.combine(id)
+            return hasher.finalize()
         }
     }
 

--- a/Sources/Nuke/Internal/ImageRequestKeys.swift
+++ b/Sources/Nuke/Internal/ImageRequestKeys.swift
@@ -11,7 +11,7 @@ final class MemoryCacheKey: Hashable, Sendable {
     private let imageId: String?
     private let scale: CGFloat
     private let thumbnail: ImageRequest.ThumbnailOptions?
-    private let processors: [any ImageProcessing]
+    private let processors: [ProcessorID]
     private let _hashValue: Int
 
     init(customKey: String) {
@@ -31,10 +31,10 @@ final class MemoryCacheKey: Hashable, Sendable {
         self.imageId = request.imageID
         self.scale = request.scale
         self.thumbnail = request.thumbnail
-        self.processors = request.processors
+        self.processors = request.processorsIdentity
 
         var hasher = Hasher()
-        hasher.combine(imageId)
+        hasher.combine(request.idHash)
         hasher.combine(scale)
         hasher.combine(thumbnail)
         hasher.combine(processors.count)
@@ -56,15 +56,15 @@ final class MemoryCacheKey: Hashable, Sendable {
 final class TaskLoadImageKey: Hashable, Sendable {
     private let loadKey: TaskFetchOriginalImageKey
     private let options: ImageRequest.Options
-    private let processors: [any ImageProcessing]
+    private let processors: [ProcessorID]
     // Computed once: the pool hashes a key on lookup, on insert, and again when
-    // the task is disposed, and hashing the fields walks the image ID.
+    // the task is disposed.
     private let _hashValue: Int
 
     init(_ request: ImageRequest) {
         self.loadKey = TaskFetchOriginalImageKey(request)
         self.options = request.options
-        self.processors = request.processors
+        self.processors = request.processorsIdentity
 
         var hasher = Hasher()
         hasher.combine(loadKey)
@@ -129,7 +129,7 @@ struct TaskFetchOriginalDataKey: Hashable {
         }
 
         var hasher = Hasher()
-        hasher.combine(imageId)
+        hasher.combine(request.originalIDHash)
         hasher.combine(cachePolicy)
         hasher.combine(allowsCellularAccess)
         self._hashValue = hasher.finalize()

--- a/Sources/Nuke/Processing/ImageProcessing.swift
+++ b/Sources/Nuke/Processing/ImageProcessing.swift
@@ -110,6 +110,25 @@ public enum ImageProcessingError: Error, CustomStringConvertible, Sendable {
     public var description: String { "Unknown" }
 }
 
+/// A processor's ``ImageProcessing/hashableIdentifier``, boxed once.
+///
+/// Asking a `Hashable` processor for its `hashableIdentifier` converts it to
+/// `AnyHashable`, which looks up the conformance at runtime, and comparing two
+/// `[any ImageProcessing]` does that for every element on both sides. The
+/// memory cache compares processors on every hit, so a request boxes them
+/// once, when they are set, and its keys compare these instead.
+struct ProcessorID: Hashable, Sendable {
+    // `AnyHashable` erases the `Sendable` conformance of whatever it wraps.
+    // Here it wraps what a processor returned – by default the processor
+    // itself or its identifier, both `Sendable` – and the keys carry it across
+    // isolation domains. It's immutable, so a lock would protect nothing.
+    nonisolated(unsafe) let value: AnyHashable
+
+    init(_ processor: any ImageProcessing) {
+        self.value = processor.hashableIdentifier
+    }
+}
+
 func == (lhs: [any ImageProcessing], rhs: [any ImageProcessing]) -> Bool {
     if lhs.isEmpty && rhs.isEmpty { return true }
     guard lhs.count == rhs.count else { return false }

--- a/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
@@ -59,6 +59,34 @@ struct ImagePipelinePerformanceTests {
     }
 
     @Test
+    func memoryHitPerformanceWithProcessor() async {
+        let imageCache = ImageCache()
+        let pipeline = makePipeline { $0.imageCache = imageCache }
+        let resize = ImageProcessors.Resize(width: 320)
+        let requests = (0..<5000).map {
+            ImageRequest(url: URL(string: "http://test.com/\($0)"), processors: [resize])
+        }
+        // Small enough for every entry to stay in the cache. The cache charges
+        // `Test.container` 1.2 MB, and 5000 of those evict each other, which
+        // times the load path instead of the hit.
+        let container = ImageContainer(image: Test.rgbImage(width: 8, height: 8))
+        for request in requests {
+            pipeline.cache[request] = container
+        }
+        #expect(imageCache.totalCount == requests.count)
+        await measure {
+            await withTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        _ = try? await pipeline.image(for: request)
+                    }
+                }
+            }
+        }
+        #expect(imageCache.totalCount == requests.count)
+    }
+
+    @Test
     func memoryHitPerformanceWithDiagnostics() async {
         let pipeline = makePipeline {
             $0.imageCache = ImageCache()

--- a/Tests/NukeTests/ImageRequestTests.swift
+++ b/Tests/NukeTests/ImageRequestTests.swift
@@ -112,6 +112,39 @@ struct ImageRequestCacheKeyTests {
         let rhs = ImageRequest(url: Test.url, processors: lhs.processors)
         assertHashableEqual(MemoryCacheKey(lhs), MemoryCacheKey(rhs))
     }
+
+    @Test func changingProcessorsChangesTheKey() {
+        var request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        let key = MemoryCacheKey(request)
+
+        request.processors = [MockImageProcessor(id: "2")]
+
+        #expect(MemoryCacheKey(request) != key)
+        assertHashableEqual(MemoryCacheKey(request), MemoryCacheKey(ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "2")])))
+    }
+
+    @Test func changingProcessorsOfCopyDoesNotChangeOriginalKey() {
+        let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        let key = MemoryCacheKey(request)
+
+        var copy = request
+        copy.processors = []
+
+        #expect(MemoryCacheKey(copy) != key)
+        assertHashableEqual(MemoryCacheKey(request), key)
+        assertHashableEqual(MemoryCacheKey(copy), MemoryCacheKey(ImageRequest(url: Test.url)))
+    }
+
+    @Test func resettingImageIDRestoresTheKey() {
+        var request = ImageRequest(url: Test.url)
+        let key = MemoryCacheKey(request)
+
+        request.imageID = "custom"
+        #expect(MemoryCacheKey(request) != key)
+
+        request.imageID = nil
+        assertHashableEqual(MemoryCacheKey(request), key)
+    }
 }
 
 @Suite(.timeLimit(.minutes(5)))
@@ -215,7 +248,7 @@ struct ImageRequestImageIdTests {
     }
 
     @Test(.disabled()) func memoryLayout() {
-        #expect(ImageRequest._containerInstanceSize == 104)
+        #expect(ImageRequest._containerInstanceSize == 128)
 
         #expect(MemoryLayout<ImageRequest.ThumbnailOptions>.size == 9)
         #expect(MemoryLayout<ImageRequest.ThumbnailOptions>.stride == 12)


### PR DESCRIPTION
Stacked on #967 – merge after it.

Every memory cache lookup compares the request's processors with the stored key's, and `[any ImageProcessing] ==` asked each processor on both sides for its `hashableIdentifier`. For a `Hashable` processor that converts it to `AnyHashable` – a runtime conformance lookup and cast (`swift_conformsToProtocol`, `tryCast`), not a compile-time conversion. Reading a request with one `ImageProcessors.Resize` from the cache in a loop, `_convertToAnyHashable` was 36% of the Time Profiler samples and the comparison closure another 25%. The keys also hashed the image ID string every time one was built, and the pipeline builds four keys per request.

### Changes

- `ImageRequest` boxes each processor's `hashableIdentifier` once, into a `ProcessorID`, when the processors are set. `MemoryCacheKey` and `TaskLoadImageKey` store and compare `[ProcessorID]`.
- It also hashes `imageID` and the original image ID when they're set. `MemoryCacheKey` and `TaskFetchOriginalDataKey` combine the stored hash instead of walking the string.
- The derived fields are computed eagerly, in `init` and in `didSet`: the container is only ever mutated while uniquely referenced, so they need no synchronization.
- New tests check the key after the processors change, after a copy's processors change, and after `imageID` is set and reset.

### Measurements

18-core Apple M5 Max, macOS 26.6.2, Xcode 26.5. #967 and this branch alternate run by run, and the side that runs first alternates by round; 5 rounds, median of the per-run averages, and the Δ of each round. Every cache benchmark stores small images and asserts that no entry is evicted, so a hit is a hit.

**Release rig** – one `ImageProcessors.Resize(width: 320)` where a processor is used. "Another request" reads through an equal `ImageRequest` built separately from the one that stored the image, the way a view builds its own; "same request" reuses the stored one, so the keys share the processors array.

| Benchmark | #967 | This PR | Δ | Rounds |
|---|---|---|---|---|
| Cache read, 1 resize, another request | 299 ns | 149 ns | **−50%** | −47, −52, −49, −52, −50 |
| Cache read, 1 resize, same request | 301 ns | 77 ns | **−74%** | −74, −74, −74, −75, −82 |
| Cache read, no processors, another request | 108 ns | 81 ns | −26% | −25, −27, −25, −25, −26 |
| 5000 `image(for:)` cache hits, 1 resize, other requests | 9.61 ms | 8.37 ms | −13% | −14, −12, −16, −2, −12 |
| 5000 `image(for:)` cache hits, no processors, other requests | 8.40 ms | 8.17 ms | −2.8% | −3.5, −2.9, −8.6, +3.8, −1.9 |
| Prefetch 5000 already-cached, 1 resize | 1.85 ms | 0.71 ms | −62% | −61, −63, −61, −62, −62 |
| Prefetch start + stop, no processors | 952 ns | 946 ns | −0.7% | −2.1, 0.0, −0.7, −0.7, −0.7 |
| `ImageRequest(url:)` | 77 ns | 117 ns | +51% | +55, +54, +62, +50, +49 |
| `ImageRequest(url:processors:)`, 1 resize | 76 ns | 203 ns | +167% | +155, +167, +164, +162, +170 |
| New request + one cache read, no processors | 180 ns | 199 ns | +10% | +10, +16, +11, +8, +8 |
| New request + one cache read, 1 resize | 418 ns | 408 ns | −2.5% | −3.5, −3.4, −1.6, −4.6, −6.0 |

The first, third, fourth, and fifth rows come from a second session, after the "another request" benchmark was added; the same-request read reproduced there at −74%, and the last row at −2.3% with its sign flipping, so call that one even. Without processors, pipeline hits and prefetching are a wash. The changelog's 2× is the first row.

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel. `memoryHitPerformanceWithProcessor` is this PR's first commit and asserts that all 5000 entries stay cached. `memoryHitPerformance` stores 1.2 MB images, so most of its requests load rather than hit.

| Test | #967 | This PR | Δ | Rounds |
|---|---|---|---|---|
| `memoryHitPerformanceWithProcessor` | 13.25 ms | 11.22 ms | **−15%** | −16.4, −16.5, −11.0, −11.5, −18.4 |
| `memoryHitPerformance` | 11.85 ms | 11.74 ms | −0.9% | +0.8, −1.7, +4.2, +1.2, −1.7 |

**Size and allocations** – `class_getInstanceSize`, `malloc_size`, allocations counted with `malloc_logger`, heap growth per retained request

| | #967 | This PR |
|---|---|---|
| `ImageRequest.Container` instance / malloc block | 104 / 112 B | 128 / 128 B |
| Allocations, `ImageRequest(url:)` | 1 | 1 |
| Allocations, `ImageRequest(url:processors:)` | 1 | 2 |
| Heap per request: no processors / 1 resize / 2 processors | 112 / 112 / 112 B | 128 / 208 / 240 B |
| Allocations per cache read | 1 | 1 |

**Time Profiler**, reading 5000 cached requests with one resize for 8 s: on #967, `_convertToAnyHashable` is 36% of the samples, the `==` closure 25%, and `AnyHashable` frames 60% inclusive. None of them is sampled on this branch, where `Hasher` (16%) and the dictionary probe (12%) lead.

### Trade-offs

- Work moves from the keys to request construction: `ImageRequest(url:)` pays ~40 ns for the ID hash, and a request with one `Resize` ~130 ns for the box and its array. The pipeline builds four keys per request (`TaskLoadImageKey`, `TaskFetchOriginalImageKey`, `TaskFetchOriginalDataKey`, `MemoryCacheKey`) and a hit compares against the stored key, so a request that is loaded, or read more than once, comes out ahead. A request built for a single cache read and thrown away breaks even with a processor and pays 19 ns (+10%) without one.
- A request with processors holds a second heap block, the `[ProcessorID]` (+96 B for one `Resize`), and every container is 24 B larger (+16 B of malloc).
- The sub-request `TaskLoadImage` creates for each processor in a chain boxes the remaining processors again: 80 → 174 ns, on the load path, next to the processing itself.
- `ProcessorID` adds one unchecked `Sendable`: its only stored property, an `AnyHashable`, is `nonisolated(unsafe)`. `AnyHashable` erases the `Sendable` conformance every `ImageProcessing` already has, and the keys carry these values across isolation domains. The value is immutable, so the alternative – a lock around a value that is already `Sendable` – would cost time and protect nothing.
- A processor's `hashableIdentifier` is read when the processors are set rather than on every comparison. Only a processor whose identifier changes after it's added to a request – which takes an `@unchecked Sendable` class – could tell.
- The key hashes still count the processors rather than hash them. Hashing each `ProcessorID` cost 11–18 ns per key and paid off only when two sizes of one URL are both cached (88 instead of 124 ns per read); single-size reads and pipeline hits were slower with it in every round.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO` – 1094 passed, 3 skipped, with `-skip-testing:` on `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`; 1098 in all, #967's suite plus the three new tests. Without the skip, that test's known ThreadSanitizer abort – a race inside the test mock `MockProgressiveDataLoader`, which reproduces on `main` – was the only failure.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 tests pass.
3. `NukePerformanceTests` builds with the same 98 warnings as #967, none in the changed files; `swiftlint` reports nothing new.
