### PR TITLE
Compare the LazyImage processors by their stored identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - Memory cache lookups for requests with `ImageProcessors/Resize` are 2× faster – https://github.com/kean/Nuke/pull/972
+- `LazyImage` checks whether a request with processors changed 1.7× faster – https://github.com/kean/Nuke/pull/978
 
 **Bug Fixes**
 

--- a/Nuke.xcodeproj/project.pbxproj
+++ b/Nuke.xcodeproj/project.pbxproj
@@ -996,6 +996,7 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nukeui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Debug;
 		};
@@ -1013,6 +1014,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nukeui;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Release;
 		};
@@ -1452,6 +1454,7 @@
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nuke;
 				PRODUCT_NAME = Nuke;
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Debug;
 		};
@@ -1469,6 +1472,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.kean.nuke;
 				PRODUCT_NAME = Nuke;
+				SWIFT_PACKAGE_NAME = Nuke;
 			};
 			name = Release;
 		};

--- a/Sources/Nuke/ImageRequest.swift
+++ b/Sources/Nuke/ImageRequest.swift
@@ -494,7 +494,7 @@ public struct ImageRequest: CustomStringConvertible, Sendable, ExpressibleByStri
     var originalImageID: String? { ref.originalImageID }
 
     /// ``processors``, each boxed into its identity when they were set.
-    var processorsIdentity: [ProcessorID] { ref.processorsIdentity }
+    package var processorsIdentity: [ProcessorID] { ref.processorsIdentity }
 
     /// The hash of ``imageID``, computed when it was set.
     var idHash: Int { ref.idHash }

--- a/Sources/Nuke/Processing/ImageProcessing.swift
+++ b/Sources/Nuke/Processing/ImageProcessing.swift
@@ -115,9 +115,10 @@ public enum ImageProcessingError: Error, CustomStringConvertible, Sendable {
 /// Asking a `Hashable` processor for its `hashableIdentifier` converts it to
 /// `AnyHashable`, which looks up the conformance at runtime, and comparing two
 /// `[any ImageProcessing]` does that for every element on both sides. The
-/// memory cache compares processors on every hit, so a request boxes them
-/// once, when they are set, and its keys compare these instead.
-struct ProcessorID: Hashable, Sendable {
+/// memory cache compares processors on every hit, and `LazyImage` on every
+/// view update, so a request boxes them once, when they are set, and both
+/// compare these instead.
+package struct ProcessorID: Hashable, Sendable {
     // `AnyHashable` erases the `Sendable` conformance of whatever it wraps.
     // Here it wraps what a processor returned – by default the processor
     // itself or its identifier, both `Sendable` – and the keys carry it across

--- a/Sources/NukeUI/Internal.swift
+++ b/Sources/NukeUI/Internal.swift
@@ -103,14 +103,3 @@ extension UIColor {
     }
 }
 #endif
-
-func == (lhs: [any ImageProcessing], rhs: [any ImageProcessing]) -> Bool {
-    guard lhs.count == rhs.count else {
-        return false
-    }
-    // Lazily creates `hashableIdentifiers` because for some processors the
-    // identifiers might be expensive to compute.
-    return zip(lhs, rhs).allSatisfy {
-        $0.hashableIdentifier == $1.hashableIdentifier
-    }
-}

--- a/Sources/NukeUI/LazyImage.swift
+++ b/Sources/NukeUI/LazyImage.swift
@@ -208,7 +208,7 @@ private struct LazyImageContext: Equatable {
         let rhs = rhs.request
         return lhs.imageID == rhs.imageID &&
         lhs.priority == rhs.priority &&
-        lhs.processors == rhs.processors &&
+        lhs.processorsIdentity == rhs.processorsIdentity &&
         lhs.priority == rhs.priority &&
         lhs.options == rhs.options
     }

--- a/Tests/NukeTests/ImageRequestTests.swift
+++ b/Tests/NukeTests/ImageRequestTests.swift
@@ -44,6 +44,62 @@ struct ImageRequestTests {
         #expect(copy.priority == .low)
     }
 
+    // MARK: - Processors Identity
+
+    // `LazyImage` compares requests by `processorsIdentity` instead of by their
+    // processors, so the two comparisons have to agree.
+
+    @Test func processorsIdentityComparesIdentifiersInOrder() {
+        expectProcessorsIdentity([], [], isEqual: true)
+        expectProcessorsIdentity([MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")], [MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")], isEqual: true)
+        expectProcessorsIdentity([MockImageProcessor(id: "p1")], [MockImageProcessor(id: "p2")], isEqual: false)
+        expectProcessorsIdentity([MockImageProcessor(id: "p1")], [MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")], isEqual: false)
+        expectProcessorsIdentity([MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")], [MockImageProcessor(id: "p2"), MockImageProcessor(id: "p1")], isEqual: false)
+    }
+
+    @Test func processorsIdentityOfHashableProcessors() {
+        expectProcessorsIdentity([ImageProcessors.Resize(width: 320)], [ImageProcessors.Resize(width: 320)], isEqual: true)
+        expectProcessorsIdentity([ImageProcessors.Resize(width: 320)], [ImageProcessors.Resize(width: 160)], isEqual: false)
+    }
+
+    @Test func processorsIdentityOfDifferentTypesWithEqualIdentifiers() {
+        // Both identify themselves by `identifier`.
+        expectProcessorsIdentity([MockImageProcessor(id: "p1")], [ImageProcessors.Anonymous(id: "p1") { $0 }], isEqual: true)
+        // A `Hashable` processor identifies itself by its value instead.
+        let resize = ImageProcessors.Resize(width: 320)
+        expectProcessorsIdentity([resize], [MockImageProcessor(id: resize.identifier)], isEqual: false)
+    }
+
+    @Test func processorsIdentityOfCompositions() {
+        let resize = ImageProcessors.Resize(width: 320)
+        expectProcessorsIdentity([ImageProcessors.Composition([resize, MockImageProcessor(id: "p1")])], [ImageProcessors.Composition([resize, MockImageProcessor(id: "p1")])], isEqual: true)
+        expectProcessorsIdentity([ImageProcessors.Composition([resize, MockImageProcessor(id: "p1")])], [ImageProcessors.Composition([MockImageProcessor(id: "p1"), resize])], isEqual: false)
+        expectProcessorsIdentity([ImageProcessors.Composition([resize])], [resize], isEqual: false)
+    }
+
+    @Test func processorsIdentityOfCustomHashableIdentifiers() {
+        expectProcessorsIdentity([MockIdentifierProcessor(id: 1)], [MockIdentifierProcessor(id: 1)], isEqual: true)
+        expectProcessorsIdentity([MockIdentifierProcessor(id: 1)], [MockIdentifierProcessor(id: 2)], isEqual: false)
+        expectProcessorsIdentity([MockIdentifierProcessor(id: 1)], [MockImageProcessor(id: MockIdentifierProcessor(id: 1).identifier)], isEqual: false)
+    }
+
+    private func expectProcessorsIdentity(_ lhs: [any ImageProcessing], _ rhs: [any ImageProcessing], isEqual: Bool, sourceLocation: SourceLocation = #_sourceLocation) {
+        let processorsEqual = lhs == rhs
+        #expect(processorsEqual == isEqual, sourceLocation: sourceLocation)
+        let lhs = ImageRequest(url: Test.url, processors: lhs)
+        let rhs = ImageRequest(url: Test.url, processors: rhs)
+        #expect((lhs.processorsIdentity == rhs.processorsIdentity) == isEqual, sourceLocation: sourceLocation)
+    }
+
+    /// Identifies itself by a number instead of its `identifier`.
+    private struct MockIdentifierProcessor: ImageProcessing {
+        let id: Int
+        var identifier: String { "MockIdentifierProcessor.\(id)" }
+        var hashableIdentifier: AnyHashable { id }
+
+        func process(_ image: PlatformImage) -> PlatformImage? { image }
+    }
+
     // MARK: - Misc
 
     // Just to make sure that comparison works as expected.

--- a/Tests/NukeUITests/LazyImageTests.swift
+++ b/Tests/NukeUITests/LazyImageTests.swift
@@ -508,6 +508,56 @@ struct LazyImageTests {
         #expect(dataLoader.createdTaskCount == 1)
     }
 
+    @Test func noNewRequestWhenProcessorsAreUnchanged() async {
+        let completions = Ref(0)
+        let first = TestExpectation()
+
+        let host = ViewHost([MockImageProcessor(id: "p1")] as [any ImageProcessing]) { processors in
+            LazyImage(url: Test.url)
+                .pipeline(pipeline)
+                .processors(processors)
+                .onCompletion { _ in
+                    completions.value += 1
+                    if completions.value == 1 { first.fulfill() }
+                }
+        }
+        await first.wait()
+
+        // Re-render with a new instance of an equal processor: the request is
+        // rebuilt, but it is equal, so no new load may start.
+        await host.update([MockImageProcessor(id: "p1")])
+        await host.render()
+
+        #expect(completions.value == 1)
+        #expect(dataLoader.createdTaskCount == 1)
+    }
+
+    @Test func newRequestStartedWhenProcessorIdentifierChangesAfterItIsSet() async {
+        let completions = Ref(0)
+        let first = TestExpectation()
+        let second = TestExpectation()
+        let processor = MutableIdentifierProcessor(identifier: "p1")
+
+        let host = ViewHost(0) { _ in
+            LazyImage(url: Test.url)
+                .pipeline(pipeline)
+                .processors([processor])
+                .onCompletion { _ in
+                    completions.value += 1
+                    if completions.value == 1 { first.fulfill() } else { second.fulfill() }
+                }
+        }
+        await first.wait()
+
+        // A request compares the identifiers its processors had when they
+        // were set, so the request rebuilt after the change is a new one.
+        processor.identifier = "p2"
+        await host.update(1)
+        await second.wait()
+
+        #expect(completions.value == 2)
+    }
+
     @Test func newRequestStartedWhenProcessorsChange() async {
         let completions = Ref(0)
         let first = TestExpectation()
@@ -550,6 +600,19 @@ struct LazyImageTests {
         await second.wait()
 
         #expect(completions.value == 2)
+    }
+}
+
+/// A processor whose identifier can change after it's added to a request.
+private final class MutableIdentifierProcessor: ImageProcessing, @unchecked Sendable {
+    var identifier: String
+
+    init(identifier: String) {
+        self.identifier = identifier
+    }
+
+    func process(_ image: PlatformImage) -> PlatformImage? {
+        image
     }
 }
 

--- a/Tests/NukeUITests/NukeUIInternalTests.swift
+++ b/Tests/NukeUITests/NukeUIInternalTests.swift
@@ -4,46 +4,8 @@
 
 import Testing
 import Foundation
-// `Nuke` is imported without `@testable` on purpose: it declares an internal
-// `==` for `[any ImageProcessing]` identical to the one under test in `NukeUI`,
-// and having both in scope makes every use of the operator ambiguous.
 import Nuke
 @testable import NukeUI
-
-@Suite(.timeLimit(.minutes(1))) @MainActor
-struct NukeUIInternalTests {
-
-    // MARK: - Processor Comparison
-
-    @Test func emptyProcessorListsAreEqual() {
-        let empty: [any ImageProcessing] = []
-        #expect(empty == [])
-    }
-
-    @Test func processorListsWithSameProcessorsAreEqual() {
-        let lhs: [any ImageProcessing] = [MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")]
-        let rhs: [any ImageProcessing] = [MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")]
-        #expect(lhs == rhs)
-    }
-
-    @Test func processorListsWithDifferentProcessorsAreNotEqual() {
-        let lhs: [any ImageProcessing] = [MockImageProcessor(id: "p1")]
-        let rhs: [any ImageProcessing] = [MockImageProcessor(id: "p2")]
-        #expect(!(lhs == rhs))
-    }
-
-    @Test func processorListsWithDifferentCountsAreNotEqual() {
-        let lhs: [any ImageProcessing] = [MockImageProcessor(id: "p1")]
-        let rhs: [any ImageProcessing] = [MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")]
-        #expect(!(lhs == rhs))
-    }
-
-    @Test func processorOrderMatters() {
-        let lhs: [any ImageProcessing] = [MockImageProcessor(id: "p1"), MockImageProcessor(id: "p2")]
-        let rhs: [any ImageProcessing] = [MockImageProcessor(id: "p2"), MockImageProcessor(id: "p1")]
-        #expect(!(lhs == rhs))
-    }
-}
 
 #if !os(watchOS)
 


### PR DESCRIPTION
Stacked on #972.

`LazyImage` passes its request to `onChange(of:)` wrapped in a private `LazyImageContext`, so SwiftUI calls `LazyImageContext.==` on the main thread on every body evaluation of every visible `LazyImage`. With one processor that costs ~250 ns, and ~195 ns of it is NukeUI's own copy of the processors `==`, which asks every processor on both sides for its `hashableIdentifier` – for a `Hashable` processor, a conversion to `AnyHashable` at runtime. #969 returns early when both sides share a request's storage, which a request built in `body` never does: `LazyImage(url:)`, or a stored request with `.processors(_:)` or `.priority(_:)` applied, is a new copy on every update, and paid the full comparison. #972 boxes each identifier once, when the processors are set, into `ImageRequest.processorsIdentity`, which the cache keys compare.

`LazyImageContext.==` now compares `processorsIdentity` too, and NukeUI's copy of the operator goes: nothing else used it.

`processorsIdentity` and `ProcessorID` were internal to `Nuke`, and `NukeUI` reached no `Nuke` internals – the one SPI, `@_spi(AsyncImageDecoding)`, is for decoders – so both are now `package`, like #969's `isIdentical(to:)`. `ProcessorID`'s value and initializer stay internal. The `Nuke.xcodeproj` hunk that sets `SWIFT_PACKAGE_NAME` on `Nuke` and `NukeUI` is #969's, line for line, so merging the two resolves it by itself. The comment on `ProcessorID` now names `LazyImage` as its second user.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. #972 and this branch alternate run by run, and the side that runs first alternates by round; median per side, and the Δ of each round.

**Release rig** – SwiftPM, `-c release`; 1M comparisons per row, ns per call; 7 rounds. NukeUI's operator is called the way `onChange(of:)` calls it, through the `Equatable` witness of the stored context; the first row is that harness on its own. These are the rows #969 measured on `main`.

| `LazyImageContext.==` | #972 | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| Harness floor (`Int? ==`) | 36.7 | 36.5 | −0.5% | +2.9, +0.3, +2.5, −0.5, +0.7, −3.2, −1.6 |
| Rebuilt request, 1 `Resize` | 249.5 | 142.2 | **−43.0%** | −45.3, −42.6, −43.1, −39.2, −42.5, −44.6, −42.3 |
| Rebuilt request, no processors | 59.8 | 59.7 | −0.2% | −1.3, +1.4, +1.2, +0.4, +1.7, −0.5, −1.9 |
| Same request, 1 `Resize` | 250.1 | 60.1 | **−76.0%** | −76.7, −75.1, −75.8, −73.7, −76.6, −76.5, −75.5 |
| Same request, no processors | 59.9 | 59.5 | −0.8% | −2.0, −0.7, +1.5, −0.8, −0.8, −0.4, −0.8 |
| Different URL, 1 `Resize` | 56.2 | 54.9 | −2.2% | −0.6, +1.0, −2.9, +11.9, −2.5, −1.3, −2.7 |

Net of the harness, a rebuilt request with one `Resize` goes from ~213 to ~106 ns; what's left of the processors is one `AnyHashable ==` per processor. Copies of one request – including copies with `.priority(_:)` applied, which copy the storage but not the processors – share the `processorsIdentity` array, and `Array ==` returns on shared storage without comparing the elements, so that row goes to ~24 ns. #969's identity check returns before that, so once both land, this PR's gain is the rebuilt row; the changelog's 1.7× is that row. The rig's rows that time a fixed copy of the old operator, which run no changed code, moved by a nanosecond at most.

**Controls** – 21 rounds

| Benchmark | #972 | This PR | Δ | Rounds slower / faster |
|---|---|---|---|---|
| `asyncAwait` | 45.15 ms | 45.20 ms | +0.1% | 12 / 9 |
| `memoryHit` | 8.26 ms | 8.09 ms | −2.0% | 8 / 13 |
| `asyncImageTask` | 45.16 ms | 45.44 ms | +0.6% | 14 / 7 |

`asyncImageTask` was slower in most rounds, so the two builds were compared instruction by instruction. Disassembled with `otool`, every function in `Nuke` is identical in both; this branch only adds the four symbols `package` makes the compiler emit – the `processorsIdentity` getter and `ProcessorID`'s `==`, `hash(into:)`, and `hashValue`. In `NukeUI`, `LazyImageContext.==` is the only function that changed. None of the controls runs different code, and a first, 7-round session measured them at +0.2%, −2.0%, and −1.0%, `asyncImageTask` faster in six rounds.

### Behaviour

A request's `processorsIdentity` holds the identifiers its processors returned when they were set; the old operator asked for them at every comparison. Only a processor whose `hashableIdentifier` changes after it's added to a request – a class, `@unchecked Sendable` – can tell. When a `LazyImage`'s body builds its request again after such a change, the view now starts a new load, where the old comparison asked the same instance on both sides and saw no change. That was already reachable: the old comparison read the two sides one after the other, so a change that landed between the reads started a new load too, and a `LazyImage` that disappears and reappears loads its current request either way. Nothing documents when `identifier` or `hashableIdentifier` is read, and since #972 the memory cache and task keys use the identifiers from when the processors were set, so the view now agrees with the cache it reads from. `LazyImageTests.newRequestStartedWhenProcessorIdentifierChangesAfterItIsSet` pins it.

Copies that share the processors are equal without asking each one, because `Array ==` checks for shared storage first. Only a processor whose `==` isn't reflexive, which `Equatable` rules out, could tell, and #969's identity check does the same for copies that share the request's storage.

### Trade-offs

- `package` access, as in #969: a build that compiles `Nuke` and `NukeUI` without a shared package name won't compile `NukeUI`. SwiftPM and `Nuke.xcodeproj` both set one.
- `ProcessorID` joins what the package can see: `NukeUI` gets the type and its `Hashable` conformance, not the value it wraps or its initializer.
- #969 edits the same `LazyImageContext.==` – its identity check goes above the line this PR changes, and it drops the duplicated `priority` line below it – so the two conflict there, and the resolution keeps both. They also conflict in `ImageRequest.swift`, where #969 adds `isIdentical(to:)` next to `processorsIdentity`, as #972 already does. The `Nuke.xcodeproj` hunk is identical in both.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` with `-skip-testing:` on `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress` – 1099 pass and 3 are skipped, 1102 in all: #972's suite plus five new tests. Without the skip, that test's known ThreadSanitizer abort – a race inside the test mock `MockProgressiveDataLoader`, which reproduces on `main` – was the only failure.
   - The new `ImageRequestTests` check that `processorsIdentity` equality agrees both with `[any ImageProcessing] ==` – `Nuke`'s copy of the deleted operator, which `Composition` still uses – and with the expected result: equal and different identifiers, counts, and order, the five cases `NukeUIInternalTests` covered; `Hashable` processors; different types with equal identifiers – `MockImageProcessor` and `Anonymous` with one `identifier` are equal, `Resize` and a processor with `Resize`'s `identifier` aren't; `Composition`s, reordered and against the processor they wrap; and a custom `hashableIdentifier`.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeUITests -destination 'platform=macOS' -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO` – 363 pass: the 366 #969 counted on `main`, which #972 doesn't change, less the five `NukeUIInternalTests` of the deleted operator, plus two `LazyImageTests`. `noNewRequestWhenProcessorsAreUnchanged` rebuilds an equal processor in `body` and starts no load; the other is the behaviour test above. The existing `newRequestStartedWhenProcessorsChange` covers the unequal path.
3. `swift build -c release` of `Nuke` and `NukeUI` has no warnings, `NukeTests` and `NukeUITests` build with none in the changed files, and `swiftlint` reports nothing new in them.
