### PR TITLE
Register ImageTask event streams without a Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
+- Subscribing to `ImageTask/events` of a finished task is 1.8× faster – https://github.com/kean/Nuke/pull/980
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
-- Subscribing to `ImageTask/events` of a finished task is 1.8× faster – https://github.com/kean/Nuke/pull/980
+- Subscribing to `ImageTask/events` no longer spawns a `Task`, which makes it 1.2–1.9× faster – https://github.com/kean/Nuke/pull/980
 
 **Bug Fixes**
 
@@ -87,6 +87,7 @@
 - Fix `DataCache` writing entries non-atomically, so a read that arrived while the same key was being overwritten could return a truncated file – https://github.com/kean/Nuke/pull/937
 - Fix `VideoPlayerView` not resuming a looping video on macOS when the view is added back to a window – https://github.com/kean/Nuke/pull/951
 - Fix `ImagePrefetcher/didComplete` not being called when stopping prefetching cancels the last outstanding request – https://github.com/kean/Nuke/pull/968
+- Fix `ImageTask/events`, `ImageTask/progress`, and `ImageTask/previews` missing previews and progress updates sent before the subscription lands – https://github.com/kean/Nuke/pull/980
 
 **Documentation**
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -212,11 +212,12 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     /// iterating both ``progress`` and ``previews`` creates two subscriptions –
     /// store the stream in a variable if you want a single subscription.
     ///
-    /// A stream always ends with the terminal ``Event/finished(_:)`` event.
-    /// Subscribing is safe at any point in the task lifetime: a stream created
-    /// after the task has already finished replays the terminal event, and a
-    /// stream created mid-download starts with the current
-    /// ``Event/progress(_:)`` value, if any.
+    /// A stream always ends with the terminal ``Event/finished(_:)`` event and
+    /// receives every event sent after it is created. Subscribing is safe at
+    /// any point in the task lifetime: a stream created after the task has
+    /// already finished replays the terminal event, and a stream created
+    /// mid-download starts with the current ``Event/progress(_:)`` value, if
+    /// any.
     ///
     /// - note: A stream buffers the events that the consumer hasn't picked up
     /// yet, so a slow consumer never misses one.
@@ -251,7 +252,9 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     nonisolated(unsafe) var _task: Task<Result<ImageResponse, ImagePipeline.Error>, Never>!
     @ImagePipelineActor var _continuation: UnsafeContinuation<Result<ImageResponse, ImagePipeline.Error>, Never>?
     @ImagePipelineActor var _isFinished = false
-    @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
+    /// Guarded by the lock of `_status` rather than by the pipeline actor, so
+    /// that a stream is registered before `events` returns, without a hop.
+    nonisolated(unsafe) private var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor var _diagnostics: ImagePipeline.Diagnostics.TaskRecord?
     @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
@@ -333,7 +336,6 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
                 _dispatch(.preview(response))
             }
         case let .progress(value):
-            _status.withLock { $0.progress = value }
             _dispatch(.progress(value))
         case let .error(error):
             _finish(.failure(error))
@@ -356,25 +358,40 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
             return // Task isn't fully wired yet
         }
 
-        // Record the result first so that it is already visible to everyone
-        // observing the terminal event.
-        if case .finished(let result) = event {
+        // Record the state the event changes and read the streams in one
+        // critical section. `makeStream` reads that state and registers a
+        // stream under the same lock, so a stream created concurrently either
+        // starts from this state or receives this event – never both, and
+        // never neither.
+        let continuations: ContiguousArray<AsyncStream<Event>.Continuation>
+        switch event {
+        case .progress(let progress):
+            continuations = _status.withLock {
+                $0.progress = progress
+                return _streamContinuations
+            }
+        case .preview:
+            continuations = _status.withLock { _ in _streamContinuations }
+        case .finished(let result):
+            // Record the result first so that it is already visible to everyone
+            // observing the terminal event. A stream created after that replays
+            // it instead of registering, so the list is taken.
             let metrics = _diagnostics?.finish(with: result)
             _diagnostics = nil
-            _status.withLock {
+            continuations = _status.withLock {
                 $0.result = result
                 $0.metrics = metrics
+                return exchange(&_streamContinuations, with: [])
             }
         }
-        for continuation in _streamContinuations {
+        for continuation in continuations {
             continuation.yield(event)
         }
         switch event {
         case .finished(let result):
-            for continuation in _streamContinuations {
+            for continuation in continuations {
                 continuation.finish()
             }
-            _streamContinuations.removeAll()
             _continuation?.resume(returning: result)
         default:
             break
@@ -420,26 +437,25 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
 extension ImageTask {
     /// Creates a new stream of events for this task.
     ///
-    /// A subscription reaches the pipeline actor asynchronously, so the task
-    /// can finish before it is registered – a memory cache hit, for example,
-    /// finishes the task while the pipeline is still starting it. To make sure
-    /// no subscriber misses the outcome, a stream created after the task
-    /// finished replays the terminal event recorded in ``Status/result``.
+    /// The stream is registered before it is returned, under the lock that
+    /// `_dispatch` takes to record an event, so it receives every event sent
+    /// after it was created. A stream created after the task finished replays
+    /// the terminal event recorded in ``Status/result`` instead.
     private func makeStream() -> AsyncStream<Event> {
         AsyncStream { continuation in
-            Task { @ImagePipelineActor in
-                let status = self.status
+            _status.withLock { status in
                 if let result = status.result {
                     continuation.yield(.finished(result))
                     return continuation.finish()
                 }
                 // Prime the stream with the progress reported so far so that a
                 // progress bar attached mid-download doesn't sit at zero until
-                // the next chunk arrives.
+                // the next chunk arrives. It's sent under the lock to be ahead
+                // of the events the pipeline sends once the stream is registered.
                 if status.progress.completed > 0 || status.progress.total > 0 {
                     continuation.yield(.progress(status.progress))
                 }
-                self._streamContinuations.append(continuation)
+                _streamContinuations.append(continuation)
             }
         }
     }

--- a/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Helpers/TestHelpers.swift
@@ -66,26 +66,3 @@ private func bitmapData(for image: PlatformImage) -> Data? {
     context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
     return data
 }
-
-extension ImageTask {
-    /// Returns ``ImageTask/previews``, waiting until the subscription is
-    /// registered on the pipeline actor.
-    ///
-    /// Subscribing reaches the actor asynchronously, and unlike the terminal
-    /// event, the previews produced before it lands are not replayed. A test
-    /// that serves the next chunk of data only when it receives a preview
-    /// deadlocks if it loses the first one, so it has to hold the data back
-    /// until the subscription exists.
-    func subscribedPreviews() async -> AsyncCompactMapSequence<AsyncStream<Event>, ImageResponse> {
-        let previews = self.previews
-        // Accessing `previews` schedules the registration on the pipeline
-        // actor, so this hop normally lands after it. Don't spin waiting for
-        // the exception: a busy-wait would starve the very actor it is
-        // waiting for, and the rest of the suite with it.
-        await Task { @ImagePipelineActor in }.value
-        while await _streamContinuations.isEmpty {
-            try? await Task.sleep(for: .milliseconds(1))
-        }
-        return previews
-    }
-}

--- a/Tests/Mocks/MockProgressiveDataLoader.swift
+++ b/Tests/Mocks/MockProgressiveDataLoader.swift
@@ -17,11 +17,8 @@ final class MockProgressiveDataLoader: DataLoading, @unchecked Sendable {
 
     /// Serves the first chunk from `loadData` without waiting for `resume()`.
     ///
-    /// Set to `false` in the tests that serve the next chunk only when they
-    /// receive a preview: subscribing to `ImageTask/previews` reaches the
-    /// pipeline actor asynchronously and the previews produced before it lands
-    /// are not replayed, so such a test deadlocks if it loses the first one.
-    /// See `ImageTask/subscribedPreviews()`.
+    /// Set to `false` in the tests that serve every chunk themselves, one for
+    /// each preview they receive.
     var servesFirstChunkAutomatically = true
 
     /// Both are only ever touched on the main queue, which is what serializes

--- a/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
+++ b/Tests/NukePerformanceTests/ImagePipelinePerformanceTests.swift
@@ -112,6 +112,34 @@ struct ImagePipelinePerformanceTests {
             }
         }
     }
+
+    @Test
+    func imageTaskEventsPerformance() async {
+        let pipeline = makePipeline()
+        let requests = (0..<5000).map { ImageRequest(url: URL(string: "http://test.com/\($0)")) }
+        await measure {
+            await withTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        for await _ in pipeline.imageTask(with: request).events {}
+                    }
+                }
+            }
+        }
+    }
+
+    /// Every read of `events`, `progress`, or `previews` is a new subscription.
+    @Test
+    func imageTaskEventsSubscriptionPerformance() async throws {
+        let pipeline = makePipeline()
+        let task = pipeline.imageTask(with: ImageRequest(url: URL(string: "http://test.com/1")))
+        _ = try await task.response
+        await measure {
+            for _ in 0..<10_000 {
+                for await _ in task.events {}
+            }
+        }
+    }
 }
 
 /// Never has the data, so every iteration downloads it again.

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineAsyncAwaitTests.swift
@@ -285,7 +285,7 @@ struct ImagePipelineAsyncAwaitTests {
         // WHEN
         var recordedPreviews: [ImageResponse] = []
         let task = pipeline.imageTask(with: Test.url)
-        let stream = await task.subscribedPreviews()
+        let stream = task.previews
         dataLoader.resume()
         for try await preview in stream {
             recordedPreviews.append(preview)

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelinePreviewPolicyTests.swift
@@ -24,7 +24,7 @@ struct ImagePipelinePreviewPolicyTests {
 
         // WHEN loading the image and collecting previews
         let task = pipeline.imageTask(with: Test.url)
-        let stream = await task.subscribedPreviews()
+        let stream = task.previews
         dataLoader.resume()
         var previews: [ImageResponse] = []
         for try await preview in stream {
@@ -108,7 +108,7 @@ struct ImagePipelinePreviewPolicyTests {
 
         // WHEN loading the image
         let task = pipeline.imageTask(with: Test.url)
-        let stream = await task.subscribedPreviews()
+        let stream = task.previews
         dataLoader.resume()
         var previews: [ImageResponse] = []
         for try await preview in stream {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineProgressiveDecodingTests.swift
@@ -186,7 +186,7 @@ struct ImagePipelineProgressiveDecodingTests {
         dataLoader.servesFirstChunkAutomatically = false
         var recordedPreviews: [ImageResponse] = []
         let task = pipeline.imageTask(with: request)
-        let stream = await task.subscribedPreviews()
+        let stream = task.previews
         dataLoader.resume()
         for try await preview in stream {
             #expect(preview.image.cgImage?.width == 45)
@@ -211,7 +211,7 @@ struct ImagePipelineProgressiveDecodingTests {
         dataLoader.servesFirstChunkAutomatically = false
         var recordedPreviews: [ImageResponse] = []
         let task = pipeline.imageTask(with: request)
-        let stream = await task.subscribedPreviews()
+        let stream = task.previews
         dataLoader.resume()
         for try await preview in stream {
             #expect(preview.image.nk_test_processorIDs.count == 1)
@@ -392,7 +392,7 @@ struct ImagePipelineProgressiveDecodingTests {
         // WHEN/THEN
         dataLoader.servesFirstChunkAutomatically = false
         let task = pipeline.imageTask(with: request)
-        let stream = await task.subscribedPreviews()
+        let stream = task.previews
         dataLoader.resume()
         var previewScale: CGFloat?
         for try await preview in stream {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskDelegateTests.swift
@@ -135,7 +135,7 @@ struct ImagePipelineTaskDelegateTests {
 
         // WHEN
         let task = pipeline.imageTask(with: Test.url)
-        let stream = await task.subscribedPreviews()
+        let stream = task.previews
         dataLoader.resume()
         for try await _ in stream {
             dataLoader.resume()

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -262,16 +262,69 @@ struct ImageTaskTests {
         task._cancelTask()
 
         // Then it receives all of them, in order
-        var events: [String] = []
-        for await event in stream {
-            switch event {
-            case .progress(let progress): events.append("progress(\(progress.completed))")
-            case .preview: events.append("preview")
-            case .finished(.failure(.cancelled)): events.append("cancelled")
-            case .finished: events.append("finished")
-            }
-        }
+        let events = await names(of: stream)
         #expect(events == ["progress(1)", "preview", "progress(2)", "cancelled"])
+    }
+
+    /// The pipeline calls its delegate once it has sent the event to the
+    /// streams, so a stream created from the delegate starts from that event:
+    /// it's primed with the progress the task recorded and receives only the
+    /// events sent after.
+    @Test @ImagePipelineActor func streamCreatedFromTheDelegateStartsFromTheEventItIsCalledFor() async throws {
+        // Given a started task whose delegate creates a stream for every event
+        let delegate = StreamCreatingDelegate()
+        let pipeline = ImagePipeline(delegate: delegate) {
+            $0.dataLoader = dataLoader
+            $0.imageCache = nil
+        }
+        dataLoader.isSuspended = true
+        let started = TestExpectation()
+        pipeline.onTaskStarted = { _ in started.fulfill() }
+        let task = pipeline.imageTask(with: Test.request)
+        await started.wait()
+
+        // When the pipeline sends the events
+        let preview = ImageResponse(container: ImageContainer(image: Test.image, isPreview: true), request: Test.request)
+        task._process(.progress(ImageTask.Progress(completed: 1, total: 2)))
+        task._process(.value(preview, isCompleted: false))
+        task._process(.progress(ImageTask.Progress(completed: 2, total: 2)))
+        task._cancelTask()
+
+        // Then each stream starts from the event it was created for
+        var events: [[String]] = []
+        for stream in delegate.streams {
+            events.append(await names(of: stream))
+        }
+        #expect(events == [
+            ["progress(1)", "preview", "progress(2)", "cancelled"],
+            ["progress(1)", "progress(2)", "cancelled"],
+            ["progress(2)", "cancelled"],
+            ["cancelled"]
+        ])
+    }
+
+    /// A task cancelled before the pipeline starts it records the result only
+    /// once the pipeline gets to it, so the streams created until then register
+    /// instead of replaying the result, and the pipeline has to finish them.
+    @Test @ImagePipelineActor func streamsCreatedBeforeACancelledTaskStartsReceiveTheCancellation() async throws {
+        // Given a task that the pipeline hasn't started yet
+        dataLoader.isSuspended = true
+        let task = pipeline.imageTask(with: Test.request)
+
+        // When it's cancelled, with a stream created before and after that
+        let streamBefore = task.events
+        task._cancelTask()
+        #expect(task.status.result == nil)
+        let streamAfter = task.events
+
+        // Then both receive the cancellation once the pipeline starts the task
+        await #expect(throws: ImagePipeline.Error.cancelled) {
+            try await task.response
+        }
+        let eventsBefore = await names(of: streamBefore)
+        let eventsAfter = await names(of: streamAfter)
+        #expect(eventsBefore == ["cancelled"])
+        #expect(eventsAfter == ["cancelled"])
     }
 
     // MARK: - Status
@@ -392,5 +445,27 @@ struct ImageTaskTests {
 
         // Then
         #expect(task.priority == .veryLow)
+    }
+}
+
+/// Collects the events of the stream as short names that are easy to compare
+/// and to read in a failure message.
+private func names(of stream: AsyncStream<ImageTask.Event>) async -> [String] {
+    await stream.reduce(into: [String]()) { names, event in
+        switch event {
+        case .progress(let progress): names.append("progress(\(progress.completed))")
+        case .preview: names.append("preview")
+        case .finished(.failure(.cancelled)): names.append("cancelled")
+        case .finished: names.append("finished")
+        }
+    }
+}
+
+/// Creates a stream for the task every time the pipeline sends it an event.
+private final class StreamCreatingDelegate: ImagePipeline.Delegate, Sendable {
+    @ImagePipelineActor private(set) var streams: [AsyncStream<ImageTask.Event>] = []
+
+    @ImagePipelineActor func imageTask(_ task: ImageTask, didReceiveEvent event: ImageTask.Event, pipeline: ImagePipeline) {
+        streams.append(task.events)
     }
 }

--- a/Tests/NukeTests/ImageTaskTests.swift
+++ b/Tests/NukeTests/ImageTaskTests.swift
@@ -137,13 +137,11 @@ struct ImageTaskTests {
         let task = pipeline.imageTask(with: Test.request)
 
         // When two streams are created for the same task
-        async let first = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
-        async let second = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
-
-        while await task._streamContinuations.count < 2 {
-            await Task.yield()
-        }
+        let firstStream = task.events
+        let secondStream = task.events
         dataLoader.isSuspended = false
+        async let first = firstStream.reduce(into: [ImageTask.Event]()) { $0.append($1) }
+        async let second = secondStream.reduce(into: [ImageTask.Event]()) { $0.append($1) }
 
         // Then both observe the terminal event
         let (lhs, rhs) = await (first, second)
@@ -227,20 +225,53 @@ struct ImageTaskTests {
         let progress = task.status.progress
 
         // When the stream is created after the first chunk is delivered
-        async let recorded = task.events.reduce(into: [ImageTask.Event]()) { $0.append($1) }
-        while await task._streamContinuations.isEmpty {
-            await Task.yield()
+        let stream = task.events
+        // The mock served the first chunk on the main queue, and nothing else
+        // synchronizes its state.
+        DispatchQueue.main.async {
+            dataLoader.resumeServingChunks(dataLoader.chunks.count)
         }
-        dataLoader.resumeServingChunks(dataLoader.chunks.count)
 
         // Then it starts with the progress reported before it was created
-        let events = await recorded
+        let events = await stream.reduce(into: [ImageTask.Event]()) { $0.append($1) }
         var firstProgress: ImageTask.Progress?
         if case .progress(let value) = try #require(events.first) {
             firstProgress = value
         }
         #expect(firstProgress == progress)
         #expect(events.contains { if case .finished(.success) = $0 { return true } else { return false } })
+    }
+
+    /// A stream is registered by the time `events` returns, so it receives the
+    /// events that the pipeline sends right after, even in the same job on its
+    /// actor.
+    @Test @ImagePipelineActor func streamReceivesEveryEventSentAfterItIsCreated() async throws {
+        // Given a started task that waits for the data
+        dataLoader.isSuspended = true
+        let started = TestExpectation()
+        pipeline.onTaskStarted = { _ in started.fulfill() }
+        let task = pipeline.imageTask(with: Test.request)
+        await started.wait()
+
+        // When the pipeline sends events right after the stream is created
+        let stream = task.events
+        let preview = ImageResponse(container: ImageContainer(image: Test.image, isPreview: true), request: Test.request)
+        task._process(.progress(ImageTask.Progress(completed: 1, total: 2)))
+        task._process(.value(preview, isCompleted: false))
+        task._process(.progress(ImageTask.Progress(completed: 2, total: 2)))
+        task._cancelTask()
+
+        // Then it receives all of them, in order
+        var events: [String] = []
+        for await event in stream {
+            switch event {
+            case .progress(let progress): events.append("progress(\(progress.completed))")
+            case .preview: events.append("preview")
+            case .finished(.failure(.cancelled)): events.append("cancelled")
+            case .finished: events.append("finished")
+            }
+        }
+        #expect(events == ["progress(1)", "preview", "progress(2)", "cancelled"])
     }
 
     // MARK: - Status

--- a/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
+++ b/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
@@ -98,6 +98,39 @@ struct ThreadSafetyTests {
         }
     }
 
+    /// Streams created on many threads while tasks finish – on a memory cache
+    /// hit, as the pipeline starts the task, or on a cancellation – each
+    /// receive the result the task finished with, exactly once.
+    @Test func imageTaskTerminalEventThreadSafety() async {
+        let dataLoader = MockDataLoader()
+        dataLoader.isSuspended = true
+        let imageCache = ImageCache()
+        let pipeline = ImagePipeline {
+            $0.dataLoader = dataLoader
+            $0.imageCache = imageCache
+        }
+
+        for index in 0..<200 {
+            // Given a request that is either in the memory cache or never loads
+            let request = ImageRequest(url: URL(string: "http://example.com/\(index).jpeg"))
+            let isCached = index.isMultiple(of: 2)
+            if isCached {
+                imageCache[request] = Test.container
+            }
+
+            // When the task finishes – cancelled, unless it's a cache hit –
+            // while streams are created for it
+            let (task, streams) = await makeStreamsAcrossTheTerminalEvent(of: request, in: pipeline, cancels: !isCached)
+
+            // Then
+            _ = try? await task.response
+            for stream in streams {
+                let received = await stream.reduce(into: [String]()) { $0.append(name(of: $1)) }
+                #expect(received == [isCached ? "success" : "cancelled"], "\(index)")
+            }
+        }
+    }
+
     @Test func prefetcherThreadSafety() {
         let pipeline = ImagePipeline {
             $0.dataLoader = MockDataLoader()
@@ -459,5 +492,42 @@ private enum EventKey: Equatable {
         case .preview(let response): self = .preview(ObjectIdentifier(response.image))
         case .finished: self = .finished
         }
+    }
+}
+
+/// Creates a task and, right away, streams for it on several threads at once
+/// until each of them sees the task finish, and one more after that. With
+/// `cancels`, one of the threads cancels the task after its first stream.
+private func makeStreamsAcrossTheTerminalEvent(of request: ImageRequest, in pipeline: ImagePipeline, cancels: Bool) async -> (ImageTask, [AsyncStream<ImageTask.Event>]) {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            let task = pipeline.imageTask(with: request)
+            let streams = OSAllocatedUnfairLock<[AsyncStream<ImageTask.Event>]>(initialState: [])
+            DispatchQueue.concurrentPerform(iterations: 8) { thread in
+                for iteration in 0..<1000 {
+                    let isFinished = task.status.result != nil
+                    let stream = task.events
+                    streams.withLock { $0.append(stream) }
+                    if cancels && thread == 0 && iteration == 0 {
+                        task.cancel()
+                    }
+                    if isFinished {
+                        return
+                    }
+                }
+            }
+            continuation.resume(returning: (task, streams.withLock { $0 }))
+        }
+    }
+}
+
+/// The name of the event, telling apart only how the task finished.
+private func name(of event: ImageTask.Event) -> String {
+    switch event {
+    case .progress: "progress"
+    case .preview: "preview"
+    case .finished(.success): "success"
+    case .finished(.failure(.cancelled)): "cancelled"
+    case .finished(.failure): "failure"
     }
 }

--- a/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
+++ b/Tests/NukeThreadSafetyTests/ThreadSafetyTests.swift
@@ -5,6 +5,7 @@
 @testable import Nuke
 import Testing
 import Foundation
+import os
 
 #if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
@@ -61,6 +62,40 @@ struct ThreadSafetyTests {
         }
 
         _ = pipelines
+    }
+
+    /// Streams created on many threads while a task sends its events. Each one
+    /// starts from the state the task recorded before it was created and then
+    /// receives every later event exactly once and in order.
+    @Test func imageTaskEventsThreadSafety() async {
+        let pipeline = ImagePipeline {
+            $0.dataLoader = ChunkedDataLoader(data: Test.data(name: "progressive", extension: "jpeg"), chunkCount: 16)
+            $0.imageCache = nil
+            $0.isProgressiveDecodingEnabled = true
+            $0.progressiveDecodingInterval = 0
+            $0.makeImageDecoder = { _ in ImageDecoders.Empty(isProgressive: true) }
+        }
+
+        for index in 0..<20 {
+            // Given a task that records its events in the order it sends them
+            let sent = OSAllocatedUnfairLock<[ImageTask.Event]>(initialState: [])
+            let request = ImageRequest(url: URL(string: "http://example.com/\(index).jpeg"))
+            let task = pipeline.makeStartedImageTask(with: request) { event, _ in
+                sent.withLock { $0.append(event) }
+            }
+
+            // When
+            let streams = await makeStreamsOnManyThreads(for: task)
+
+            // Then
+            await Task { @ImagePipelineActor in }.value // `onEvent` is called after the streams get the event
+            let events = sent.withLock { $0 }.map(EventKey.init)
+            #expect(events.contains { if case .preview = $0 { true } else { false } })
+            for stream in streams {
+                let received = await stream.events.reduce(into: [EventKey]()) { $0.append(EventKey($1)) }
+                #expect(stream.isExpected(received, sent: events), "\(received)")
+            }
+        }
     }
 
     @Test func prefetcherThreadSafety() {
@@ -325,4 +360,104 @@ private func performPipelineThreadSafetyTest(_ pipeline: ImagePipeline) async {
 
 private func _request(index: Int) -> ImageRequest {
     return ImageRequest(url: URL(string: "http://example.com/img\(index)")!)
+}
+
+// MARK: - ImageTask Events
+
+/// Serves the data in small chunks, as fast as the pipeline takes them.
+private final class ChunkedDataLoader: DataLoading {
+    private let data: Data
+    private let chunkCount: Int
+
+    init(data: Data, chunkCount: Int) {
+        self.data = data
+        self.chunkCount = chunkCount
+    }
+
+    func loadData(with request: URLRequest, didReceiveData: @escaping @Sendable (Data, URLResponse) -> Void, completion: @escaping @Sendable (Error?) -> Void) -> Cancellable {
+        let response = URLResponse(url: request.url ?? Test.url, mimeType: "jpeg", expectedContentLength: data.count, textEncodingName: nil)
+        let data = data
+        let chunkSize = data.count / chunkCount + 1
+        DispatchQueue.global().async {
+            for offset in stride(from: 0, to: data.count, by: chunkSize) {
+                didReceiveData(data.subdata(in: offset..<min(offset + chunkSize, data.count)), response)
+            }
+            completion(nil)
+        }
+        return NoOpCancellable()
+    }
+}
+
+private struct NoOpCancellable: Cancellable {
+    func cancel() {}
+}
+
+/// Creates streams for the task on several threads at once until it finishes.
+/// Each thread creates one as soon as it sees the task record new progress –
+/// while the pipeline is still sending that event – and one more after the
+/// task finishes.
+private func makeStreamsOnManyThreads(for task: ImageTask) async -> [EventStream] {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            let streams = OSAllocatedUnfairLock<[EventStream]>(initialState: [])
+            DispatchQueue.concurrentPerform(iterations: 8) { _ in
+                while true {
+                    let status = task.status
+                    let stream = EventStream(events: task.events, isFinishedBefore: status.result != nil, isFinishedAfter: task.status.result != nil)
+                    streams.withLock { $0.append(stream) }
+                    guard !stream.isFinishedBefore else {
+                        return
+                    }
+                    while task.status.result == nil && task.status.progress == status.progress {
+                        usleep(10)
+                    }
+                }
+            }
+            continuation.resume(returning: streams.withLock { $0 })
+        }
+    }
+}
+
+/// A stream, and whether its task had finished right before and right after
+/// the stream was created.
+private struct EventStream: Sendable {
+    let events: AsyncStream<ImageTask.Event>
+    let isFinishedBefore: Bool
+    let isFinishedAfter: Bool
+
+    /// Returns `true` if the stream received what it had to, given the events
+    /// the task sent.
+    ///
+    /// A stream created after the task finished replays the terminal event.
+    /// Any other stream is registered between two of the events: it starts
+    /// with the progress recorded before that point, if any, and receives every
+    /// event sent after it, exactly once and in order.
+    func isExpected(_ received: [EventKey], sent: [EventKey]) -> Bool {
+        let isReplay = received == [.finished]
+        guard !isFinishedBefore else {
+            return isReplay
+        }
+        guard !isReplay else {
+            return isFinishedAfter
+        }
+        return sent.indices.contains { index in
+            let progress = sent[..<index].last { if case .progress = $0 { true } else { false } }
+            return received == (progress.map { [$0] } ?? []) + sent[index...]
+        }
+    }
+}
+
+/// What tells the events of a task apart.
+private enum EventKey: Equatable {
+    case progress(Int64)
+    case preview(ObjectIdentifier)
+    case finished
+
+    init(_ event: ImageTask.Event) {
+        switch event {
+        case .progress(let progress): self = .progress(progress.completed)
+        case .preview(let response): self = .preview(ObjectIdentifier(response.image))
+        case .finished: self = .finished
+        }
+    }
 }


### PR DESCRIPTION
Every read of `ImageTask/events`, `progress`, or `previews` created an `AsyncStream` whose build closure spawned a `Task { @ImagePipelineActor in … }` for one job: appending the stream's continuation to `_streamContinuations`, which the pipeline actor owned. A subscription to a finished task made 13 allocations and 1 task, and received its replayed terminal event only once that task had reached the actor. The documentation encourages more than one subscription per task: iterating both `progress` and `previews` is two.

What the hop provided was mutual exclusion between reading the task's state to replay or prime a new stream, and changing that state as the pipeline sends an event. The list now sits behind the lock `_status` already is, and both sides take it:

- `makeStream` registers the stream before it returns it. Under the lock, it replays `.finished` if a result is recorded (#916), or primes the stream with the current progress and appends it. The primed progress is yielded inside the lock, so it's ahead of anything the pipeline can send to that stream.
- `_dispatch` records the state an event changes – the progress, or the result and metrics – and reads the list in the same critical section, then yields outside of it. A stream created at the same time on another thread either starts from that state or is in the list that receives the event: never both, never neither. The terminal event takes the whole list in the section that records the result, so every stream is finished exactly once – by the dispatch, or by its own replay – and nothing is yielded to a stream after that. `_dispatch` runs on the pipeline actor, so the events of each stream stay in order.

The list is `nonisolated(unsafe)` and touched only inside `_status.withLock`. Moving it into the lock's state would change every `_status` access, and #973's new one with them; this way `ImageTask.Status` and `ImageTask` keep their sizes.

The first commit adds `imageTaskEventsSubscriptionPerformance` and `imageTaskEventsPerformance`.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. `main` (769ce84e) and this branch alternate run by run, and the side that runs first alternates by round; median of the per-run averages, and the Δ of each round. The branch has since been rebased on #971 and #975, which don't touch `ImageTask`.

**Release rig** – mock data loader, `ImageDecoders.Empty`; 7 rounds, 5 samples per run

| Benchmark | `main` | This PR | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| 20000 subscriptions to a finished task, detached | 57.89 ms | 31.28 ms | **−46.0%** | −43.1, −46.4, −48.1, −46.5, −45.4, −44.5, −49.2 |
| 20000 subscriptions to a finished task, main actor | 350.11 ms | 295.49 ms | **−15.6%** | −21.2, −21.1, −15.9, −14.6, −15.2, −16.5, −15.4 |
| 1000 subscriptions to a running task, then cancel it and await the response | 0.96 ms | 0.61 ms | **−36.7%** | −36.4, −34.4, −38.1, −35.0, −36.7, −36.6, −38.8 |
| 5000 downloads, each iterating `events` | 54.95 ms | 53.16 ms | −3.3% | −3.7, −5.6, −4.2, −2.3, −0.2, −13.6, +9.2 |
| 5000 downloads, each iterating `progress` and awaiting `response` | 56.10 ms | 53.53 ms | −4.6% | −11.0, +10.8, +0.9, −3.7, −2.8, −4.5, −5.2 |
| 5000 downloads, `response` only | 45.92 ms | 46.16 ms | +0.5% | −1.9, −0.5, +4.5, −11.8, +3.6, +0.5, +0.5 |
| 2000 downloads of 8 chunks with 7 previews, no subscriber | 36.85 ms | 36.92 ms | +0.2% | −0.6, +6.3, +0.4, −8.8, −0.8, −1.0, +1.1 |
| 2000 downloads of 8 chunks with 7 previews, each iterating `events` | 81.06 ms | 80.68 ms | −0.5% | −8.1, +3.5, −1.1, −7.5, +1.1, −1.7, +0.3 |
| `asyncAwait` | 45.59 ms | 45.47 ms | −0.3% | +4.6, −0.2, +10.5, −1.6, −0.1, −0.4, −1.1 |
| `asyncImageTask` | 46.25 ms | 46.23 ms | −0.0% | +6.5, +5.8, −3.6, −2.2, +2.4, −0.2, −2.6 |

A subscription iterated on the main actor saves more time than a detached one, 2.7 µs against 1.3 µs, but most of its time goes to iterating, which is unchanged. In a download of 8 chunks and 7 previews, one subscription is within the noise. Against aae3faed, before #967 landed, an earlier 7-round session measured the three subscription rows at −42.7%, −17.0%, and −35.3%, faster in every round.

**Resident memory cache hits** – 8×8 images, so all 5000 stay in the cache, asserted before and after timing; 21 rounds, a separate session

| Benchmark | `main` | This PR | Δ | Rounds slower |
|---|---|---|---|---|
| 5000 hits, concurrent | 8.31 ms | 8.25 ms | −0.7% | 8 of 21 |
| 20000 hits, sequential | 37.67 ms | 37.73 ms | +0.2% | 9 of 21 |
| `memoryHit` | 8.22 ms | 8.18 ms | −0.6% | 9 of 21 |
| Control: the same cache reads, without an `ImageTask` | 4.48 ms | 4.54 ms | +1.4% | 12 of 21 |

A hit sends only the terminal event, whose dispatch now also takes the list in the section that records the result. In the 7-round session, the sequential hits read +1.2%, slower in 6 of 7 rounds, and `memoryHit` +2.9%, slower in 5 of 7; this session settles them.

**Tasks, allocations, and lock acquisitions** – release rig; heap allocations through `malloc_logger`, and `swift_task_create` and `os_unfair_lock_lock` calls through an interposed library; identical in each of two runs

| Per | Tasks | Allocations | Locks |
|---|---|---|---|
| Subscription to a finished task, iterated to the end | 1 → **0** | 13 → **8** | 7 → 7 |
| Subscription to a running task | 1 → **0** | 6 → **2** | 1 → 1 |
| Download of 8 chunks with 7 previews, no subscriber | 11 → 11 | 152 → 152 | 48 → **55** |
| Resident memory cache hit | 1 → 1 | 17 → 17 | 4 → 4 |

`MemoryLayout<ImageTask.Status>` stays 56 bytes, `ImageTask` 160, and the buffer of its lock 80.

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel; "before" is the first commit of this PR; 5 rounds

| Test | Before | After | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `imageTaskEventsSubscriptionPerformance` – 10000 subscriptions to a finished task, main actor | 30.85 ms | 15.65 ms | **−49.3%** | −49.3, −52.9, −50.9, −48.1, −44.3 |
| `imageTaskEventsPerformance` – 5000 downloads, each iterating `events` | 73.79 ms | 73.19 ms | −0.8% | −2.1, −1.1, −4.6, +0.4, −0.9 |

In that session the controls read `memoryHitPerformance` +3.0%, slower in every round and by more than 15% in two, and `asyncImageTaskPerformance` +2.7%. A separate 11-round session of the two:

| Test | Before | After | Δ | Rounds (Δ%) |
|---|---|---|---|---|
| `memoryHitPerformance` | 12.01 ms | 11.86 ms | −1.3% | +1.7, −0.2, −1.6, +3.0, −3.2, −5.2, −1.9, +4.6, +2.6, +0.3, −10.6 |
| `asyncImageTaskPerformance` | 63.03 ms | 62.48 ms | −0.9% | +2.4, −1.0, +0.2, +1.3, +1.3, −2.5, −1.1, −0.1, −2.6, −0.1, −2.7 |

### Behaviour

A stream is now registered by the time `events` returns, so it receives every event the pipeline sends after that. On `main` the registration is a `Task` of its own, and a stream misses whatever the pipeline sends before that task reaches the actor: previews, progress other than the latest, and – when the task finishes first – every event but the replayed `.finished`. Delivering all of them is already one interleaving on `main`, and the one the documentation describes – "each one delivers the complete set of events"; this PR makes it the only one. The `events` documentation now also says a stream "receives every event sent after it is created", which `ImageTaskTests.streamReceivesEveryEventSentAfterItIsCreated` pins.

The tests had worked around the late registration with a `subscribedPreviews()` helper that polled `_streamContinuations`. The helper is gone, and the seven tests that used it read `previews` directly.

Unchanged: a stream created after the task finished replays `.finished`; one created mid-download starts with the current progress; the events a consumer receives arrive on the consumer's own executor, as before; the pipeline still sends them from its actor, in the same order relative to `response`, `onEvent`, and the delegate. No `Task` retains the `ImageTask` until a registration hop runs, and subscribing no longer enqueues a job on the pipeline actor at the subscriber's priority.

### Trade-offs

- Dispatching a preview now takes the task's lock to read the list. A progressive download with 8 chunks and no subscriber goes from 48 lock acquisitions to 55 – one per preview – and measures the same (+0.2%, slower in 3 of 7 rounds). Progress and the terminal event already took the lock.
- Subscribing yields the primed progress, or the replayed terminal event, while holding the task's lock. Nothing can be iterating that stream yet, so the yield only appends to its buffer.
- The compiler doesn't check that the list is touched only under the lock – the trade `_task` already makes with `nonisolated(unsafe)`.

### Overlaps

- #973 adds `Status.isStarted` and a `_status.withLock` in `_markStarted`, and edits `cancel()`: no shared lines, and `_status` keeps its name and type.
- #974 edits the `pipeline` and `_node` declarations and the end of `_dispatch`: neighbouring lines, no shared ones.
- #977 makes `_task` optional and adds `terminalResult()` after `makeStream()`, which iterates `events`: neighbouring lines, no shared ones.

`git merge-tree` of this branch with the current head of each merges `ImageTask.swift` without a conflict. #973 also adds tests at the end of `ImagePipelinePerformanceTests`, so that file conflicts where the first commit of this PR does the same; #974 and #977 conflict only in `CHANGELOG.md`.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO` – 1107 pass under ThreadSanitizer, `main`'s tests plus three; only the `.disabled()` tests are skipped. The known abort in `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress` is gone. The test called `resumeServingChunks` from its own thread after the mock had served the first chunk on the main queue – a race on `MockProgressiveDataLoader.chunks`, which aborts the suite on `main`. It had to change anyway, since it polled `_streamContinuations`, and it now serves the remaining chunks on the main queue as well.
   - `ImageTaskTests.streamReceivesEveryEventSentAfterItIsCreated` – on the pipeline actor, creates a stream and, in the same job, sends two progress events, a preview, and the cancellation; the stream receives all four, in order. Against `main`'s sources it receives only the replayed `.finished`.
   - `eventsAreDeliveredToMultipleIndependentStreams` creates both streams before the loader resumes instead of polling for their registration.
   - `ImageTaskTests.streamCreatedFromTheDelegateStartsFromTheEventItIsCalledFor` – a delegate creates a stream every time the pipeline calls it with an event: progress, a preview, progress, and the cancellation. The delegate is called after the streams get the event and outside the task's lock, so each stream starts with the progress recorded so far and receives the events after the one it was created for, but not that one. Against `main`'s sources all four receive only the replayed `.finished`.
   - `ImageTaskTests.streamsCreatedBeforeACancelledTaskStartsReceiveTheCancellation` – on the pipeline actor, a task is cancelled before the pipeline starts it, so it has no result until the pipeline gets to it. A stream created before the cancellation and one created after both register rather than replay, and both receive only the cancellation. It passes against `main`'s sources too, where both are replays.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 10 pass, including the new `imageTaskEventsThreadSafety` and `imageTaskTerminalEventThreadSafety`.
   - `imageTaskEventsThreadSafety` runs 20 progressive downloads of 16 chunks, each sending progress events, previews, and the terminal event, while 8 threads create a stream every time they see the task record new progress, and once more after it finishes. A stream created after the task finished must receive only `.finished`. Any other stream must receive the progress recorded before some point in the sequence the pipeline sent, then every event after that point; and if the task still had no result right after the stream was created, the stream must not be a replay. Against `main`'s sources the ordering and exactly-once checks hold, and 58 streams fail the last one: their registration `Task` ran after the task finished.
   - `imageTaskTerminalEventThreadSafety` runs 200 tasks – half are memory cache hits, which finish as the pipeline starts them, and half never load and are cancelled by one of the threads – while 8 threads create streams from the moment the task is created until each sees it finish, and once more after. Every stream must receive only the result the task finished with. It passes against `main`'s sources too.
   - `.scripts/ci.sh` doesn't run this scheme, so neither test runs in CI.
3. `swiftlint` reports nothing new in the changed files, and they add no build warnings.
4. Both stress tests ran against two copies of this branch, each with one of the critical sections in `_dispatch` split in two, under a one-minute time limit:
   - Recording the progress and reading the list in separate sections: `imageTaskEventsThreadSafety` fails on its first run with 76 issues – streams that receive the same progress twice.
   - Taking the list and recording the result in separate sections: `imageTaskTerminalEventThreadSafety` fails on its first run – a stream created in between is never finished, and the test hits its time limit. `imageTaskEventsThreadSafety` passed the run it had.

