### PR TITLE
Stop prefetching by URL without creating a request per URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - Memory cache lookups for requests with `ImageProcessors/Resize` are 2× faster – https://github.com/kean/Nuke/pull/972
-- `ImagePrefetcher/stopPrefetching(with:)` with URLs is 20% faster and no longer creates an `ImageRequest` per URL – https://github.com/kean/Nuke/pull/976
+- `ImagePrefetcher/stopPrefetching(with:)` with URLs is 20% faster – https://github.com/kean/Nuke/pull/976
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - Memory cache lookups for requests with `ImageProcessors/Resize` are 2× faster – https://github.com/kean/Nuke/pull/972
+- `ImagePrefetcher/stopPrefetching(with:)` with URLs is 20% faster and no longer creates an `ImageRequest` per URL – https://github.com/kean/Nuke/pull/976
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -502,6 +502,15 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     /// The hash of ``originalImageID``, computed once.
     var originalIDHash: Int { ref.originalIDHash }
 
+    // The container's `init` and its `imageID` observer must agree, or a request
+    // whose `imageID` is reset would no longer find its own cache entries. So
+    // must `TaskFetchOriginalDataKey(url:)`, or a stop by URL would miss.
+    static func makeIDHash(_ id: String?) -> Int {
+        var hasher = Hasher()
+        hasher.combine(id)
+        return hasher.finalize()
+    }
+
     static var _containerInstanceSize: Int { class_getInstanceSize(Container.self) }
 }
 
@@ -521,7 +530,7 @@ extension ImageRequest {
         // It is stored partially for performance reasons (`absoluteString` can be expensive to compute)
         let originalImageID: String?
         var customImageID: String? {
-            didSet { idHash = Container.makeIDHash(customImageID ?? originalImageID) }
+            didSet { idHash = ImageRequest.makeIDHash(customImageID ?? originalImageID) }
         }
         var processors: [any ImageProcessing] {
             didSet { processorsIdentity = Container.makeIdentity(processors) }
@@ -546,7 +555,7 @@ extension ImageRequest {
             self.options = options
             self.originalImageID = originalImageID
             self.processorsIdentity = Container.makeIdentity(processors)
-            let idHash = Container.makeIDHash(originalImageID)
+            let idHash = ImageRequest.makeIDHash(originalImageID)
             self.idHash = idHash
             self.originalIDHash = idHash
         }
@@ -569,14 +578,6 @@ extension ImageRequest {
 
         private static func makeIdentity(_ processors: [any ImageProcessing]) -> [ProcessorID] {
             processors.isEmpty ? [] : processors.map(ProcessorID.init)
-        }
-
-        // `init` and both observers must agree, or a request whose `imageID`
-        // is reset would no longer find its own cache entries.
-        private static func makeIDHash(_ id: String?) -> Int {
-            var hasher = Hasher()
-            hasher.combine(id)
-            return hasher.finalize()
         }
     }
 

--- a/Sources/Nuke/Internal/ImageRequestKeys.swift
+++ b/Sources/Nuke/Internal/ImageRequestKeys.swift
@@ -73,6 +73,22 @@ final class TaskLoadImageKey: Hashable, Sendable {
         self._hashValue = hasher.finalize()
     }
 
+    /// The key of `ImageRequest(url: url)`, without creating the request.
+    ///
+    /// It restates the defaults that request is created with, so the two have
+    /// to change together; `ImageRequestLoadKeyTests` fails if they drift apart.
+    init(url: URL) {
+        self.loadKey = TaskFetchOriginalImageKey(url: url)
+        self.options = []
+        self.processors = []
+
+        var hasher = Hasher()
+        hasher.combine(loadKey)
+        hasher.combine(options)
+        hasher.combine(processors.count)
+        self._hashValue = hasher.finalize()
+    }
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(_hashValue)
     }
@@ -95,6 +111,18 @@ struct TaskFetchOriginalImageKey: Hashable {
         self.dataLoadKey = TaskFetchOriginalDataKey(request)
         self.scale = request.scale
         self.thumbnail = request.thumbnail
+
+        var hasher = Hasher()
+        hasher.combine(dataLoadKey)
+        hasher.combine(scale)
+        hasher.combine(thumbnail)
+        self._hashValue = hasher.finalize()
+    }
+
+    init(url: URL) {
+        self.dataLoadKey = TaskFetchOriginalDataKey(url: url)
+        self.scale = 1
+        self.thumbnail = nil
 
         var hasher = Hasher()
         hasher.combine(dataLoadKey)
@@ -130,6 +158,19 @@ struct TaskFetchOriginalDataKey: Hashable {
 
         var hasher = Hasher()
         hasher.combine(request.originalIDHash)
+        hasher.combine(cachePolicy)
+        hasher.combine(allowsCellularAccess)
+        self._hashValue = hasher.finalize()
+    }
+
+    init(url: URL) {
+        let imageId = url.absoluteString
+        self.imageId = imageId
+        self.cachePolicy = .useProtocolCachePolicy
+        self.allowsCellularAccess = true
+
+        var hasher = Hasher()
+        hasher.combine(ImageRequest.makeIDHash(imageId))
         hasher.combine(cachePolicy)
         hasher.combine(allowsCellularAccess)
         self._hashValue = hasher.finalize()

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -174,7 +174,11 @@ public final class ImagePrefetcher: Sendable {
     ///
     /// See also ``stopPrefetching(with:)-8cdam`` that works with ``ImageRequest``.
     nonisolated public func stopPrefetching(with urls: [URL]) {
-        stopPrefetching(with: urls.map { ImageRequest(url: $0) })
+        // Straight from the URLs to the keys, on the actor: a request per URL
+        // would be allocated on the caller's thread only to derive its key.
+        Task { @ImagePipelineActor in
+            self._stopPrefetching(with: urls.map { TaskLoadImageKey(url: $0) })
+        }
     }
 
     /// Stops prefetching images for the given requests and cancels outstanding
@@ -187,15 +191,17 @@ public final class ImagePrefetcher: Sendable {
     /// See also ``stopPrefetching(with:)-2tcyq`` that works with `URL`.
     nonisolated public func stopPrefetching(with requests: [ImageRequest]) {
         Task { @ImagePipelineActor in
-            for request in requests {
-                self._stopPrefetching(with: request)
-            }
+            self._stopPrefetching(with: requests.map { TaskLoadImageKey($0) })
         }
     }
 
-    private func _stopPrefetching(with request: ImageRequest) {
-        if let task = tasks.removeValue(forKey: TaskLoadImageKey(request)) {
-            task.cancel()
+    // The keys are built before the first one is looked up: a lazy map, which
+    // interleaves building them with the removals, measured slower.
+    private func _stopPrefetching(with keys: [TaskLoadImageKey]) {
+        for key in keys {
+            if let task = tasks.removeValue(forKey: key) {
+                task.cancel()
+            }
         }
     }
 

--- a/Tests/NukePerformanceTests/ImagePrefetcherPerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImagePrefetcherPerformanceTests.swift
@@ -1,0 +1,70 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2026 Alexander Grebenyuk (github.com/kean).
+
+import Testing
+import Foundation
+import os
+import Nuke
+
+@Suite(.serialized)
+@MainActor
+struct ImagePrefetcherPerformanceTests {
+    /// The scroll-away pattern: a fast scroll schedules rows for prefetching
+    /// and stops them by URL before most of them get to start.
+    @Test
+    func startAndStopPrefetchingWithURLs() async {
+        let pipeline = makePipeline()
+        let urls = (0..<5000).map { URL(string: "http://test.com/\($0)")! }
+        let sentinel = [URL(string: "http://test.com/sentinel")!]
+        await measure {
+            let prefetcher = ImagePrefetcher(pipeline: pipeline, maxConcurrentRequestCount: 8)
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                // The one request that isn't stopped makes sure the prefetcher
+                // runs out of work after the stop. The lock resumes the
+                // continuation once, however many times it does on the way.
+                let pending = OSAllocatedUnfairLock<CheckedContinuation<Void, Never>?>(initialState: continuation)
+                prefetcher.didComplete = {
+                    let continuation = pending.withLock { state in
+                        defer { state = nil }
+                        return state
+                    }
+                    continuation?.resume()
+                }
+                prefetcher.startPrefetching(with: urls)
+                prefetcher.stopPrefetching(with: urls)
+                prefetcher.startPrefetching(with: sentinel)
+            }
+            withExtendedLifetime(prefetcher) {}
+        }
+    }
+
+    /// Stops prefetching by URL with nothing outstanding for those URLs: the
+    /// rows a scroll leaves after their images have loaded.
+    @Test
+    func stopPrefetchingWithURLs() async {
+        let prefetcher = ImagePrefetcher(pipeline: makePipeline(), maxConcurrentRequestCount: 8)
+        let urls = (0..<5000).map { URL(string: "http://test.com/\($0)")! }
+        await measure {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                // The empty batch reports completion once the prefetcher has
+                // processed it, which is after the stop queued before it.
+                prefetcher.didComplete = { continuation.resume() }
+                prefetcher.stopPrefetching(with: urls)
+                prefetcher.startPrefetching(with: [URL]())
+            }
+        }
+    }
+}
+
+private func makePipeline() -> ImagePipeline {
+    ImagePipeline {
+        $0.imageCache = nil
+        $0.dataLoader = MockDataLoader()
+        $0.isDecompressionEnabled = false
+        // The rate limiter is tuned for apps loading over the network, not for
+        // a synthetic burst like this one.
+        $0.isRateLimiterEnabled = false
+        $0.makeImageDecoder = { _ in ImageDecoders.Empty() }
+    }
+}

--- a/Tests/NukeTests/ImagePrefetcherTests.swift
+++ b/Tests/NukeTests/ImagePrefetcherTests.swift
@@ -163,6 +163,51 @@ struct ImagePrefetcherTests {
         #expect(dataLoader.createdTaskCount == 0)
     }
 
+    @Test func stopPrefetchingWithRequests() async {
+        dataLoader.isSuspended = true
+
+        let request = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+
+        await notification(ImagePipelineObserver.didStartTask, object: observer) {
+            prefetcher.startPrefetching(with: [request])
+        }
+
+        await notification(ImagePipelineObserver.didCancelTask, object: observer) {
+            prefetcher.stopPrefetching(with: [request])
+        }
+    }
+
+    @Test @ImagePipelineActor func stopPrefetchingWithURLLeavesOtherRequestsForThatURL() async {
+        // GIVEN two outstanding prefetches of one URL, one of them with a
+        // processor, and neither started
+        prefetcher.isPaused = true
+        let processed = ImageRequest(url: Test.url, processors: [MockImageProcessor(id: "1")])
+        let operations = await prefetcher.queue.waitForOperations(count: 2) {
+            prefetcher.startPrefetching(with: [processed, ImageRequest(url: Test.url)])
+        }
+        #expect(operations.count == 2)
+
+        // WHEN stopping prefetching by that URL
+        nonisolated(unsafe) var cancelled: [TaskQueue.Operation] = []
+        let expectation = TestExpectation()
+        prefetcher.queue.onEvent = { event in
+            if case .cancelled(let operation) = event {
+                cancelled.append(operation)
+                expectation.fulfill()
+            }
+        }
+        prefetcher.stopPrefetching(with: [Test.url])
+        await expectation.wait()
+
+        // THEN only the prefetch without a processor is cancelled
+        #expect(cancelled.count == 1)
+        #expect(cancelled.first === operations.last)
+        #expect(prefetcher.queue.pendingCount == 1)
+
+        // Cleanup
+        prefetcher.stopPrefetching()
+    }
+
     // MARK: Destination
 
     @Test func startPrefetchingDestinationDisk() async {

--- a/Tests/NukeTests/ImageRequestTests.swift
+++ b/Tests/NukeTests/ImageRequestTests.swift
@@ -184,6 +184,55 @@ struct ImageRequestLoadKeyTests {
         #expect(TaskFetchOriginalDataKey(lhs) != TaskFetchOriginalDataKey(rhs))
     }
 
+    // `ImagePrefetcher` stops prefetching by URL with `TaskLoadImageKey(url:)`,
+    // which restates the defaults of `ImageRequest(url:)` instead of creating
+    // the request. It has to match exactly the tasks that request's key matches.
+    @Test func keyForURLMatchesTheKeyOfARequestWithThatURL() {
+        let urls = [
+            Test.url,
+            URL(string: "http://test.com/example.jpeg?token=1#fragment")!,
+            URL(string: "example.jpeg", relativeTo: URL(string: "http://test.com/images/"))!,
+            URL(fileURLWithPath: "/tmp/an image.png")
+        ]
+        for url in urls {
+            assertHashableEqual(TaskLoadImageKey(url: url), TaskLoadImageKey(ImageRequest(url: url)))
+        }
+
+        // So does every request that differs from it only outside the key
+        let url = Test.url
+        var processorsRemoved = ImageRequest(url: url, processors: [MockImageProcessor(id: "1")])
+        processorsRemoved.processors = []
+        let requests = [
+            ImageRequest(url: url, priority: .veryHigh),
+            ImageRequest(url: url).with { $0.imageID = "custom" },
+            ImageRequest(url: url).with { $0.userInfo[.labelKey] = "feed" },
+            ImageRequest(urlRequest: URLRequest(url: url)),
+            ImageRequest(url: URL(string: "example.jpeg", relativeTo: URL(string: "http://test.com/"))),
+            processorsRemoved
+        ]
+        for request in requests {
+            assertHashableEqual(TaskLoadImageKey(url: url), TaskLoadImageKey(request))
+        }
+    }
+
+    @Test func keyForURLDiffersInEveryComponentOfTheKey() {
+        let url = Test.url
+        var cellularDisallowed = URLRequest(url: url)
+        cellularDisallowed.allowsCellularAccess = false
+        let requests = [
+            ImageRequest(url: URL(string: "http://test.com/example-2.jpeg")),
+            ImageRequest(urlRequest: URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)),
+            ImageRequest(urlRequest: cellularDisallowed),
+            ImageRequest(url: url).with { $0.scale = 2 },
+            ImageRequest(url: url).with { $0.thumbnail = ImageRequest.ThumbnailOptions(maxPixelSize: 400) },
+            ImageRequest(url: url, options: [.disableMemoryCacheReads]),
+            ImageRequest(url: url, processors: [MockImageProcessor(id: "1")])
+        ]
+        for request in requests {
+            #expect(TaskLoadImageKey(url: url) != TaskLoadImageKey(request))
+        }
+    }
+
     @Test func mockImageProcessorCorrectlyImplementsIdentifiers() {
         #expect(MockImageProcessor(id: "1").identifier == MockImageProcessor(id: "1").identifier)
         #expect(MockImageProcessor(id: "1").hashableIdentifier == MockImageProcessor(id: "1").hashableIdentifier)


### PR DESCRIPTION
Stacked on #972.

`ImagePrefetcher/stopPrefetching(with:)` for URLs turned every URL into an `ImageRequest` and handed the requests to the overload that takes requests, which derived a `TaskLoadImageKey` from each on `ImagePipelineActor` and dropped the request. Only the key was ever used. The request allocated its container and hashed its image ID on the caller's thread – for `collectionView(_:cancelPrefetchingForItemsAt:)`, the main thread – and #972 moves that hash into request creation. In a Time Profiler trace of the scroll-away loop (start 5000 URLs, stop them), `ImageRequest.init(url:…)` and its ID hash were 7.8% of the samples on #972, and half of those requests were created only to be turned into keys.

### Changes

- `TaskLoadImageKey(url:)` builds the key `ImageRequest(url:)` gets, without the request: the URL's `absoluteString` and its hash, the cache policy and cellular access of a URL resource, scale 1, no thumbnail, no options, no processors. `TaskFetchOriginalImageKey` and `TaskFetchOriginalDataKey` get the same initializer. The ID is hashed by the function the request uses, which moves out of its container to `ImageRequest.makeIDHash(_:)`, so the two can't hash an ID differently.
- The URL overload builds the keys inside the `Task` that already hops to the actor, so the caller only retains the array.
- Both overloads now end in `_stopPrefetching(with keys: [TaskLoadImageKey])`, and both build their keys into an array before the loop rather than creating each one next to its removal.
- Tests pin the URL key to `TaskLoadImageKey(ImageRequest(url:))`. It's equal and hash-equal for absolute, relative, query, and file URLs, and for requests that differ only outside the key: priority, `imageID`, `userInfo`, an equivalent `URLRequest`, a relative URL with the same absolute string, processors added and removed. It's unequal for each component the key includes: URL, cache policy, cellular access, scale, thumbnail, options, processors. Two prefetcher tests cover stopping by request, which had no test, and check that stopping by URL leaves a request for the same URL with a processor outstanding.
- The first commit adds `ImagePrefetcherPerformanceTests`.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. #972 and this branch alternate run by run, and the side that runs first alternates by round; median per side, and the Δ of each round.

**Release rig** – a mock data loader and `ImageDecoders.Empty`; 5 rounds. The outstanding URLs are scheduled on a paused prefetcher first, untimed. A stop is timed until an empty batch queued after it reports completion, which it does only once nothing is outstanding, so a stop that missed a key would hang. 20 samples per run, except `prefetch`, which takes its own 5.

| Benchmark | #972 | This PR | Δ | Rounds |
|---|---|---|---|---|
| Stop 5000 URLs, all outstanding | 2.64 ms | 2.09 ms | **−20.9%** | −24.5, −20.1, −23.3, −19.7, −21.6 |
| Stop 5000 URLs, none outstanding | 1.12 ms | 0.64 ms | **−43.2%** | −44.0, −43.2, −43.0, −43.2, −42.8 |
| – of which the call holds the caller | 0.46 ms | 0.002 ms | −99.6% | −99.7, −99.6, −99.6, −99.6, −99.6 |
| Stop 5000 requests, all outstanding | 2.02 ms | 2.00 ms | −1.1% | −1.3, −0.0, −3.8, +0.6, −2.3 |
| Scroll-away: start 5000 URLs, stop them, start one more; CPU time | 5.37 ms | 4.75 ms | **−11.6%** | −11.7, −11.9, −11.6, −11.9, −10.7 |
| Scroll-away, wall time | 4.88 ms | 4.73 ms | −3.0% | −3.5, −3.3, −3.4, −3.7, −2.7 |
| `prefetch`: 5000 start + stop | 4.78 ms | 4.57 ms | −4.4% | −20.8, −4.9, −0.4, −5.3, −5.2 |
| `hotprefetch`: start + stop pairs in 2 s | 2.085 M | 2.150 M | +3.1% | +3.1, +3.4, +2.9, +2.9, +4.1 |

Per URL, a stop goes from 528 to 418 ns with a task outstanding, and from 224 to 128 ns without one. The scroll-away CPU time is the whole process's. Its wall time moves less: the caller used to create the requests while the actor was still scheduling the start, and now the actor builds the keys after it.

Controls, which run no changed code beyond `ImageRequest.makeIDHash(_:)` moving out of the container: `prefetch` of 5000 at 2, 8, and 64 concurrent requests +0.3%, +0.8%, −0.1%; all already cached −0.9%; `asyncAwait` +0.6%; `scroll`'s cached loads +1.6%, fresh requests with a cache read +0.6%, cache reads +0.3% – all with mixed signs. `scroll`'s original-and-thumbnail cache read measured +1.5%, positive in every round; in an earlier session, against a candidate that differed only in the stop loop, it measured −2.0%, negative in every round.

**Allocations** – counted with `malloc_logger` over a stop of 5000, net of an empty stop's hop and completion; 5 runs, identical

| Per URL | #972 | This PR |
|---|---|---|
| Stop by URL | 2 allocations, 234 B | 1 allocation, 112 B |
| Stop by request | 1 allocation, 104 B | 1 allocation, 112 B |

The allocation that goes is the request's container; the one that stays is the key. The 8 B are the array of keys, one per stop.

**Suite** – `ImagePrefetcherPerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel; "before" is this PR's first commit; 7 rounds

| Test | Before | After | Δ | Rounds |
|---|---|---|---|---|
| `stopPrefetchingWithURLs` – 5000 URLs, nothing outstanding | 1.14 ms | 0.76 ms | **−33.2%** | −31.5, −36.4, −39.5, −34.6, −32.8, −32.9, −36.4 |
| `startAndStopPrefetchingWithURLs` – scroll-away | 5.27 ms | 5.27 ms | −0.0% | −1.9, +0.7, −4.0, −0.4, +0.7, −0.7, +5.9 |

The scroll-away test doesn't move, for the wall-time reason above.

**Time Profiler** – the scroll-away loop, 8 s, self time attributed to the nearest Nuke frame. On #972, `ImageRequest.init(url:…)` is 5.1% of the samples, the ID hash 2.7%, and the container's `deinit` 2.1%. On this branch they're 3.3%, 1.5%, and 1.6%, all of it from `startPrefetching(with:)`, which still creates the requests it schedules; the stop creates none.

### Trade-offs

- `TaskLoadImageKey(url:)` restates the defaults of `ImageRequest(url:)` instead of reading them off a request. If a default changes, or the key gains a component, the two keys can drift apart and a stop by URL would quietly miss. `keyForURLMatchesTheKeyOfARequestWithThatURL` and `keyForURLDiffersInEveryComponentOfTheKey` fail when they do, and a new stored component doesn't compile until the URL initializer sets it.
- `absoluteString` is still read for every URL, because the key compares image IDs. Keying by `URL` would change which stops match: today a relative URL matches the absolute URL with the same absolute string.
- The keys are built on the actor. That takes the stop off the caller – 0.48 ms to 4 µs for 5000 URLs – but gives up the parallelism of an idle caller. In one session, building them on the caller before the hop measured the same CPU time (−11.6% instead of −11.9%) and a faster scroll-away (−12.2% wall time instead of −3.9%), with the call holding the caller about as long as it does today. A scrolling main thread isn't idle, so the keys stay off it.
- Each stop allocates one array of keys, the request overload included. A lazy map would avoid it, but it interleaves creating each key with its removal, and it measured slower: −15.7% instead of −22.6% for stopping 5000 outstanding URLs, in the same session. For requests, the two measured the same.
- #968 routes the stops by request through a new `_stopPrefetching(with requests:)` that returns early when nothing is outstanding and calls `sendCompletionIfNeeded()` at the end. Here both overloads meet in `_stopPrefetching(with keys:)`, so the two branches conflict in that one hunk, and resolving it moves those two statements into the function over keys, where a stop by URL reports completion too. The early return then skips the removals but not the keys, which are built before the call.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` with `-skip-testing:` on `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`, the known ThreadSanitizer abort inside the test mock `MockProgressiveDataLoader` – 1098 passed and 3 skipped, 1101 in all: #972's suite plus four new tests.
   - `ImageRequestLoadKeyTests.keyForURLMatchesTheKeyOfARequestWithThatURL` and `keyForURLDiffersInEveryComponentOfTheKey`
   - `ImagePrefetcherTests.stopPrefetchingWithRequests` and `stopPrefetchingWithURLLeavesOtherRequestsForThatURL`
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 pass.
3. `NukePerformanceTests` builds, and the new file adds no warnings; `swiftlint` reports nothing new in the changed files.
