### PR TITLE
Keep ImageTask off the refcount side table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 **Performance**
 
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
+- A memory cache hit is 12% faster – https://github.com/kean/Nuke/pull/974
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -242,7 +242,11 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     /// the recorder. `nil` unless diagnostics are on.
     let _createdAt: TimeInterval?
     private let onEvent: (@Sendable (Event, ImageTask) -> Void)?
-    @ImagePipelineActor private weak var pipeline: ImagePipeline?
+    /// Retained until the task finishes: a weak reference costs a side-table
+    /// load on every event. The work a running task waits for retains the
+    /// pipeline too, and a finished task releases it, so a task the app keeps
+    /// doesn't keep the pipeline.
+    @ImagePipelineActor private var pipeline: ImagePipeline?
 
     /// Set once during creation, before the task is handed to anyone, then
     /// read-only from the `response` getter, so it needs no synchronization.
@@ -254,7 +258,10 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor var _diagnostics: ImagePipeline.Diagnostics.TaskRecord?
-    @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
+    /// Retains the node that retains the task: `removeTask` breaks the cycle
+    /// when it takes the task off the list. A weak reference would give every
+    /// node a side table.
+    @ImagePipelineActor var _node: LinkedList<ImageTask>.Node?
 
     init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, isPrefetch: Bool = false, pipeline: ImagePipeline, onEvent: (@Sendable (Event, ImageTask) -> Void)?, createdAt: TimeInterval? = nil) {
         self.taskId = taskId
@@ -381,7 +388,13 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
         }
 
         onEvent?(event, self)
-        pipeline?.imageTask(self, didProcessEvent: event, isDataTask: isDataTask)
+        guard let pipeline else { return }
+        if case .finished = event {
+            // The last call that needs the pipeline: cancelling a finished
+            // task, or changing its priority, has nothing left to do.
+            self.pipeline = nil
+        }
+        pipeline.imageTask(self, didProcessEvent: event, isDataTask: isDataTask)
     }
 
     // MARK: Identifiable

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -218,8 +218,8 @@ public final class ImagePipeline: Sendable {
         task._node = tasks.append(task)
         imageTaskDidStart(task, isDataTask: isDataTask)
         onTaskStarted?(task)
-        task._subscription = worker.subscribe(priority: task.priority.taskPriority, subscriber: task) { [weak task] in
-            task?._process($0)
+        task._subscription = worker.subscribe(priority: task.priority.taskPriority, subscriber: task) {
+            task._process($0)
         }
     }
 
@@ -234,7 +234,7 @@ public final class ImagePipeline: Sendable {
     private func removeTask(_ task: ImageTask) {
         guard let node = task._node else { return }
         tasks.remove(node)
-        task._node = nil
+        task._node = nil // Break the retain cycle
     }
 
     func imageTaskUpdatePriorityCalled(_ task: ImageTask, priority: ImageRequest.Priority) {

--- a/Sources/Nuke/Tasks/AsyncTask.swift
+++ b/Sources/Nuke/Tasks/AsyncTask.swift
@@ -18,15 +18,30 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
 
     private final class Subscription {
         let closure: (Event) -> Void
-        // The protocol and not `AnyObject`: walking the subscribers is then a
-        // witness call rather than a conditional cast, which has the runtime
-        // search the protocol conformance tables.
-        weak var subscriber: (any ImageTaskSubscribers)?
+        /// An image task is retained. A weak reference would move its reference
+        /// count to a side table for the rest of its life, which puts every
+        /// retain and release of it on the slow path. The task retains the job
+        /// back through its `TaskSubscription`, and the cycle ends with either
+        /// side: the task unsubscribes, or the job sends the terminal event.
+        let imageTask: ImageTask?
+        /// A job is not: it retains its dependency until it is deallocated
+        /// rather than until it finishes. The protocol and not `AnyObject`:
+        /// walking the subscribers is then a witness call rather than a
+        /// conditional cast, which has the runtime search the protocol
+        /// conformance tables.
+        weak var job: (any ImageTaskSubscribers)?
         var priority: TaskPriority
+
+        var subscriber: (any ImageTaskSubscribers)? { imageTask ?? job }
 
         init(closure: @escaping (Event) -> Void, subscriber: any ImageTaskSubscribers, priority: TaskPriority) {
             self.closure = closure
-            self.subscriber = subscriber
+            if let imageTask = subscriber as? ImageTask {
+                self.imageTask = imageTask
+            } else {
+                self.imageTask = nil
+                self.job = subscriber
+            }
             self.priority = priority
         }
     }
@@ -209,6 +224,13 @@ class AsyncTask<Value: Sendable, Error: Sendable>: AsyncTaskSubscriptionDelegate
             for entry in subscriptions {
                 entry.sub.closure(event)
             }
+        }
+        if isDisposed {
+            // Nothing is sent after the terminal event: release the
+            // subscriptions and the image tasks they retain, which a job that
+            // depends on this one would otherwise keep until it finishes too.
+            inlineSubscription = nil
+            subscriptions = nil
         }
     }
 

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
@@ -174,6 +174,278 @@ struct ImagePipelineTaskLifetimeTests {
         #expect(weakTask == nil)
     }
 
+    @Test func taskIsDeallocatedAfterAsynchronousCompletion() async throws {
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            _ = try await task.response
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(weakTask == nil)
+    }
+
+    @Test func dataTaskIsDeallocatedAfterAsynchronousCompletion() async throws {
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.makeStartedImageTask(with: Test.request, isDataTask: true)
+            weakTask = task
+            _ = try await task.response
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedAfterFailure() async throws {
+        // Given
+        dataLoader.results[Test.url] = .failure(URLError(.unknown) as NSError)
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await #expect(throws: (any Error).self) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedAfterCancellation() async throws {
+        // Given a task waiting for the data
+        dataLoader.isSuspended = true
+        let started = TestExpectation()
+        pipeline.onTaskStarted = { _ in started.fulfill() }
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await started.wait()
+            task.cancel()
+            await #expect(throws: ImagePipeline.Error.cancelled) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedAfterCancellationBeforeStart() async throws {
+        // When the task is cancelled before the pipeline starts it
+        let pipeline = pipeline
+        weak var weakTask: ImageTask?
+        do {
+            let task = await Task { @ImagePipelineActor in
+                let task = pipeline.imageTask(with: Test.request)
+                task._cancelTask()
+                return task
+            }.value
+            weakTask = task
+            await #expect(throws: ImagePipeline.Error.cancelled) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 0)
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedWhenPipelineIsInvalidated() async throws {
+        // Given a task waiting for the data
+        dataLoader.isSuspended = true
+        let started = TestExpectation()
+        pipeline.onTaskStarted = { _ in started.fulfill() }
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await started.wait()
+            pipeline.invalidate()
+            await #expect(throws: ImagePipeline.Error.cancelled) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedWhenStartedOnInvalidatedPipeline() async throws {
+        // Given
+        pipeline.invalidate()
+        await drainPipeline()
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await #expect(throws: ImagePipeline.Error.pipelineInvalidated) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func coalescedTasksAreDeallocated() async throws {
+        // When two tasks wait for the same job
+        weak var weakTask1: ImageTask?
+        weak var weakTask2: ImageTask?
+        do {
+            let (task1, task2) = await withSuspendedDataLoading(for: pipeline, expectedCount: 2) {
+                (pipeline.imageTask(with: Test.request), pipeline.imageTask(with: Test.request))
+            }
+            weakTask1 = task1
+            weakTask2 = task2
+            _ = try await task1.response
+            _ = try await task2.response
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(weakTask1 == nil)
+        #expect(weakTask2 == nil)
+    }
+
+    @Test func cancelledTaskIsDeallocatedWhileTheJobItJoinedIsRunning() async throws {
+        // Given two tasks waiting for the same job, which is held in the queue
+        pipeline.configuration.dataLoadingQueue.isSuspended = true
+
+        // When one of them is cancelled
+        weak var weakTask1: ImageTask?
+        let task2: ImageTask
+        do {
+            let (task1, other) = await withSuspendedDataLoading(for: pipeline, expectedCount: 2) {
+                (pipeline.imageTask(with: Test.request), pipeline.imageTask(with: Test.request))
+            }
+            weakTask1 = task1
+            task2 = other
+            task1.cancel()
+            await #expect(throws: ImagePipeline.Error.cancelled) {
+                try await task1.response
+            }
+        }
+        await drainPipeline()
+
+        // Then it isn't retained by the job the other one still waits for
+        #expect(weakTask1 == nil)
+
+        pipeline.configuration.dataLoadingQueue.isSuspended = false
+        _ = try await task2.response
+        #expect(dataLoader.createdTaskCount == 1)
+    }
+
+    @Test func taskIsDeallocatedWhileTheJobItSharedIsStillRetained() async throws {
+        // Given a task that shares its job with a request that processes the
+        // job's result: the processing job retains the shared job until it
+        // finishes too, and the processing is held back
+        let processed = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        pipeline.configuration.imageProcessingQueue.isSuspended = true
+
+        // When the shared job finishes
+        weak var weakTask: ImageTask?
+        let processedTask: ImageTask
+        do {
+            let (task, other) = await withSuspendedDataLoading(for: pipeline, expectedCount: 2) {
+                (pipeline.imageTask(with: Test.request), pipeline.imageTask(with: processed))
+            }
+            weakTask = task
+            processedTask = other
+            _ = try await task.response
+        }
+        await drainPipeline()
+
+        // Then the finished task isn't retained along with the shared job
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(weakTask == nil)
+
+        pipeline.configuration.imageProcessingQueue.isSuspended = false
+        _ = try await processedTask.response
+    }
+
+    // MARK: - Pipeline Deallocation
+
+    @Test func pipelineIsRetainedUntilRunningTaskFinishes() async throws {
+        // Given a task waiting for the data
+        dataLoader.isSuspended = true
+
+        // When the app releases the pipeline
+        weak var weakPipeline: ImagePipeline?
+        let task: ImageTask
+        do {
+            let pipeline = ImagePipeline {
+                $0.dataLoader = dataLoader
+                $0.imageCache = imageCache
+            }
+            weakPipeline = pipeline
+            let started = TestExpectation()
+            pipeline.onTaskStarted = { _ in started.fulfill() }
+            task = pipeline.imageTask(with: Test.request)
+            await started.wait()
+        }
+        await drainPipeline()
+
+        // Then the running task keeps it alive
+        #expect(weakPipeline != nil)
+
+        // When the task finishes
+        dataLoader.isSuspended = false
+        _ = try await task.response
+        await drainPipeline()
+
+        // Then the pipeline is released even though the app keeps the task
+        #expect(weakPipeline == nil)
+        withExtendedLifetime(task) {}
+    }
+
+    @Test func pipelineIsDeallocatedWhileFinishedTaskIsRetained() async throws {
+        // Given
+        imageCache[Test.request] = Test.container
+
+        // When the app keeps a task after it finished
+        weak var weakPipeline: ImagePipeline?
+        let task: ImageTask
+        do {
+            let pipeline = ImagePipeline {
+                $0.dataLoader = dataLoader
+                $0.imageCache = imageCache
+            }
+            weakPipeline = pipeline
+            task = pipeline.imageTask(with: Test.request)
+            _ = try await task.response
+        }
+        await drainPipeline()
+
+        // Then the task doesn't keep the pipeline alive
+        #expect(weakPipeline == nil)
+        withExtendedLifetime(task) {}
+    }
+
     // MARK: - Events
 
     @Test func startedEventIsDeliveredBeforeFinishedOnMemoryCacheHit() async throws {


### PR DESCRIPTION
Stacked on #971.

Once the runtime forms a weak reference to an object, the object's reference count moves out of its header into a side table – a separate allocation – for the rest of its life, and every later retain and release of it takes the slow path through that table. Every `ImageTask` collected weak references before it did any work: the worker's `Subscription` held it weakly, the closure `startImageTask` subscribes with captured it weakly, and the task held its `LinkedList` node weakly, which gives every node a side table of its own. It also held `ImagePipeline` weakly and loaded that reference on every event. On a memory cache hit that meant two side tables per request, and in a trace of resident hits the weak-reference and side-table machinery took 14.5% of the samples.

None of those references has to be weak. Each points at something that retains the task anyway, or can be released at a point the pipeline already reaches:

- `Subscription` retains an `ImageTask` subscriber. Other subscribers – the jobs that depend on this one – stay weak: a job retains its dependency until it's deallocated rather than until it finishes. The closure `startImageTask` subscribes with captures the task strongly.
- The task retains the job through its `TaskSubscription`, so that's a cycle, and it ends on every path a task can take: cancellation and `invalidate()` unsubscribe, and a job now releases its subscriptions right after it sends the terminal event. Without the release, a finished task would stay alive for as long as another job that depends on its job runs – a request with a processor that shares the original's job, for one. The data-cache walk from #971 and `hasSubscriber(of:)` both run before the terminal event.
- `_node` is strong. `removeTask`, which every finish and cancellation already goes through, breaks the cycle.
- `pipeline` is retained until the task finishes and released with the terminal event. The work a running task waits for retains the pipeline too, so a running task already kept it alive; a finished task the app holds on to still doesn't.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. The release rig uses a mock data loader and `ImageDecoders.Empty`. Its memory cache hits store 8×8 images, so all 5000 entries stay in the cache, which the benchmark asserts before and after timing. In the timed runs #971 and this branch alternate run by run, and the side that runs first alternates by round; median per side, and the Δ of each round.

**Reference counts** – release rig, per request over 5000; weak references counted by interposing the runtime's `swift_weak*` and `swift_unknownObjectWeak*` entry points

| | #971 | This PR |
|---|---|---|
| A finished `ImageTask`'s reference count – after a hit, a download, or a cancellation | side table | inline |
| Side tables formed per memory cache hit | 2 | 0 |
| Weak references formed / loaded / destroyed per hit | 5 / 4 / 5 | 1 / 1 / 2 |
| Side tables formed per download | 6 | 4 |
| Weak references formed / loaded / destroyed per download | 21 / 20 / 21 | 17 / 14 / 18 |

None of the four side tables a download still forms is the task's.

**Allocations per request** – release rig, counted through `malloc_logger`, median of 3

| Configuration | #971 | This PR | Δ |
|---|---|---|---|
| Memory cache hit, `image(for:)` | 17 | 14 | **−3** |
| Memory cache hit, `imageTask(with:).response` | 17 | 14 | −3 |
| Download | 76.0 | 73.0 | −3 |
| 5000 requests over 50 URLs, concurrent | 18.0 | 15.2 | −2.8 |
| Create and cancel | 51 | 48 | −3 |

Two of the three are the side tables. The third is most likely the context of the weakly capturing closure, which a closure that captures one object strongly doesn't allocate. `ImageTask` stays 160 bytes.

**Timing** – release rig, 7 rounds, 10 samples per run

| Benchmark | #971 | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| Memory cache hit, 5000 concurrent | 9.49 ms | 7.65 ms | **−19.4%** | −19.9, −16.4, −20.3, −16.9, −19.2, −16.8, −4.2 |
| Memory cache hit, 20000 in sequence | 41.59 ms | 35.49 ms | **−14.7%** | −12.9, −14.1, −17.8, −15.8, −15.0, −12.9, −15.8 |
| Memory cache hit, 5000 concurrent, pipeline on a side table | 9.19 ms | 8.02 ms | **−12.7%** | −13.2, −16.4, −22.7, −14.3, −14.8, −12.5, −8.3 |
| Memory cache hit, 20000 in sequence, pipeline on a side table | 42.10 ms | 36.10 ms | **−14.2%** | −13.3, −13.4, −21.2, −16.0, −14.1, −10.3, −13.6 |
| Cache reads without an `ImageTask`, 5000 concurrent | 4.64 ms | 4.54 ms | −2.2% | −4.1, +0.9, −4.9, −4.3, +3.9, −1.6, −6.2 |
| `asyncAwait`: 5000 downloads | 47.58 ms | 44.61 ms | −6.2% | −6.0, −6.0, −1.9, −9.6, −6.2, −7.0, −1.9 |
| 5000 downloads through `imageTask(with:)` | 47.63 ms | 44.36 ms | −6.9% | −6.5, −6.2, −7.9, −6.9, −7.5, −5.5, −5.9 |
| 5000 requests over 50 URLs | 25.18 ms | 24.47 ms | −2.8% | −3.2, +0.7, −4.5, −0.6, −2.9, −3.1, +1.8 |
| 5000 requests over 50 URLs, coalescing disabled | 40.84 ms | 38.21 ms | −6.4% | −1.1, −6.3, −5.9, −6.2, −6.9, −8.6, −6.6 |

The first five rows are one session and the rest another. "Pipeline on a side table" forms a weak reference to the pipeline before timing – see Trade-offs. The cache reads are the control: the same task group and lookups on a pipeline no `ImageTask` has touched, and the sign flips in two rounds.

**Time Profiler** – resident memory cache hits in a loop, 8 s, self time as a share of all samples

| Leaf | #971 | This PR |
|---|---|---|
| `doDecrementSlow` | 7.40% | 2.94% |
| `incrementSlow` | 2.40% | 0.00% |
| `formWeakReference` | 1.81% | 0.08% |
| `decrementUnownedShouldFree` | 1.06% | 0.00% |
| `swift_weakDestroy` | 0.98% | 0.03% |
| `swift_weakLoadStrong` | 0.71% | 0.09% |
| The weak-reference and side-table machinery in all | 14.5% | 3.2% |

The loop ran 886 rounds on #971 and 1076 on this branch. On #971, 74% of the self time attributed to `ImageTask.__deallocating_deinit` was `swift_weakDestroy`. Most of the `doDecrementSlow` that's left should be releases that take a count to zero, which go through it with or without a side table.

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel; "before" is the first commit of this PR; 5 rounds

| Test | Before | After | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `memoryHitPerformance` | 12.14 ms | 9.83 ms | **−19.0%** | −18.5, −18.3, −18.4, −21.9, −19.4 |
| `asyncAwaitPerformance` | 66.22 ms | 64.14 ms | −3.1% | −3.3, −1.7, −2.4, −2.9, −3.1 |
| `asyncImageTaskPerformance` | 64.83 ms | 62.34 ms | −3.8% | −2.8, −4.1, −3.9, −4.3, −2.5 |

### Trade-offs

- Part of the gain on a fresh pipeline is the pipeline itself staying off a side table, and that lasts only until something forms a weak reference to it. One place in the pipeline does: `storeImageInDataCache`, when a data cache stores encoded images. Hence the rows with the pipeline on a side table, which isolate the task's share.
- `Subscription` grows by 8 bytes, from 49 to 57, and stays in the 64-byte size class. Its initializer tells an image task from a job with a cast to `ImageTask`, which is `final`.
- Jobs keep their side tables – the operations they schedule reference them weakly as well – and a prefetched task still gets one: `ImagePrefetcher` holds its image task weakly.
- `ImageTask`'s `_status` lock is still a separate allocation. `Mutex` would store it inline but needs iOS 18.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO`, with `-skip-testing:` for `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress` – 1106 pass: #971's 1094 plus 12 new. The skipped test aborts under ThreadSanitizer on a race inside the test mock `MockProgressiveDataLoader`, on `main` too; run on its own on this branch, it passes.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 pass.
3. `ImagePipelineTaskLifetimeTests` – the first commit adds 12 tests, and all 23 in the suite pass against #971's sources as well, so they pin the lifetimes as they are: a task is deallocated after a download, a data task, a failure, a cancellation before or after it starts, `invalidate()`, and a start on an invalidated pipeline; so are two coalesced tasks, a cancelled task while the job it joined still runs, and a finished task while a request with a processor still retains the job they shared. A running task keeps a pipeline the app released alive until it finishes, and a finished task doesn't keep it. Undoing each cycle break fails them: keeping the subscriptions after the terminal event fails one test, keeping the pipeline two, and leaving `_node` set nine.
4. `swiftlint` reports nothing new in the changed files.
