### PR TITLE
Skip the runtime exclusivity checks on the memory cache's state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 - The default `ImagePipeline/Configuration-swift.struct/rateLimiter` rate goes from 80 to 100 requests per second – https://github.com/kean/Nuke/pull/960
 - `ImageTask` and `ImageDecoders/Video` are now `Sendable` instead of `@unchecked Sendable` – https://github.com/kean/Nuke/pull/965
 
+**Performance**
+
+- `ImageCache` lookups are 6% faster – https://github.com/kean/Nuke/pull/975
+
 **Bug Fixes**
 
 - Remove an unused `AVKit` import from `Nuke`, which linked AVKit, AVFoundation, and their dependencies into every app – https://github.com/kean/Nuke/pull/947

--- a/Sources/Nuke/Caching/Cache.swift
+++ b/Sources/Nuke/Caching/Cache.swift
@@ -48,7 +48,7 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
         }
     }
 
-    private var _conf: Configuration {
+    @exclusivity(unchecked) private var _conf: Configuration {
         didSet { _trim() }
     }
 
@@ -64,8 +64,13 @@ final class Cache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendabl
         return map.count
     }
 
-    private var _totalCost = 0
-    private var map = [Key: LinkedList<Entry>.Node]()
+    // These and `_conf` are only accessed under `lock`, so the runtime
+    // exclusivity checks can't catch anything, and they cost a
+    // `swift_beginAccess` on every lookup. Moving the state into the lock's
+    // storage would drop them too, but put `map` on the cache line that
+    // contending threads write the lock word to.
+    @exclusivity(unchecked) private var _totalCost = 0
+    @exclusivity(unchecked) private var map = [Key: LinkedList<Entry>.Node]()
     private let list = LinkedList<Entry>()
     private let lock = OSAllocatedUnfairLock()
     private let memoryPressure: DispatchSourceMemoryPressure


### PR DESCRIPTION
`Cache` – the LRU behind `ImageCache` – keeps its dictionary, total cost and configuration in `var` properties on the class, next to the `OSAllocatedUnfairLock` that guards them. A class property gets dynamic exclusivity enforcement, so every lookup opened an access to `map` with `swift_beginAccess` and closed it with `swift_endAccess`, and every write paid for more on `_totalCost` and `_conf`. The optimizer can't drop them because the accesses span the key's `hash(into:)` and `==`. Reading cached images in a loop, the exclusivity runtime and the thread-local lookups it makes were 1.9% of all samples, 44% of the time attributed to `Cache`.

Every access to those three properties already happens under the lock, so the runtime check has nothing to catch. They're now `@exclusivity(unchecked)`. Nothing else changes, including `Cache`'s layout. One check per hit is left, on `LinkedList.Node.value`, which lives on a separate class.

Keeping the state inside the lock instead – `OSAllocatedUnfairLock<State>`, every access through `withLock` – drops the same calls, and would make `Cache` a checked `Sendable`. I built and measured that too. It's as fast on one or two threads, but under contention it gives the gain back: `OSAllocatedUnfairLock` stores its state in the same allocation as the lock word, 16 bytes before it, so the holder reads `map` from the cache line that waiting threads write to. A copy padded to put the lock word on another line gets the gain back. The numbers are in the second table.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. `main` and the change alternate run by run, and the order rotates by round; median of the per-run averages, Δ, and the number of rounds the change was faster. Some sessions built the change from a separate worktree, identical except for the code comment; their rounds are pooled with this branch's.

**Release rig** – an `ImageCache` with 5000 entries, 8×8 images, all resident (asserted); prebuilt `ImageCacheKey`s. The write loops store an image without a bitmap, so `cost(for:)` doesn't dominate; the thread counts split 1M hits evenly, on `concurrentPerform`.

| Benchmark | `main` | This PR | Δ | Faster rounds |
|---|---|---|---|---|
| 1M hits | 38.10 ms | 35.87 ms | **−5.9%** | 8/8 |
| 1M misses | 37.56 ms | 34.29 ms | **−8.7%** | 8/8 |
| 200k writes, 20% of them evicting | 334.1 ms | 328.0 ms | −1.8% | 8/8 |
| 20 × (5000 inserts, `trim(toCount: 0)`) | 162.7 ms | 160.6 ms | −1.3% | 6/8 |
| 1M hits on 2 threads | 204.4 ms | 191.9 ms | −6.1% | 13/13 |
| 1M hits on 4 threads | 286.0 ms | 271.6 ms | −5.0% | 10/13 |
| 1M hits on 8 threads | 284.3 ms | 282.1 ms | −0.8% | 6/13 |
| 1M hits on 8 threads, first in the process | 294.1 ms | 271.5 ms | −7.7% | 12/13 |
| 7 threads reading, 1 writing and evicting | 451.5 ms | 433.8 ms | −3.9% | 13/13 |
| 5000 `image(for:)` hits in a task group | 9.28 ms | 9.36 ms | +0.9% | 8/20 |
| 5000 `cache[request]` reads in a task group | 4.60 ms | 4.50 ms | −2.1% | 13/20 |
| `asyncAwait`, no memory cache | 47.36 ms | 47.40 ms | +0.1% | 10/20 |
| `imageTask`, no memory cache | 47.34 ms | 47.60 ms | +0.5% | 5/20 |

The two 8-thread rows are the same workload; contended `os_unfair_lock` throughput moves by ±10% depending on what the process ran before, so read them together. The task-group rows are mostly Swift concurrency: `image(for:)` hits lean slower while the direct read in the same task group is faster. The last two rows are the controls. Neither has a memory cache; both reach `Cache` once per load, for the same resumable-data miss, which this change makes cheaper. `asyncAwait` is flat and `imageTask` leans slower in 15 of 20 rounds, so I read that as code layout in the rebuilt binary rather than this change.

**State inside the lock** – the same sessions, 10 rounds (6 with the padded copy); Δ against `main`, faster rounds in parentheses

| 1M hits on | State inside the lock | …padded off the lock word's cache line | This PR |
|---|---|---|---|
| 1 thread | −5.9% (10) | −6.4% (6) | −6.8% (10) |
| 2 threads | −6.3% (10) | −4.8% (6) | −6.3% (10) |
| 4 threads | −1.3% (5) | −2.4% (5) | −3.7% (10) |
| 8 threads | +1.9% (4) | −10.3% (6) | −1.0% (4) |
| 8 threads, first in the process | −0.8% (5) | −5.2% (6) | −8.4% (9) |
| 7 threads reading, 1 writing | −3.1% (8) | −2.3% (5) | −2.5% (9) |

**Suite** – `ImageCachePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel, 5 rounds

| Test | `main` | This PR | Δ | Faster rounds |
|---|---|---|---|---|
| `cacheMiss` | 9.56 ms | 9.14 ms | −4.3% | 5/5 |
| `cacheHitCustomStringKey` | 7.43 ms | 7.12 ms | −4.2% | 5/5 |
| `cacheHit` | 13.66 ms | 13.27 ms | −2.9% | 3/5 |
| `cacheWrite` | 21.69 ms | 21.25 ms | −2.0% | 4/5 |
| `cacheEvictionByCount` | 59.13 ms | 56.70 ms | −4.1% | 4/5 |
| `cacheTrim` | 5.10 ms | 4.98 ms | −2.3% | 4/5 |
| `cacheConcurrentMixed` | 59.46 ms | 57.55 ms | −3.2% | 3/5 |
| `cacheConcurrentReads` | 51.51 ms | 52.13 ms | +1.2% | 1/5 |
| `imageCacheKeyHashing` (no cache) | 8.62 ms | 8.59 ms | −0.3% | 3/5 |

The suite's tests build an `ImageRequest` or a key for every read, so the gain is diluted. Of the eleven not shown, six more that use the cache are 1–3% faster; `cacheOversizedEntryRejection` (+1.0%, rejected before `map` is touched), `cacheRemove` (+0.3%) and `cacheHitWithProcessors` (+0.3%) are even, as are the other two key-only tests. `cacheConcurrentReads` is the one row that leans the other way, with ±2.3% between samples in a run.

**Time Profiler** – 6 s per side, the first 500 ms skipped, share of all samples. The read loop gets 5000 cached requests with one `Resize` through `ImageCache`'s subscript; the write loop sets 5000 keys in a 4000-entry cache and removes 500 per pass.

| | Read loop, `main` | This PR | Write loop, `main` | This PR |
|---|---|---|---|---|
| Self time attributed to `Cache` | 4.30% | 2.97% | 4.05% | 3.78% |
| Exclusivity runtime under `Cache` | 1.57% | 0.52% | 1.07% | 0.15% |
| Samples with `swift_beginAccess` or `swift_endAccess` in the stack | 1.57% | 0.56% | 1.16% | 0.11% |

What's left on the read side is the `Node.value` access. In the release binary the `swift_beginAccess`/`swift_endAccess` call sites go from 2/2 to 1/0 in `value(forKey:)`, 3/3 to 1/0 in `_add`, and 6/2 to 2/0 in `_trim()`. No `_NativeDictionary` copy frame shows up in either trace, on either side.

### Trade-offs

- `@exclusivity(unchecked)` isn't used anywhere else in Nuke, so it's one more attribute to know. It turns off only the dynamic check, which tracks accesses per thread: an access added outside the lock would be a data race either way, and that check never detected those.
- `Cache` stays `@unchecked Sendable`. The state-inside-the-lock version would have made the conformance checked, with `init(uncheckedState:)` carrying the one assumption, but at the contended cost above.
- The write paths go through `NSImage.cgImage` in `ImageCache.cost(for:)` first, which is most of their time, so they move less than the reads.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` – the only failure is the known ThreadSanitizer abort inside the test mock, `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`, which fails on `main` too. With it skipped, 1092 pass: `main`'s 1093, less that one.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 pass.
3. The `Nuke` scheme builds for the iOS Simulator; `NukePerformanceTests` builds with the same warnings as `main`; `swiftlint` reports nothing in the changed file.
