### PR TITLE
Run image(for:) and data(for:) on the caller's task when no other call is in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 - The default `ImagePipeline/Configuration-swift.struct/rateLimiter` rate goes from 80 to 100 requests per second – https://github.com/kean/Nuke/pull/960
 - `ImageTask` and `ImageDecoders/Video` are now `Sendable` instead of `@unchecked Sendable` – https://github.com/kean/Nuke/pull/965
 
+**Performance**
+
+- `ImagePipeline/image(for:)` returns a memory-cached image 2× faster when it's the only call in flight – https://github.com/kean/Nuke/pull/977
+
 **Bug Fixes**
 
 - Remove an unused `AVKit` import from `Nuke`, which linked AVKit, AVFoundation, and their dependencies into every app – https://github.com/kean/Nuke/pull/947

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -162,7 +162,11 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     public var response: ImageResponse {
         get async throws(ImagePipeline.Error) {
             let result = await withTaskCancellationHandler {
-                await _task.value
+                // A task that runs on the Swift task of its caller has no
+                // `_task`, so wait for its terminal event instead – in a `Task`
+                // of its own: a stream ends early when the task iterating it is
+                // cancelled, and a cancelled awaiter still gets the outcome.
+                await (_task ?? Task { await self.terminalResult() }).value
             } onCancel: {
                 cancel()
             }
@@ -248,7 +252,10 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     /// read-only from the `response` getter, so it needs no synchronization.
     /// `nonisolated(unsafe)` keeps that unchecked to this one property instead
     /// of `@unchecked Sendable` waiving the check for the whole class.
-    nonisolated(unsafe) var _task: Task<Result<ImageResponse, ImagePipeline.Error>, Never>!
+    ///
+    /// `nil` for a task that `image(for:)` or `data(for:)` runs on the Swift
+    /// task of its caller.
+    nonisolated(unsafe) var _task: Task<Result<ImageResponse, ImagePipeline.Error>, Never>?
     @ImagePipelineActor var _continuation: UnsafeContinuation<Result<ImageResponse, ImagePipeline.Error>, Never>?
     @ImagePipelineActor var _isFinished = false
     @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
@@ -442,6 +449,16 @@ extension ImageTask {
                 self._streamContinuations.append(continuation)
             }
         }
+    }
+
+    /// Returns the result carried by the terminal event.
+    private func terminalResult() async -> Result<ImageResponse, ImagePipeline.Error> {
+        for await event in events {
+            if case .finished(let result) = event {
+                return result
+            }
+        }
+        return .failure(.cancelled) // Unreachable: a stream always ends with `.finished`
     }
 }
 

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -55,12 +55,18 @@ public final class ImagePipeline: Sendable {
     private var isInvalidated = false
 
     private nonisolated var nextTaskId: UInt64 {
-        _nextTaskId.withLock { value in
-            value += 1
-            return value
+        _counters.withLock { counters in
+            counters.taskId += 1
+            return counters.taskId
         }
     }
-    private nonisolated let _nextTaskId = OSAllocatedUnfairLock<UInt64>(initialState: 0)
+    private nonisolated let _counters = OSAllocatedUnfairLock(initialState: Counters())
+
+    private struct Counters {
+        var taskId: UInt64 = 0
+        /// The number of `image(for:)` and `data(for:)` calls in flight.
+        var responseCount = 0
+    }
 
     let rateLimiter: RateLimiter?
     /// Records the diagnostics. `nil` unless
@@ -160,7 +166,12 @@ public final class ImagePipeline: Sendable {
 
     /// Returns an image for the given request.
     nonisolated public func image(for request: ImageRequest) async throws(ImagePipeline.Error) -> PlatformImage {
-        try await imageTask(with: request).image
+        let (task, isStarted) = makeTaskForResponse(with: request, isDataTask: false)
+        defer { didFinishResponse() }
+        guard isStarted else {
+            return try await run(task, isDataTask: false).get().image
+        }
+        return try await task.image
     }
 
     // MARK: - Loading Data (Async/Await)
@@ -169,25 +180,87 @@ public final class ImagePipeline: Sendable {
     ///
     /// - parameter request: An image request.
     nonisolated public func data(for request: ImageRequest) async throws(ImagePipeline.Error) -> (Data, URLResponse?) {
-        let task = makeStartedImageTask(with: request, isDataTask: true)
-        let response = try await task.response
+        let (task, isStarted) = makeTaskForResponse(with: request, isDataTask: true)
+        defer { didFinishResponse() }
+        let response: ImageResponse
+        if isStarted {
+            response = try await task.response
+        } else {
+            response = try await run(task, isDataTask: true).get()
+        }
         return (response.container.data ?? Data(), response.urlResponse)
     }
 
     // MARK: - ImageTask (Internal)
 
     nonisolated func makeStartedImageTask(with request: ImageRequest, isDataTask: Bool = false, isPrefetch: Bool = false, onEvent: (@Sendable (ImageTask.Event, ImageTask) -> Void)? = nil) -> ImageTask {
-        // The creation time is the one thing the diagnostics read off the actor.
-        let task = ImageTask(taskId: nextTaskId, request: request, isDataTask: isDataTask, isPrefetch: isPrefetch, pipeline: self, onEvent: onEvent, createdAt: recorder?.now)
-        // Important to call it before `imageTaskStartCalled`
-        imageTaskCreated(task, isDataTask: isDataTask)
+        let task = makeImageTask(taskId: nextTaskId, request: request, isDataTask: isDataTask, isPrefetch: isPrefetch, onEvent: onEvent)
+        startInTask(task, isDataTask: isDataTask)
+        return task
+    }
+
+    nonisolated private func startInTask(_ task: ImageTask, isDataTask: Bool) {
         task._task = Task { @ImagePipelineActor in
             await withUnsafeContinuation { continuation in
                 task._continuation = continuation
                 self.startImageTask(task, isDataTask: isDataTask)
             }
         }
+    }
+
+    nonisolated private func makeImageTask(taskId: UInt64, request: ImageRequest, isDataTask: Bool, isPrefetch: Bool, onEvent: (@Sendable (ImageTask.Event, ImageTask) -> Void)?) -> ImageTask {
+        // The creation time is the one thing the diagnostics read off the actor.
+        let task = ImageTask(taskId: taskId, request: request, isDataTask: isDataTask, isPrefetch: isPrefetch, pipeline: self, onEvent: onEvent, createdAt: recorder?.now)
+        // Important to call it before `imageTaskStartCalled`
+        imageTaskCreated(task, isDataTask: isDataTask)
         return task
+    }
+
+    /// Creates a task for `image(for:)` or `data(for:)`, which await its
+    /// response right away, and starts it in a `Task` only when another such
+    /// call is in flight or the caller is already cancelled. Otherwise the
+    /// caller runs it on its own Swift task with `run(_:isDataTask:)`, which
+    /// saves the `Task`.
+    ///
+    /// Only a call with no other in flight skips the `Task`: a Swift task
+    /// leaving the actor takes the actor's thread with it and reschedules the
+    /// actor's remaining jobs on a new one. With other requests queued on the
+    /// actor, that thread wakeup delays all of them and costs more than the
+    /// `Task` it saves.
+    ///
+    /// Balance every call with `didFinishResponse()`.
+    nonisolated private func makeTaskForResponse(with request: ImageRequest, isDataTask: Bool) -> (ImageTask, isStarted: Bool) {
+        let (taskId, isOnlyResponse) = _counters.withLock { counters in
+            counters.taskId += 1
+            counters.responseCount += 1
+            return (counters.taskId, counters.responseCount == 1)
+        }
+        let task = makeImageTask(taskId: taskId, request: request, isDataTask: isDataTask, isPrefetch: false, onEvent: nil)
+        // The delegate callbacks the start makes run on the Swift task that
+        // starts it, and a cancelled one shouldn't be it.
+        let isStarted = !isOnlyResponse || Task.isCancelled
+        if isStarted {
+            startInTask(task, isDataTask: isDataTask)
+        }
+        return (task, isStarted)
+    }
+
+    nonisolated private func didFinishResponse() {
+        _counters.withLock { $0.responseCount -= 1 }
+    }
+
+    private func run(_ task: ImageTask, isDataTask: Bool) async -> Result<ImageResponse, Error> {
+        // The handler is installed after the hop to the actor, so a caller
+        // cancelled on its way here still starts the task before it cancels
+        // it, the same as when it awaits `ImageTask/response`.
+        await withTaskCancellationHandler {
+            await withUnsafeContinuation { continuation in
+                task._continuation = continuation
+                startImageTask(task, isDataTask: isDataTask)
+            }
+        } onCancel: {
+            task.cancel()
+        }
     }
 
     // By this time, the task has `continuation` set and is fully wired.

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -247,6 +247,154 @@ struct ImagePipelineAsyncAwaitTests {
         #expect(imageTask != nil)
     }
 
+    // MARK: - Running on the Caller's Task
+
+    @Test func taskCreatedByImageForCanBeAwaitedByOthers() async throws {
+        // GIVEN an observer awaiting the task that `image(for:)` runs on the
+        // caller's own Swift task
+        nonisolated(unsafe) var imageTask: ImageTask?
+        nonisolated(unsafe) var observer: Task<ImageResponse, any Error>?
+        pipelineDelegate.onTaskCreated = { task in
+            imageTask = task
+            observer = Task { try await task.response }
+        }
+
+        // WHEN
+        let image = try await pipeline.image(for: Test.request)
+
+        // THEN the observer gets the same response
+        let observerTask = try #require(observer)
+        let response = try await observerTask.value
+        #expect(response.image === image)
+        #expect(try #require(imageTask)._task == nil)
+    }
+
+    @Test func cancellingAnotherAwaiterCancelsTaskCreatedByImageFor() async throws {
+        // GIVEN a request that doesn't finish on its own, and an observer
+        // awaiting the task that `image(for:)` runs
+        dataLoader.queue.isSuspended = true
+        let didCreateObserver = TestExpectation()
+        nonisolated(unsafe) var observer: Task<ImageResponse, any Error>?
+        pipelineDelegate.onTaskCreated = { task in
+            observer = Task { try await task.response }
+            didCreateObserver.fulfill()
+        }
+        let pipeline = self.pipeline
+        let caller = Task {
+            try await pipeline.image(for: Test.url)
+        }
+        await didCreateObserver.wait()
+        let observerTask = try #require(observer)
+
+        // WHEN
+        observerTask.cancel()
+
+        // THEN the task is cancelled for everyone awaiting it
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await caller.value
+        }
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await observerTask.value
+        }
+    }
+
+    @Test func imageForStartsTaskInTaskWhileAnotherCallerRunsOne() async throws {
+        // GIVEN a caller that runs its task on its own Swift task and waits
+        // for the data loader
+        dataLoader.queue.isSuspended = true
+        let didStartLoading = TestExpectation(notification: MockDataLoader.DidStartTask, object: dataLoader)
+        let didCreateSecondTask = TestExpectation()
+        nonisolated(unsafe) var tasks: [ImageTask] = []
+        pipelineDelegate.onTaskCreated = { task in
+            tasks.append(task)
+            if tasks.count == 2 { didCreateSecondTask.fulfill() }
+        }
+        let pipeline = self.pipeline
+        let first = Task {
+            try await pipeline.image(for: Test.url)
+        }
+        await didStartLoading.wait()
+
+        // WHEN another caller loads the image at the same time and is cancelled
+        let second = Task {
+            try await pipeline.image(for: Test.url)
+        }
+        await didCreateSecondTask.wait()
+        second.cancel()
+
+        // THEN the second task gets a `Task` of its own and is cancelled,
+        // and the first one still finishes
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await second.value
+        }
+        dataLoader.queue.isSuspended = false
+        _ = try await first.value
+        #expect(tasks.count == 2)
+        #expect(tasks.first?._task == nil)
+        #expect(tasks.last?._task != nil)
+    }
+
+    @Test func imageForStartsTaskInTaskWhenCallerIsAlreadyCancelled() async throws {
+        // GIVEN a caller that is cancelled before it asks for the image
+        let pipeline = self.pipeline
+        nonisolated(unsafe) var isStartCancelled: Bool?
+        pipeline.onTaskStarted = { _ in isStartCancelled = Task.isCancelled }
+        nonisolated(unsafe) var imageTask: ImageTask?
+        pipelineDelegate.onTaskCreated = { imageTask = $0 }
+
+        // WHEN
+        let caller = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await pipeline.image(for: Test.request)
+        }
+        _ = try? await caller.value
+
+        // THEN the task starts in a `Task` of its own, not on the cancelled one
+        #expect(isStartCancelled == false)
+        #expect(try #require(imageTask)._task != nil)
+    }
+
+    @Test func imageForRunsTaskOnCallersTaskAgainAfterCancellation() async throws {
+        // GIVEN a caller that was cancelled
+        dataLoader.queue.isSuspended = true
+        let pipeline = self.pipeline
+        let cancelled = Task {
+            try await pipeline.image(for: Test.url)
+        }
+        cancelled.cancel()
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await cancelled.value
+        }
+        dataLoader.queue.isSuspended = false
+
+        // WHEN
+        nonisolated(unsafe) var imageTask: ImageTask?
+        pipelineDelegate.onTaskCreated = { imageTask = $0 }
+        _ = try await pipeline.image(for: Test.request)
+
+        // THEN the next request runs on its caller's task too
+        #expect(try #require(imageTask)._task == nil)
+    }
+
+    @Test func imageForStartsTaskWithCallersPriority() async throws {
+        // GIVEN
+        let pipeline = self.pipeline
+        nonisolated(unsafe) var startPriority: _Concurrency.TaskPriority?
+        pipeline.onTaskStarted = { _ in startPriority = Task.currentPriority }
+
+        // WHEN a utility task loads an image, resumed through a continuation
+        // so that nothing escalates it
+        await withCheckedContinuation { continuation in
+            Task.detached(priority: .utility) {
+                _ = try? await pipeline.image(for: Test.request)
+                continuation.resume()
+            }
+        }
+
+        // THEN
+        #expect(startPriority == _Concurrency.TaskPriority.utility)
+    }
+
     @Test func progressUpdated() async throws {
         // GIVEN
         dataLoader.results[Test.url] = .success(

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
@@ -174,6 +174,25 @@ struct ImagePipelineTaskLifetimeTests {
         #expect(weakTask == nil)
     }
 
+    @Test func taskIsDeallocatedAfterSynchronousCompletionWithImageFor() async throws {
+        // Given
+        let observer = ImagePipelineObserver()
+        let pipeline = ImagePipeline(delegate: observer) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = imageCache
+        }
+        imageCache[Test.request] = Test.container
+        let weakTask = WeakRef<ImageTask>()
+        observer.onTaskCreated = { weakTask.value = $0 }
+
+        // When `image(for:)` runs the task on the caller's own Swift task
+        _ = try await pipeline.image(for: Test.request)
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask.value == nil)
+    }
+
     // MARK: - Events
 
     @Test func startedEventIsDeliveredBeforeFinishedOnMemoryCacheHit() async throws {
@@ -195,6 +214,29 @@ struct ImagePipelineTaskLifetimeTests {
             .started,
             .completed(result: .success(response))
         ])
+    }
+
+    @Test func startedEventIsDeliveredBeforeFinishedOnMemoryCacheHitWithImageFor() async throws {
+        // Given
+        let observer = ImagePipelineObserver()
+        let pipeline = ImagePipeline(delegate: observer) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = imageCache
+        }
+        imageCache[Test.request] = Test.container
+
+        // When `image(for:)` runs the task on the caller's own Swift task
+        _ = try await pipeline.image(for: Test.request)
+        await drainPipeline()
+
+        // Then
+        let events = observer.events
+        #expect(events.count == 3)
+        #expect(Array(events.prefix(2)) == [ImageTaskEvent.created, .started])
+        guard case .completed(result: .success)? = events.last else {
+            Issue.record("Expected a successful completion, got \(events)")
+            return
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
`image(for:)` and `data(for:)` created their task through `makeStartedImageTask`, which spawns a `Task { @ImagePipelineActor in … }` whose only job is to install the continuation and call `startImageTask`. `imageTask(with:)` needs that: it's a synchronous factory. The async methods don't – they await the response right away – but they paid for the `Task`, and for waiting on it, on every request, memory cache hits included. With nothing else going on, a hit also woke two threads: one to run the `Task` on the actor, one to resume the caller.

When a call is the only `image(for:)` or `data(for:)` in flight, it now hops onto the actor on its own Swift task and starts the image task there, the way `startImageTask` does inside that `Task` today. Otherwise – and when the caller is already cancelled – it takes the `Task` path, unchanged.

Why only then. Running every call on its own task made the task-group benchmarks slower: `memoryHit` +39%, `asyncAwait` +13%, 5 of 5 rounds each. A Swift task that leaves the actor for the generic executor takes the actor's thread with it and reschedules the actor's remaining jobs on a new thread. With thousands of callers queued behind each other on the actor, every one of them pays a thread wakeup, and the actor never drains a batch. The traces below show it, and on a one-thread pool the same build is faster in both shapes.

- `makeTaskForResponse(with:isDataTask:)` counts the `image(for:)` and `data(for:)` calls in flight, under the lock that already hands out task IDs, and creates the task; `didFinishResponse()` counts it out on return.
- `run(_:isDataTask:)` is the actor-isolated start: a cancellation handler around a continuation around `startImageTask`, the same shape `ImageTask/response` puts around the `Task`.
- `ImageTask._task` is optional. `response` on a task without one waits for its terminal event, in a `Task` of its own so that a cancelled awaiter still gets the outcome.
- `makeStartedImageTask` is split into `makeImageTask` and `startInTask` so both paths share them. Nothing public changes.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. `main` and this branch alternate run by run, and the side that runs first alternates by round; median of the per-run averages, and the Δ of each round. The release rig uses a mock data loader and `ImageDecoders.Empty`; 5000 requests per sample.

**Memory cache hits** – every entry resident (8×8 images; asserted before and after), `image(for:)`; 5 samples per run, 7 rounds

| Callers | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| One task, one request at a time | 10.72 ms | 5.17 ms | **−51.8%** | −52.1, −51.8, −51.8, −52.4, −50.3, −52.1, −50.7 |
| The main actor, one request at a time | 57.64 ms | 34.09 ms | **−40.9%** | −42.0, −41.3, −40.8, −41.3, −40.2, −34.4, −35.2 |
| A task group of 5000 | 9.33 ms | 9.38 ms | +0.5% | −2.2, +1.6, −2.6, +1.9, −1.0, +3.2, −2.0 |

**Full loads** – no caches; 3 samples per run (10 for the last two rows), same 7 rounds

| Benchmark | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `data(for:)`, one at a time | 56.86 ms | 51.10 ms | **−10.1%** | −12.4, −8.3, −12.5, −8.5, −11.1, −5.1, −9.7 |
| `image(for:)`, one at a time | 63.48 ms | 61.22 ms | −3.6% | −2.1, −7.8, −5.9, −0.1, −3.8, −5.8, −3.6 |
| `data(for:)`, task group | 40.60 ms | 40.35 ms | −0.6% | −4.9, −0.1, −1.0, +0.6, −0.5, +1.0, +0.2 |
| `asyncAwait` – `image(for:)`, task group | 47.46 ms | 47.80 ms | +0.7% | +0.9, −0.5, +0.4, +0.9, −4.8, −1.1, +2.1 |
| `memoryHit` – 640×480, ~655 of 5000 resident, task group | 8.65 ms | 8.66 ms | +0.1% | −4.9, −2.7, +2.0, +1.1, −4.7, −2.6, +0.9 |

**Control** – `imageTask(with:).image`, which this PR doesn't route differently

| Benchmark | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `asyncImageTask`, 7 rounds | 47.55 ms | 48.55 ms | +2.1% | +2.1, +5.4, +0.0, +4.4, +0.4, +12.5, +1.1 |
| `asyncImageTask`, 11 more rounds | 47.35 ms | 48.18 ms | +1.7% | +1.7, −0.3, +2.4, +1.8, −1.6, +1.1, +1.0, +2.2, +6.8, +1.8, +0.8 |
| `asyncImageTask`, every function aligned to 64 bytes, 9 rounds | 47.77 ms | 47.98 ms | +0.4% | −4.8, +1.2, −0.4, +1.5, +5.7, +1.8, +1.2, +0.7, −3.7 |

That path's code doesn't change, but its placement does. `makeStartedImageTask` and `imageTask(with:)` link at the same addresses as in a build without the `Task.isCancelled` check, and every function after `makeTaskForResponse` – the pipeline's tasks included – moves by the 12 bytes the check adds. That build measured +0.1% (15 rounds) and +0.4% (11 rounds). With `-align-all-functions=6` on both sides, the difference is inside the noise; `memoryHit` is +1.2% and the one-at-a-time hits are −52.1% in the same session.

**Allocations per request** – counted through `malloc_logger`, 5000 requests, two batches each (identical)

| Benchmark | `main` | This PR |
|---|---|---|
| Memory cache hit, one at a time | 17 | **12** |
| `image(for:)` full load, one at a time | 76 | **72** |
| `data(for:)` full load, one at a time | 67 | **63** |
| Memory cache hit, task group | 21 | 22 |
| Memory cache hit, `imageTask(with:).image` | 17 | 17 |

In each task-group batch – `memoryHit`, resident hits, `asyncAwait` – 1 of the 5000 requests ran on the caller's task, the one that found nothing else in flight; one at a time, all 5000 did. The count reads `_task` back after each of 5 batches.

**Time Profiler** – 8 s loop of resident hits, `main` against running every call on its own task, inclusive CPU per request

| Frame | One at a time: `main` | Every call | Task group: `main` | Every call |
|---|---|---|---|---|
| Total | 2577 ns | 1002 ns | 5427 ns | 3415 ns |
| `swift_task_create` | 344 ns | – | 421 ns | 249 ns |
| `swift::AsyncTask::completeFuture` | 336 ns | – | 655 ns | 126 ns |
| `swift_task_enqueueGlobal` | 578 ns | – | 273 ns | 491 ns |
| `__workq_kernreturn` | 524 ns | – | 225 ns | 424 ns |
| `DefaultActorImpl::unlock(bool)` | 10 ns | 7 ns | – | 403 ns |

In the task group, running every call on its own task costs less CPU per request but takes longer: 1.77 → 2.20 µs of wall time per request, with 1.6 cores busy instead of 3.2. On a one-thread pool (`LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`), where no wakeup can be lost, it's faster in both shapes: 1.85 → 1.32 µs per request in the group, 1.45 → 1.00 µs one at a time.

The suite doesn't have a test that loads one request at a time, so `NukePerformanceTests` wasn't run.

### Behaviour

Unchanged, and pinned by tests where the existing ones don't already cover it:

- Cancelling the caller cancels the image task (`cancellation`, `cancelImmediately`, `loadDataCancelImmediately`; and `imageForStartsTaskInTaskWhileAnotherCallerRunsOne` for a call that takes the `Task` path).
- A second awaiter of `response` – for example, one the delegate spawns from `imageTaskCreated` – gets the same response, and cancelling it cancels the task for the caller too.
- `created`, `started`, and `finished` arrive in the same order on a memory cache hit, and the `ImageTask` is deallocated once it finishes.
- The start runs at the caller's priority. A probe of eight caller contexts – a bare `Task` from the main queue, detached tasks from background to user-interactive, a background task escalated before it calls, a task-group child of a utility task – records the same priority for the caller, the start, and the data loader's task as `main`, for both `image(for:)` and `imageTask(with:).image`.

One detail changes. For a call that's alone in flight, the synchronous part of the start – `imageTaskDidStart`, `imageTask(_:didReceiveEvent:)` for a request that finishes during the start, and the cache lookups it makes – runs on the caller's Swift task instead of an unstructured one. `Task.currentPriority` and task-local values there are the same as before. `Task.isCancelled` there can now be `true`, if the caller is cancelled while its request is being started. A caller that's already cancelled takes the `Task` path, which `imageForStartsTaskInTaskWhenCallerIsAlreadyCancelled` pins. Nothing in Nuke reads it during the start, but on `main` those callbacks never see a cancelled task.

On `main`, a delegate that awaits `response` before `makeStartedImageTask` has assigned `_task` force-unwraps `nil`. A task that `image(for:)` runs on the caller's task has no `_task`, so `response` waits for the terminal event instead. For the others the ordering is unchanged, and reading `_task` that early now finds `nil` instead of crashing.

### Trade-offs

- Every `image(for:)` and `data(for:)` takes the task-ID lock twice instead of once: once to count the call in, once to count it out.
- A request that takes the `Task` path from `image(for:)` makes one more allocation than on `main`; the task-group timings don't show it.
- The fast path is all or nothing. With two calls in flight, both take the `Task`, so an app that loads several images at once sees `main`'s behaviour. So does code that awaits `imageTask(with:)`, and the prefetcher.
- Awaiting `response` on a task that has no `_task` costs a `Task`, plus the one `events` spawns to subscribe, where it used to wait on the task's own. Only the delegate or a stored reference can reach such a task.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` with `-skip-testing:` for `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`, which aborts under ThreadSanitizer on a race inside the test mock `MockProgressiveDataLoader`, as it does on `main` – 1100 tests pass: `main`'s 1093, less that one, plus eight new ones.
   - `ImagePipelineAsyncAwaitTests`: a second awaiter gets the same response; cancelling it cancels the caller; a call made while another is in flight gets a `Task` and can be cancelled while the first one finishes; a caller that's already cancelled gets a `Task`, and the start doesn't see the cancellation; the next call after a cancelled one runs on its caller's task again; a utility caller starts the task at utility.
   - `ImagePipelineTaskLifetimeTests`: `started` before `finished` on a memory cache hit, and the task deallocated after it, both through `image(for:)`.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 pass.
3. `swiftlint` reports nothing new in the changed files.
