### PR TITLE
Don't start a task that was cancelled before the pipeline got to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
-- `ImageTask/cancel()` no longer starts a task the pipeline hasn't started yet, 3.7× faster to create and cancel a task – https://github.com/kean/Nuke/pull/973
+- Creating and immediately cancelling an `ImageTask` is 3.7× faster – https://github.com/kean/Nuke/pull/973
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
+- `ImageTask/cancel()` no longer starts a task the pipeline hasn't started yet, 3.7× faster to create and cancel a task – https://github.com/kean/Nuke/pull/973
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -110,6 +110,11 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
         /// The priority of the task.
         public internal(set) var priority: ImageRequest.Priority = .normal
 
+        /// Set when the pipeline gets to the task, under the same lock as
+        /// `isCancelled`, so a cancellation that finds it `false` can leave the
+        /// task to the pipeline instead of hopping to its actor.
+        var isStarted = false
+
         /// The download progress. Contains zeros until the download starts and
         /// the total resource size is known.
         public internal(set) var progress = Progress(completed: 0, total: 0)
@@ -280,15 +285,17 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     /// The method is thread-safe and calling it more than once, or after the
     /// task has already finished, has no effect.
     public func cancel() {
-        let didChange: Bool = _status.withLock {
+        let isRunning: Bool = _status.withLock {
             let didChange = !$0.isCancelled && $0.result == nil
             $0.isCancelled = true
-            return didChange
+            return didChange && $0.isStarted
         }
         // Reaching the pipeline requires a hop to its actor, which then
         // unsubscribes the task and tears down the work no one else needs,
-        // so make sure it happens at most once.
-        guard didChange else { return }
+        // so make sure it happens at most once. A task the pipeline hasn't
+        // started doesn't need one: the pipeline checks `isCancelled` before
+        // it starts the task, and finishes it without starting any work.
+        guard isRunning else { return }
         Task { @ImagePipelineActor in
             self.pipeline?.imageTaskCancelCalled(self)
         }
@@ -314,6 +321,20 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     /// the lock and the actor hop used by the public `cancel()` method.
     @ImagePipelineActor func _cancelTask() {
         pipeline?.imageTaskCancelCalled(self)
+    }
+
+    /// Records that the pipeline is starting the task, and returns `false` if
+    /// the task was cancelled first, in which case it must not start.
+    ///
+    /// It takes the same lock as ``cancel()``, so every cancellation lands on
+    /// exactly one side of it: before, and the pipeline doesn't start the task,
+    /// or after, and ``cancel()`` finds it started and hops to the actor to
+    /// tear it down.
+    @ImagePipelineActor func _markStarted() -> Bool {
+        _status.withLock {
+            $0.isStarted = true
+            return !$0.isCancelled
+        }
     }
 
     /// Gets called when the task is cancelled either by the user or by an

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -205,6 +205,11 @@ public final class ImagePipeline: Sendable {
         guard !isInvalidated else {
             return task._process(.error(.pipelineInvalidated))
         }
+        guard task._markStarted() else {
+            // `cancel()` doesn't hop to the actor for a task that hasn't started,
+            // so nothing gets started here just to be torn down.
+            return task._cancel()
+        }
         if let startedAt {
             task._diagnostics?.didStart(at: startedAt)
         }

--- a/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
@@ -112,6 +112,23 @@ struct ImagePipelinePerformanceTests {
             }
         }
     }
+
+    @Test
+    func cancelImmediatelyPerformance() async {
+        let pipeline = makePipeline()
+        let requests = (0..<5000).map { ImageRequest(url: URL(string: "http://test.com/\($0)")) }
+        await measure {
+            await withTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        let task = pipeline.imageTask(with: request)
+                        task.cancel()
+                        _ = try? await task.response
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Never has the data, so every iteration downloads it again.

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineDiagnosticsTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineDiagnosticsTests.swift
@@ -341,6 +341,25 @@ struct ImagePipelineDiagnosticsTests {
         }
     }
 
+    @Test @ImagePipelineActor func cancellationBeforeTheTaskStartsIsRecorded() async throws {
+        // GIVEN a task cancelled while the test holds the actor, so the
+        // pipeline can't have started it yet
+        let task = pipeline.imageTask(with: Test.request)
+        task.cancel()
+
+        // WHEN
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
+
+        // THEN
+        let metrics = try #require(task.metrics)
+        #expect(metrics.outcome == .cancelled)
+        #expect(metrics.startedAt == nil)
+        #expect(metrics.rootJobID == nil)
+        #expect(metrics.jobs.isEmpty)
+    }
+
     @Test func labelIsRecorded() async throws {
         // GIVEN
         var request = Test.request

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
@@ -101,6 +101,47 @@ struct ImagePipelineTaskDelegateTests {
         ])
     }
 
+    /// The pipeline starts a task in a hop to its actor. A task cancelled before
+    /// that hop runs is finished there, without being started.
+    @Test @ImagePipelineActor func cancellationBeforeTheTaskStartsSkipsTheStart() async {
+        // Given a task cancelled while the test holds the actor, so the
+        // pipeline can't have started it yet
+        let task = pipeline.imageTask(with: Test.request)
+        task.cancel()
+
+        // When
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
+
+        // Then
+        #expect(delegate.events == [
+            ImageTaskEvent.created,
+            .cancelled
+        ])
+        #expect(dataLoader.createdTaskCount == 0)
+        #expect(pipeline.taskCount == 0)
+    }
+
+    /// A task cancelled from `imageTaskCreated` is cancelled before the
+    /// pipeline gets to it, so it reports no start either.
+    @Test @ImagePipelineActor func cancellationFromTaskCreatedSkipsTheStart() async {
+        // Given
+        delegate.onTaskCreated = { $0.cancel() }
+
+        // When
+        let task = pipeline.imageTask(with: Test.request)
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
+
+        // Then
+        #expect(delegate.events == [
+            ImageTaskEvent.created,
+            .cancelled
+        ])
+    }
+
     @Test func errorCompletionEventDelivered() async throws {
         // GIVEN a data loader that fails
         let error = URLError(.notConnectedToInternet)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
@@ -72,6 +72,42 @@ struct ImagePipelineTaskLifetimeTests {
         #expect(await pipeline.taskCount == 0)
     }
 
+    /// `cancel()` races the pipeline, which is starting the task on its actor,
+    /// for the task's lock. Whichever side gets it first, the task has to
+    /// finish and leave the list.
+    @Test func cancellationRacingTheStartIsNeverLost() async {
+        // Given a data loader that never finishes, so only the cancellation
+        // can finish a task
+        dataLoader.isSuspended = true
+
+        // When
+        let pipeline = self.pipeline
+        let cancelledCount = await withTaskGroup(of: Bool.self) { group in
+            for index in 0..<500 {
+                group.addTask {
+                    let task = pipeline.imageTask(with: URL(string: "https://example.com/image-\(index).jpeg")!)
+                    if index % 2 == 0 {
+                        await Task.yield()
+                    }
+                    task.cancel()
+                    do {
+                        _ = try await task.response
+                        return false
+                    } catch ImagePipeline.Error.cancelled {
+                        return true
+                    } catch {
+                        return false
+                    }
+                }
+            }
+            return await group.reduce(0) { $0 + ($1 ? 1 : 0) }
+        }
+
+        // Then
+        #expect(cancelledCount == 500)
+        #expect(await pipeline.taskCount == 0)
+    }
+
     // MARK: - Synchronous Completion
 
     @Test func taskIsRemovedOnMemoryCacheHit() async throws {


### PR DESCRIPTION
`ImageTask.cancel()` reaches the pipeline with a `Task { @ImagePipelineActor in … }`, and `makeStartedImageTask` starts every task with a hop of its own. At the same priority the actor runs the two hops in the order they were enqueued, so a task cancelled right after it was created was always started first: `startImageTask` built its task graph – `TaskLoadImage`, `TaskFetchOriginalImage`, `TaskFetchOriginalData`, a data loading queue operation – and the cancel hop then tore it down. Creating and cancelling a task cost 3.9 µs, to load nothing.

`startImageTask` now records that it is starting the task, under the lock `cancel()` already takes, and `cancel()` hops to the actor only when it finds the task started. A cancellation that lands first is picked up by `startImageTask`, which finishes the task as cancelled without creating any work. Every cancellation lands on exactly one side of that lock, so none is lost and none is delivered twice. Cancelling a task that has started works as before.

The first commit adds `cancelImmediatelyPerformance`, so the gain is reproducible from the repo.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. `main` and this branch alternate run by run, and the side that runs first alternates by round; median of the per-run averages, and the Δ of each round.

**Release rig** – mock data loader, `ImageDecoders.Empty`, 5000 requests per sample; 11 rounds

| Benchmark | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| Create and cancel 5000 tasks | 19.36 ms | 5.21 ms | **−73%** | −71.2, −71.0, −71.0, −74.3, −75.2, −74.0, −74.9, −75.0, −60.1, −71.2, −75.4 |
| 5000 `image(for:)` in cancelled Swift tasks | 19.44 ms | 7.65 ms | **−61%** | −58.8, −60.2, −62.5, −64.6, −66.4, −60.8, −61.6, −61.3, −42.6, −62.1, −60.3 |
| Cancel 5000 started tasks, await each response | 10.67 ms | 10.72 ms | +0.5% | −1.8, +1.8, −0.2, +4.7, −0.7, +1.0, +2.2, +1.2, +0.5, −4.4, −1.1 |
| Cancel 5000 started tasks, then drain the actor | 12.63 ms | 12.64 ms | +0.1% | +0.2, +3.0, +1.5, +0.9, +2.0, +2.0, +0.2, +1.5, −0.6, +0.3, −1.6 |
| 5000 memory cache hits, all resident, concurrent | 9.41 ms | 9.36 ms | −0.5% | +1.0, −3.6, +2.0, +1.2, −3.1, +0.1, +1.3, +0.7, +6.4, −3.5, +0.1 |
| 5000 memory cache hits, all resident, one at a time | 52.13 ms | 52.84 ms | +1.4% | −4.2, −0.6, +1.3, +4.1, +2.6, +1.0, +3.8, −0.9, +1.6, +2.4, −2.3 |
| `asyncAwait` | 47.74 ms | 47.67 ms | −0.1% | −3.9, −0.7, +0.8, −0.5, −0.9, +0.4, +1.1, +1.5, +0.0, +0.9, −0.4 |
| `memoryHit` | 9.06 ms | 9.13 ms | +0.8% | +14.3, +3.6, +3.8, +2.7, −4.2, −4.7, −0.1, +7.4, +3.5, +4.9, −3.0 |
| `asyncImageTask` | 47.75 ms | 48.23 ms | +1.0% | −0.0, +10.8, +2.4, +1.3, −0.3, +0.8, −0.0, −4.4, +2.0, +2.8, +0.3 |

The started-task rows park every task behind a suspended loader before the clock starts, so they time only the path that still hops to the actor. They, the resident hits, and the controls move inside the noise, with the sign flipping between rounds. An earlier 7-round session measured create-and-cancel at −73.7%, faster in every round; its started-task rows still slept 200 ms before each sample, which made the samples swing by a third, and read +3.0% and +3.7% with the sign flipping.

**Allocations, tasks, and lock acquisitions per row** – release rig; heap allocations through `malloc_logger`, and `swift_task_create` and `os_unfair_lock_lock` calls through an interposed library; 5000 rows, median of 3. Each row includes the task group child that runs it.

| Row | Allocations | Tasks | Locks |
|---|---|---|---|
| Create and cancel | 50.02 → **11.01** | 3.00 → **2.00** | 9.01 → **6.00** |
| Cancel a started task | 9.00 → 9.01 | 2.00 → 2.00 | 4.01 → 4.01 |
| Load (control) | 79.43 → 79.35 | 5.00 → 5.00 | 37.00 → 38.00 |
| Memory cache hit (control) | 21.00 → 21.00 | 2.00 → 2.00 | 6.00 → 7.00 |

**Time Profiler** – `hotcancel`, create-and-cancel in a loop for 8 s; self time attributed to the nearest Nuke frame

| | `main` | This PR |
|---|---|---|
| Tasks created and cancelled | 2.20 M | 9.10 M |
| `ImageTask.cancel()` and its closures | 6.64% | 0.47% |
| `TaskPool.publisherForKey`, `AsyncTask.terminate`, `imageTaskCancelCalled`, `TaskFetchOriginalData.start`, `startImageTask`, `TaskQueue.Operation.cancel`, `LinkedList.remove` | 11.9% | 0.02% |

On this branch only `startImageTask` of those is sampled at all. The loop's time goes to creating the tasks: `makeStartedImageTask` (10.7%, which spawns the start `Task`), `TaskGroup.addTask` (7.0%), and `ImageTask` teardown.

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel; "before" is the first commit of this PR; 5 rounds

| Test | Before | After | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `cancelImmediatelyPerformance` | 31.28 ms | 5.48 ms | **−82%** | −82.4, −81.8, −82.3, −83.3, −83.3 |
| `asyncImageTaskPerformance` (control) | 65.71 ms | 65.63 ms | −0.1% | +0.2, +2.9, −0.2, −1.1, −0.5 |

### Behaviour

A task cancelled before the pipeline gets to it now reports `imageTaskCreated` and then `.finished(.failure(.cancelled))`, without `imageTaskDidStart`. The sequence isn't new. Recorded with a delegate, the loader suspended:

| How the task is cancelled | `main` | This PR |
|---|---|---|
| From `imageTaskCreated` | created → cancelled (500 of 500) | created → cancelled |
| Right after `imageTask(with:)` | created → started → cancelled (500 of 500) | created → cancelled |
| Both hops queued behind a busy actor, created at `.utility`, cancelled at `.userInitiated` | created → cancelled (200 of 200) | created → cancelled |
| Both hops queued behind a busy actor, same priority | created → started → cancelled (200 of 200) | created → cancelled |

`main` already produces it whenever the cancellation reaches the actor before the start; this PR makes it the outcome of every early cancellation:

- **Delegate.** `imageTaskDidStart` is documented as "Gets called when the task is started by the pipeline", not as a callback every task gets.
- **Diagnostics.** The task's `metrics` records the outcome `.cancelled`, no `startedAt` or `rootJobID`, and no jobs – what `ImageTask.Metrics` documents for a task "cancelled before" it started, and what `main` records when the cancellation wins. No signposts are emitted for it, since no `TaskFetchOriginalData` is created.
- **Priority.** The terminal event, and the `response` it resumes, come from the start hop, at the priority the task was created with, instead of from the cancel hop at the priority of the caller – again as on `main` when the cancellation wins.
- **Lifetime.** No cancel `Task` retains the `ImageTask`, so it can be released as soon as the start hop is done.

Unchanged: cancelling a task that has started; priority updates; a task cancelled early on an invalidated pipeline, which still fails with `.pipelineInvalidated` because the new check follows the invalidation check; and the prefetcher, which cancels on the actor with `_cancelTask()` and is still handled by the `_isFinished` check.

### Trade-offs

- A started task still spawns a `Task` per `cancel()`. Such a row costs 2.1 µs in the rig, and a bare `Task { @ImagePipelineActor in }` accounts for 339 ns of it (50,000 tasks, 17 ms). Batching the hops, like the data loading inbox does, would save that only for cancellations that arrive while a delivery is still pending, and it would run each one at the priority of the batch it joined: a `.userInitiated` cancellation could wait behind a `.utility` batch, which nothing on `main` produces. Not worth it for at most 16% of that row.
- Starting a task takes its lock once more: 6 → 7 acquisitions per memory cache hit, 37 → 38 per load. Folding the flag into the priority read `startImageTask` already makes removes the extra one, but moves that read before `imageTaskDidStart`, where a delegate can still change the priority. Interleaved in the same session, the fold measured the same as this PR – resident hits −0.8% concurrent and +1.4% one at a time, against −0.5% and +1.4% – so the read stays where it is.
- `ImageTask.Status` gains an internal `Bool`, which lands in padding: `MemoryLayout<ImageTask.Status>` is 128 B, size and stride, before and after.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` – the only failure is the known ThreadSanitizer abort inside the test mock `MockProgressiveDataLoader`, in `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`, which fails on `main` too. With `-skip-testing:` on it, 1096 tests pass and 3 are skipped as on `main`: `main`'s 1093, less that one, plus four new tests. Against `main`'s sources, the two that pin the new case fail and the other two pass.
   - `ImagePipelineTaskDelegateTests.cancellationBeforeTheTaskStartsSkipsTheStart` – holds the actor across `imageTask(with:)` and `cancel()`, so the start hop can't run in between; the delegate sees created → cancelled, the loader is never called, and the pipeline retains no task. `main` reports created → started → cancelled.
   - `ImagePipelineTaskDelegateTests.cancellationFromTaskCreatedSkipsTheStart` – a cancellation from `imageTaskCreated` reports created → cancelled, on `main` too.
   - `ImagePipelineDiagnosticsTests.cancellationBeforeTheTaskStartsIsRecorded` – no `startedAt`, root job, or jobs; on `main` the task records three cancelled jobs.
   - `ImagePipelineTaskLifetimeTests.cancellationRacingTheStartIsNeverLost` – 500 tasks cancelled from a task group, half of them after a yield, with the loader suspended so only a cancellation can finish one; all 500 finish cancelled and the pipeline retains none.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 tests pass.
3. The NukeTests build has the same 29 warnings as `main`, and `NukePerformanceTests` the same 102 warning lines; `swiftlint` reports nothing new in the changed files.
