### PR TITLE
Build Resize identifiers, data cache keys, and filenames without intermediate strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
+- `ImagePipeline/Cache-swift.struct/containsCachedImage(for:caches:)` is 16% faster for requests with `ImageProcessors/Resize` – https://github.com/kean/Nuke/pull/979
 
 **Bug Fixes**
 

--- a/Sources/Nuke/Internal/Extensions.swift
+++ b/Sources/Nuke/Internal/Extensions.swift
@@ -13,18 +13,24 @@ extension String {
     /// // prints "50334ee0b51600df6397ce93ceed4728c37fee4e"
     /// ```
     var sha1: String {
-        let digest = Insecure.SHA1.hash(data: Data(self.utf8))
-        let hexCount = Insecure.SHA1Digest.byteCount * 2
-        let bytes = [UInt8](unsafeUninitializedCapacity: hexCount) { buffer, count in
-            var i = 0
-            for byte in digest {
-                buffer[i] = sha1HexChars[Int(byte >> 4)]
-                buffer[i &+ 1] = sha1HexChars[Int(byte & 0x0F)]
-                i &+= 2
+        // Hashes the UTF-8 in place and writes the hex straight into the new
+        // string: no `Data` copy of the key, no array behind the digest's
+        // iterator, and no buffer to copy the hex out of. `withUTF8` only
+        // copies a string that isn't contiguous UTF-8, e.g. a bridged one.
+        var string = self
+        var hasher = Insecure.SHA1()
+        string.withUTF8 { hasher.update(bufferPointer: UnsafeRawBufferPointer($0)) }
+        return hasher.finalize().withUnsafeBytes { digest in
+            String(unsafeUninitializedCapacity: digest.count * 2) { buffer in
+                var i = 0
+                for byte in digest {
+                    buffer[i] = sha1HexChars[Int(byte >> 4)]
+                    buffer[i &+ 1] = sha1HexChars[Int(byte & 0x0F)]
+                    i &+= 2
+                }
+                return i
             }
-            count = hexCount
         }
-        return String(decoding: bytes, as: UTF8.self)
     }
 }
 

--- a/Sources/Nuke/Pipeline/ImagePipeline+Cache.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Cache.swift
@@ -232,7 +232,16 @@ extension ImagePipeline.Cache {
         if let customKey = pipeline.delegate.cacheKey(for: request, pipeline: pipeline) {
             return customKey
         }
-        return "\(request.imageID ?? "")\(request.thumbnail?.identifier ?? "")\(ImageProcessors.Composition(request.processors).identifier)"
+        // Appends to the image ID instead of interpolating the pieces, so the
+        // processor identifiers aren't joined into an intermediate string first.
+        var key = request.imageID ?? ""
+        if let thumbnail = request.thumbnail {
+            key += thumbnail.identifier
+        }
+        for processor in request.processors {
+            key += processor.identifier
+        }
+        return key
     }
 
     // MARK: Misc

--- a/Sources/Nuke/Processing/ImageProcessors+Resize.swift
+++ b/Sources/Nuke/Processing/ImageProcessors+Resize.swift
@@ -63,7 +63,24 @@ extension ImageProcessors {
         }
 
         public var identifier: String {
-            "com.github.kean/nuke/resize?s=\(size.cgSize),cm=\(contentMode),crop=\(crop),upscale=\(upscale)"
+            guard !isCGSizeInterpolatedThroughRetroactiveConformance else {
+                return "com.github.kean/nuke/resize?s=\(size.cgSize),cm=\(contentMode),crop=\(crop),upscale=\(upscale)"
+            }
+            // Appended piece by piece instead of interpolated: interpolating a
+            // `CGSize` looks up its conformances at runtime and builds its
+            // `debugDescription`, "(width, height)", as an intermediate string.
+            // The output is the same byte for byte – it's part of the disk cache key.
+            let size = self.size.cgSize
+            var identifier = "com.github.kean/nuke/resize?s=("
+            identifier.reserveCapacity(96)
+            identifier += size.width.description
+            identifier += ", "
+            identifier += size.height.description
+            identifier += "),cm="
+            identifier += contentMode.description
+            identifier += crop ? ",crop=true" : ",crop=false"
+            identifier += upscale ? ",upscale=true" : ",upscale=false"
+            return identifier
         }
 
         public var description: String {
@@ -71,6 +88,16 @@ extension ImageProcessors {
         }
     }
 }
+
+// Interpolation prints a `CGSize` through a `CustomStringConvertible` or
+// `TextOutputStreamable` conformance if an app adds one retroactively, and
+// `Resize.identifier` keeps interpolating then, so its output doesn't change.
+// The casts are from `Any`, like the interpolation's: casting `CGSize` directly
+// warns that the test is always true, which it isn't.
+private let isCGSizeInterpolatedThroughRetroactiveConformance: Bool = {
+    let size: Any = CGSize.zero
+    return size is any CustomStringConvertible || size is any TextOutputStreamable
+}()
 
 // Adds Hashable without making changes to public CGSize API. It uses `Float`
 // to reduce memory size.

--- a/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
@@ -112,6 +112,24 @@ struct ImagePipelinePerformanceTests {
             }
         }
     }
+
+    /// The disk cache key is built on every read, write, and existence check
+    /// against the data cache, and it includes the identifier of every
+    /// processor in the request.
+    @Test
+    func makingDataCacheKeys() {
+        let pipeline = makePipeline()
+        let requests = (0..<64).map {
+            ImageRequest(url: URL(string: "http://test.com/\($0)"), processors: [ImageProcessors.Resize(width: 320)])
+        }
+        measure {
+            var count = 0
+            for index in 0..<100_000 {
+                count &+= pipeline.cache.makeDataCacheKey(for: requests[index & 63]).utf8.count
+            }
+            return count
+        }
+    }
 }
 
 /// Never has the data, so every iteration downloads it again.

--- a/Tests/NukeTests/DataCacheTests.swift
+++ b/Tests/NukeTests/DataCacheTests.swift
@@ -95,6 +95,23 @@ final class DataCacheTests {
         #expect("http://test.com".sha1 == "50334ee0b51600df6397ce93ceed4728c37fee4e")
     }
 
+    /// The names of the files that are already on disk: a change to the
+    /// default generator orphans every one of them.
+    @Test func defaultFilenames() {
+        #expect(DataCache.filename(for: "") == nil)
+        #expect(DataCache.filename(for: "http://test.com/example.jpeg") == "d6508d77a18185fe66de6d86114ab5ec047601f1")
+        // Longer than a single SHA-1 block
+        #expect(DataCache.filename(for: "http://test.com/example.jpegcom.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=false") == "2b9ba15e11fdeb66d16c9a567ec76daffede4d19")
+        #expect(DataCache.filename(for: "ключ-🙂-キー") == "3501d5a013096b5cddfd72bae019d21233fc221b")
+        // Strings bridged from Objective-C, which aren't stored as native UTF-8
+        #expect(DataCache.filename(for: NSString(string: "http://test.com/example.jpeg") as String) == "d6508d77a18185fe66de6d86114ab5ec047601f1")
+        #expect(DataCache.filename(for: NSString(string: "ключ-🙂-キー") as String) == "3501d5a013096b5cddfd72bae019d21233fc221b")
+        // Lone surrogates are hashed as U+FFFD
+        let units: [unichar] = [0x61, 0xD83D, 0x62, 0xDC00]
+        #expect(DataCache.filename(for: NSString(characters: units, length: units.count) as String) == "100bcf494247472b60afe6f0d383d037b522cd76")
+        #expect(DataCache.filename(for: "a\u{FFFD}b\u{FFFD}") == "100bcf494247472b60afe6f0d383d037b522cd76")
+    }
+
     // MARK: Add
 
     @Test func add() {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -330,6 +330,48 @@ struct ImagePipelineTests {
         #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpegcom.github/kean/nuke/thumbnail?width=400.0,height=400.0,contentMode=.aspectFit,options=truetruetruetrue")
     }
 
+    @Test func cacheKeyForRequestWithResize() {
+        let request = ImageRequest(url: Test.url, processors: [ImageProcessors.Resize(width: 320, unit: .pixels)])
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpegcom.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=false")
+    }
+
+    @Test func cacheKeyForRequestWithMultipleProcessors() {
+        let request = ImageRequest(url: Test.url, processors: [ImageProcessors.Resize(width: 320, unit: .pixels), ImageProcessors.Circle()])
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpegcom.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=falsecom.github.kean/nuke/circle")
+    }
+
+    @Test func cacheKeyForRequestWithThumbnailAndProcessors() {
+        let request = ImageRequest(url: Test.url, processors: [ImageProcessors.Resize(width: 320, unit: .pixels)]).with {
+            $0.thumbnail = .init(maxPixelSize: 400)
+        }
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpegcom.github/kean/nuke/thumbnail?maxPixelSize=400.0,options=truetruetruetruecom.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=false")
+    }
+
+    @Test func cacheKeyForRequestWithoutURL() {
+        let request = ImageRequest(url: nil, processors: [ImageProcessors.Resize(width: 320, unit: .pixels)])
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "com.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=false")
+    }
+
+    @Test func cacheKeyForRequestWithoutURLOrProcessors() {
+        #expect(pipeline.cache.makeDataCacheKey(for: ImageRequest(url: nil)).isEmpty)
+    }
+
+    @Test func cacheKeyForRequestWithNestedComposition() {
+        let resize = ImageProcessors.Resize(width: 320, unit: .pixels)
+        let anonymous = ImageProcessors.Anonymous(id: "1", { $0 })
+        let nested = ImageRequest(url: Test.url, processors: [ImageProcessors.Composition([resize, ImageProcessors.Circle()]), anonymous])
+        let flat = ImageRequest(url: Test.url, processors: [resize, ImageProcessors.Circle(), anonymous])
+        let key = "http://test.com/example.jpegcom.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=falsecom.github.kean/nuke/circle1"
+        #expect(pipeline.cache.makeDataCacheKey(for: nested) == key)
+        #expect(pipeline.cache.makeDataCacheKey(for: flat) == key)
+    }
+
+    @Test func cacheKeyForRequestWithEmptyProcessorIdentifiers() {
+        let empty = ImageProcessors.Anonymous(id: "", { $0 })
+        let request = ImageRequest(url: Test.url, processors: [empty, ImageProcessors.Resize(width: 320, unit: .pixels), empty])
+        #expect(pipeline.cache.makeDataCacheKey(for: request) == "http://test.com/example.jpegcom.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=false")
+    }
+
     // MARK: - Invalidate
 
     @Test func whenInvalidatedTasksAreCancelled() async {

--- a/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
+++ b/Tests/NukeTests/ImageProcessorsTests/ResizeTests.swift
@@ -363,6 +363,61 @@ struct ImageProcessorsResizeTests {
         )
     }
 
+    /// The identifier is part of the disk cache key: a change to its format
+    /// orphans every processed image that is already on disk.
+    @Test(arguments: [
+        (ImageProcessors.Resize(size: CGSize(width: 320, height: 240), unit: .pixels), "com.github.kean/nuke/resize?s=(320.0, 240.0),cm=.aspectFill,crop=false,upscale=false"),
+        (ImageProcessors.Resize(width: 320, unit: .pixels), "com.github.kean/nuke/resize?s=(320.0, 9999.0),cm=.aspectFit,crop=false,upscale=false"),
+        (ImageProcessors.Resize(height: 240, unit: .pixels, upscale: true), "com.github.kean/nuke/resize?s=(9999.0, 240.0),cm=.aspectFit,crop=false,upscale=true"),
+        // Every content mode, crop, and upscale
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFill, crop: false, upscale: false), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFill,crop=false,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFill, crop: false, upscale: true), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFill,crop=false,upscale=true"),
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFill, crop: true, upscale: false), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFill,crop=true,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFill, crop: true, upscale: true), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFill,crop=true,upscale=true"),
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFit, crop: false, upscale: false), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFit,crop=false,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFit, crop: false, upscale: true), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFit,crop=false,upscale=true"),
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFit, crop: true, upscale: false), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFit,crop=true,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: 30, height: 40), unit: .pixels, contentMode: .aspectFit, crop: true, upscale: true), "com.github.kean/nuke/resize?s=(30.0, 40.0),cm=.aspectFit,crop=true,upscale=true"),
+        // Sizes that aren't integral, aren't representable as `Float`, print
+        // with an exponent, or aren't finite
+        (ImageProcessors.Resize(size: CGSize(width: 100.5, height: 33.3), unit: .pixels, crop: true), "com.github.kean/nuke/resize?s=(100.5, 33.29999923706055),cm=.aspectFill,crop=true,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: 1.0 / 3, height: 2.0 / 3), unit: .pixels, contentMode: .aspectFit, crop: true, upscale: true), "com.github.kean/nuke/resize?s=(0.3333333432674408, 0.6666666865348816),cm=.aspectFit,crop=true,upscale=true"),
+        (ImageProcessors.Resize(size: CGSize(width: 16_777_217, height: 1e7), unit: .pixels), "com.github.kean/nuke/resize?s=(16777216.0, 10000000.0),cm=.aspectFill,crop=false,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: 1e-7, height: 1e20), unit: .pixels), "com.github.kean/nuke/resize?s=(1.0000000116860974e-07, 1.0000000200408773e+20),cm=.aspectFill,crop=false,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: -0.0, height: 0), unit: .pixels), "com.github.kean/nuke/resize?s=(-0.0, 0.0),cm=.aspectFill,crop=false,upscale=false"),
+        (ImageProcessors.Resize(size: CGSize(width: CGFloat.infinity, height: CGFloat.nan), unit: .pixels), "com.github.kean/nuke/resize?s=(inf, nan),cm=.aspectFill,crop=false,upscale=false")
+    ])
+    func identifierFormat(processor: ImageProcessors.Resize, identifier: String) {
+        #expect(processor.identifier == identifier)
+    }
+
+#if os(macOS)
+    @Test func identifierFormatInPoints() {
+        // Points are pixels on macOS, where the screen scale is always 1
+        #expect(
+            ImageProcessors.Resize(size: CGSize(width: 40, height: 30)).identifier ==
+            "com.github.kean/nuke/resize?s=(40.0, 30.0),cm=.aspectFill,crop=false,upscale=false"
+        )
+    }
+#endif
+
+#if os(iOS) || os(tvOS)
+    @Test func identifierFormatInPoints() {
+        UITraitCollection(displayScale: 2).performAsCurrent {
+            #expect(
+                ImageProcessors.Resize(size: CGSize(width: 33.3, height: 40)).identifier ==
+                "com.github.kean/nuke/resize?s=(66.5999984741211, 80.0),cm=.aspectFill,crop=false,upscale=false"
+            )
+        }
+        UITraitCollection(displayScale: 3).performAsCurrent {
+            #expect(
+                ImageProcessors.Resize(size: CGSize(width: 33.3, height: 40)).identifier ==
+                "com.github.kean/nuke/resize?s=(99.9000015258789, 120.0),cm=.aspectFill,crop=false,upscale=false"
+            )
+        }
+    }
+#endif
+
     @Test func description() {
         // Given
         let processor = ImageProcessors.Resize(size: CGSize(width: 30, height: 30), unit: .pixels, contentMode: .aspectFit)


### PR DESCRIPTION
Every read, write, and existence check against the disk cache builds a key with `ImagePipeline.Cache/makeDataCacheKey(for:)`, and `DataCache` hashes the key into a filename. With one `ImageProcessors.Resize` in the request, the key took 470 ns and the filename another 455 ns – a quarter of a `containsCachedImage(for:)` that checks the disk. Behind a download and a decode that's under 1%, but a check per cell, prefetching to disk, and `ImagePipeline.Cache` used directly have nothing to hide it behind.

Most of it was intermediate strings:

- `Resize.identifier` interpolated `size.cgSize`. `CGSize` is only `CustomDebugStringConvertible`, so the interpolation takes the unconstrained overload, which checks the value's conformances at runtime and then builds its `debugDescription` – `"(\(width), \(height))"`, a second interpolation – to copy into the first: 334 ns and 2 allocations.
- `makeDataCacheKey(for:)` wrapped the processors in an `ImageProcessors.Composition`, whose identifier maps them into an array and joins it, and interpolated that with the image ID and the thumbnail's identifier: 5 allocations with one `Resize`.
- `String.sha1` copied the key into `Data`, read the digest through `Sequence`, which copies it into an array, wrote the hex into a second array, and copied that into the string: 8 allocations.

### Changes

- `Resize.identifier` appends the prefix, `width.description`, `", "`, `height.description`, and the rest to one string – what `CGSize.debugDescription` prints, byte for byte.
- Because the interpolation checks conformances at runtime, an app that conforms `CGSize` to `CustomStringConvertible` or `TextOutputStreamable` retroactively gets a different identifier on `main`: with a `description` of `"\(width)x\(height)"`, `s=320.0x9999.0`. A file-level constant checks for either conformance once, and the identifier keeps interpolating if there is one, so that app's keys don't change either. It casts from `Any`, as the interpolation does: `CGSize.zero is any CustomStringConvertible` warns that the test is always true, though it evaluates to `false` at `-Onone` and `-O` alike.
- `makeDataCacheKey(for:)` appends the thumbnail's identifier and each processor's to the image ID. `Composition.identifier` is its processors' identifiers concatenated, so the key is the same for every processor, a nested `Composition` included, and each identifier is still read once, in the same order. With no thumbnail and no processors, the key is the image ID itself.
- `String.sha1` hashes the string's UTF-8 in place with `withUTF8` and writes the hex straight into `String(unsafeUninitializedCapacity:initializingUTF8With:)`. `withUTF8` copies a string that isn't contiguous UTF-8, such as a bridged `NSString`, and repairs ill-formed UTF-16 as `Data(utf8)` did.
- The first commit adds `makingDataCacheKeys` to `ImagePipelinePerformanceTests`.

### Keys and filenames

Nothing on disk changes.

- The second commit lands before the change and passes on `main`, on macOS and in the iOS 18.6 simulator. It pins the identifier of 17 `Resize` configurations – every content mode, crop, and upscale; 100.5 × 33.3, 1/3 × 2/3, (2²⁴ + 1) × 10⁷, 10⁻⁷ × 10²⁰, −0 × 0, ∞ × NaN – and of a size in points at scale 1 on macOS and at 2 and 3 on iOS and tvOS; the data cache key with one and two processors, a thumbnail and a processor, no URL, no URL and no processors, a `Composition` among the processors against the same processors flat, and processors with empty identifiers; and the filename of an ASCII key, a key longer than a SHA-1 block, a non-ASCII key, bridged ASCII and non-ASCII `NSString`s, and a key with lone surrogates.
- Two harnesses, one linking `main` and one this branch, hashed the UTF-8 and the UTF-16 of 2.21 M `Resize` identifiers – 270,000 sizes from special values, random `Float` bit patterns, and realistic sizes, each in every content mode, crop, and upscale, plus points and the `width:` and `height:` initializers; of 1,296 data cache keys – nine image IDs (none, empty, the URL, non-ASCII, bridged, ill-formed UTF-16) × four thumbnails × 36 processor lists with nested and empty compositions and empty and non-`Hashable` custom processors – and their filenames; and of 12,900 filenames for keys of every ASCII length up to 300, random scalars, and random UTF-16 with lone surrogates, native, bridged, and sliced. The digests are identical.
- An app with a retroactive `CustomStringConvertible` conformance gets the same identifier and key from `main` and from this branch.
- On 32-bit watchOS, arm64_32, `CGFloat.NativeType` is `Float`. The appends print through `CGFloat.description`, which the SDK declares `@_transparent` as `native.description` for every architecture. `main` prints through `CGSize.debugDescription`, whose body isn't in the interface; it prints the same two `CGFloat` descriptions on macOS 26.6 and in the iOS 18.6 simulator. The branch builds for arm64_32. The pins assume a 64-bit `CGFloat`, and the test targets don't run on watchOS.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. `main` and this branch alternate run by run, and the side that runs first alternates by round; median per side, and the Δ of each round. The release rig ran with both sides on `aae3faed`, and the suite on #971's merge; neither #971 nor #975, which the branch is now rebased on, changes the three source files.

**Release rig** – 7 rounds, 5 samples per run

| Benchmark | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `Resize(width: 320).identifier` | 333.6 ns | 129.7 ns | **−61.1%** | −60.0, −60.6, −60.7, −61.3, −62.5, −63.0, −60.9 |
| `.identifier` of a 213.33333 × 133.7 `Resize` that crops | 414.2 ns | 159.4 ns | **−61.5%** | −60.2, −61.7, −61.4, −62.2, −61.0, −62.1, −63.2 |
| `makeDataCacheKey(for:)`, no processors | 61.8 ns | 9.5 ns | **−84.7%** | −84.1, −85.0, −84.7, −83.8, −84.9, −85.4, −83.4 |
| `makeDataCacheKey(for:)`, one `Resize` | 470.4 ns | 181.3 ns | **−61.5%** | −61.0, −60.6, −61.0, −61.4, −62.1, −61.8, −60.8 |
| `makeDataCacheKey(for:)`, `Resize` and `Circle` | 550.6 ns | 233.0 ns | **−57.7%** | −56.8, −55.3, −56.5, −58.0, −56.2, −58.5, −55.4 |
| `makeDataCacheKey(for:)`, thumbnail and `Resize` | 661.3 ns | 407.0 ns | **−38.5%** | −38.3, −37.4, −37.6, −39.8, −38.0, −38.9, −34.4 |
| `DataCache.filename(for:)`, 28-character key | 395.3 ns | 238.9 ns | **−39.6%** | −39.5, −38.9, −38.7, −39.8, −38.8, −39.6, −31.6 |
| `DataCache.filename(for:)`, 120-character key | 455.5 ns | 315.3 ns | **−30.8%** | −30.4, −32.8, −34.4, −34.4, −30.5, −30.0, −28.1 |
| `containsCachedImage(for:)`, one `Resize` | 3574 ns | 3001 ns | **−16.0%** | −16.6, −17.2, −15.9, −16.7, −19.9, −17.3, −17.3 |
| `containsCachedImage(for:caches: [.disk])`, one `Resize` | 3491 ns | 2900 ns | **−16.9%** | −18.5, −18.6, −17.8, −17.9, −16.0, −16.0, −15.7 |
| `containsCachedImage(for:)`, no processors | 2984 ns | 2691 ns | **−9.8%** | −13.8, −10.5, −6.7, −10.2, −9.1, −9.6, −7.0 |
| Missing load, processor with `Resize`'s identifier | 15.0 µs | 14.6 µs | −2.5% | −2.9, −3.7, −1.8, −2.5, +1.1, −6.8, −6.1 |
| Missing load, processor with a literal identifier | 14.7 µs | 14.3 µs | −2.3% | −1.2, −2.2, −2.3, −1.8, +4.2, −4.5, −2.0 |
| `asyncAwait` (control) | 9.7 µs | 9.6 µs | −1.0% | −1.0, −1.8, −2.1, −0.9, −0.5, +61.5, −4.3 |
| `memoryHit` (control) | 1.8 µs | 1.8 µs | +2.4% | +2.4, +2.4, −2.5, +14.8, −4.1, +0.8, −5.4 |
| `asyncImageTask` (control) | 9.7 µs | 9.5 µs | −1.7% | −1.7, −2.0, −0.7, +0.0, +1.5, +0.4, +16.5 |

`Resize(width: 320)` is in points, which are pixels on macOS, and the thumbnail is `maxPixelSize: 320`. The `containsCachedImage` rows use a real `DataCache` and 256 requests, every other one on disk after a flush and none in memory; with the default caches, each call misses the memory cache first. The missing loads are 5000 concurrent `image(for:)` with a mock loader, `ImageDecoders.Empty`, and a `DataCaching` that never has the data. The processor does nothing but carry the identifier, so nothing is resized; each load builds one key with it and two without, counted. The controls configure no data cache and build no key. In a separate session, each of 15 rounds also ran `main` against itself: `memoryHit` measured +2.1% and was slower in 7 rounds, against −1.6% and 6 for the A/A; `asyncImageTask` +0.3% and 8, against −0.9% and 4, with A/A rounds from −13.2% to +1.1%.

**Allocations per call** – release rig, counted through `malloc_logger` over 10,000 calls; 3 runs, identical

| | `main` | This PR |
|---|---|---|
| `Resize(width: 320).identifier` | 2 (272 B) | **1** (144 B) |
| `.identifier` of a 213.33333 × 133.7 `Resize` that crops | 6 (560 B) | **3** (272 B) |
| `makeDataCacheKey(for:)`, no processors | 1 (80 B) | **0** |
| `makeDataCacheKey(for:)`, one `Resize` | 5 (576 B) | **2** (320 B) |
| `makeDataCacheKey(for:)`, `Resize` and `Circle` | 7 (832 B) | **3** (384 B) |
| `makeDataCacheKey(for:)`, `Composition([Resize, Circle])` | 8 (880 B) | **5** (624 B) |
| `makeDataCacheKey(for:)`, thumbnail and `Resize` | 9 (1200 B) | **7** (1024 B) |
| `DataCache.filename(for:)`, 28 or 120 characters, native or bridged | 8 (475–572 B) | **4** (260 B) |
| `containsCachedImage(for:caches: [.disk])`, one `Resize`, on disk | 26 (2757 B) | **19** (2189 B) |

The fractional size allocates more because its `Double` descriptions don't fit in a small string.

**Suite** – `NukePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel; "before" is the second commit of this PR; 5 rounds

| Test | Before | After | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `ImagePipelinePerformanceTests.makingDataCacheKeys` | 52.77 ms | 19.21 ms | **−63.6%** | −62.6, −63.4, −61.3, −62.5, −64.0 |
| `ImageProcessingPerformanceTests.creatingProcessorIdentifiers` | 9.08 ms | 3.24 ms | **−64.3%** | −60.1, −66.8, −64.3, −64.3, −56.7 |
| `MiscPerformanceTests.sha1FilenameGeneration` | 39.53 ms | 22.78 ms | **−42.4%** | −42.4, −40.9, −41.3, −43.8, −42.7 |
| `DataCachePeformanceTests.defaultFilenameGeneration` | 0.504 ms | 0.289 ms | **−42.7%** | −42.7, −41.7, −42.2, −44.0, −43.1 |

### Trade-offs

- `Resize.identifier` is 17 lines instead of one, and its format is written twice: in the appends, and in the interpolation kept for a retroactive conformance. The pins fail if the two drift.
- The conformance check runs once per process. A conformance in a bundle loaded after the first `Resize` identifier is built isn't picked up; on `main`, the identifiers built before that bundle loads ignore it too.
- With no thumbnail and no processors, `makeDataCacheKey(for:)` returns the image ID rather than a copy of it. The digest's bridged and ill-formed IDs read the same in UTF-8 and UTF-16.
- The thumbnail's identifier still interpolates, and it's most of what the thumbnail row still costs.
- Overlaps: the delegate-hook guard from the same round of profiling edits the `cacheKey(for:pipeline:)` line at the top of `makeDataCacheKey(for:)`, two lines above this hunk. #970, #972, and #973 also add tests at the end of `ImagePipelinePerformanceTests`.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` with `-skip-testing:` on `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress`, the known ThreadSanitizer abort inside the test mock `MockProgressiveDataLoader` – 1113 passed and 3 skipped, on `main` after #975. The new tests:
   - `ImageProcessorsResizeTests.identifierFormat(processor:identifier:)`, 17 cases, and `identifierFormatInPoints`
   - `ImagePipelineTests.cacheKeyForRequestWithResize`, `…WithMultipleProcessors`, `…WithThumbnailAndProcessors`, `…WithoutURL`, `…WithoutURLOrProcessors`, `…WithNestedComposition`, and `…WithEmptyProcessorIdentifiers`
   - `DataCacheTests.defaultFilenames`
2. The pins on the second commit, before the change: `ImageProcessorsResizeTests`, `ImageProcessorsCompositionTests`, and the cache key and filename tests pass on macOS (53) and in the iOS 18.6 simulator (57, with the points pins at 2× and 3×).
3. The same selection on this branch in the iOS 18.6 simulator – 57 passed.
4. `xcodebuild build -project Nuke.xcodeproj -scheme Nuke -destination 'generic/platform=watchOS' CODE_SIGNING_ALLOWED=NO` – builds for arm64_32 and arm64.
5. `NukePerformanceTests` builds with no warnings in the changed files. `swiftlint` reports nothing new in the changed files, and one violation fewer in `Extensions.swift`.
