### PR TITLE
Run low-priority downloads in at most 3 of the data loading slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 **Performance**
 
+- `ImagePipeline/Configuration-swift.struct/dataLoadingQueue` now has 7 slots and keeps one for requests with `.normal` or higher priority, so an image on screen shows up to 22% sooner while prefetching fills the queue – https://github.com/kean/Nuke/pull/981
 - `ImageCache` lookups are 6% faster – https://github.com/kean/Nuke/pull/975
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,11 @@
 - Add `ImageDiagnosticsStringEnum`: the `Codable` conformance the diagnostics enums share, which decodes a name it doesn't know as `unknown` – https://github.com/kean/Nuke/pull/960
 - The default `ImagePipeline/Configuration-swift.struct/rateLimiter` rate goes from 80 to 100 requests per second – https://github.com/kean/Nuke/pull/960
 - `ImageTask` and `ImageDecoders/Video` are now `Sendable` instead of `@unchecked Sendable` – https://github.com/kean/Nuke/pull/965
+- Add `TaskQueue/reservedTaskCount`: the number of slots that the work with a priority lower than `.normal` can't take – https://github.com/kean/Nuke/pull/981
 
 **Performance**
 
-- `ImagePipeline/Configuration-swift.struct/dataLoadingQueue` now has 7 slots and keeps one for requests with `.normal` or higher priority, so an image on screen shows up to 22% sooner while prefetching fills the queue – https://github.com/kean/Nuke/pull/981
+- `ImagePipeline/Configuration-swift.struct/dataLoadingQueue` runs the requests below `.normal` priority in at most 3 of its 6 slots. When prefetching has more work than that, an image opened in the meantime shows up 12% sooner on LTE, and 32% sooner if it's large – https://github.com/kean/Nuke/pull/981
 - `ImageCache` lookups are 6% faster – https://github.com/kean/Nuke/pull/975
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967

--- a/Documentation/Nuke.docc/Performance/performance-guide.md
+++ b/Documentation/Nuke.docc/Performance/performance-guide.md
@@ -139,6 +139,22 @@ final class ImageView: UIView {
 }
 ```
 
+## Data Loading Slots
+
+Prefetching and the images on screen share ``ImagePipeline/Configuration-swift.struct/dataLoadingQueue``, which runs up to 6 downloads at a time. A download that has started can't be interrupted, so the requests with a priority lower than `.normal` run in at most 3 of the slots, and an image on screen starts loading right away even when prefetching is busy.
+
+The limit, ``TaskQueue/reservedTaskCount``, only matters when there is more low-priority work than it allows: an ``ImagePrefetcher`` with `maxConcurrentRequestCount` above 3 (the default is 2), several prefetchers at once, or requests that you start or lower to `.low` or `.veryLow`. When an image appears on screen while it's still being prefetched, its download gets the higher priority and frees its slot.
+
+Reserving more slots gets the images on screen sooner, but slows prefetching down when it has more work than slots. Reserve 4 for large images, such as a feed or a gallery, and 0–2 if prefetching has to keep up with fast scrolling through thumbnails.
+
+```swift
+ImagePipeline.shared = ImagePipeline {
+    $0.dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 6, reservedTaskCount: 4)
+}
+```
+
+> Tip: To see whether the images on screen wait for a slot, enable ``ImagePipeline/Configuration-swift.struct/isDiagnosticsEnabled`` and check the ``ImageTask/Metrics/Category/queue`` share of their ``ImageTask/Metrics/timeShares``.
+
 ## Rate Limiting
 
 If the app starts and cancels requests at a fast rate, the pipeline will rate limit the requests, protecting `URLSession`. `RateLimiter` uses a classic [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm. The implementation supports quick bursts of requests which can be executed without any delays when "the bucket is full". It is important to make sure `RateLimiter` only kicks in when needed, but when the user opens the screen, all the requests are fired immediately.

--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -191,8 +191,12 @@ extension ImagePipeline {
 
         // MARK: - Task Queues
 
-        /// Data loading queue. Default maximum concurrent task count is 6.
-        public var dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 6)
+        /// Data loading queue. Default maximum concurrent task count is 7.
+        ///
+        /// The requests with a priority lower than ``ImageRequest/Priority-swift.enum/normal``,
+        /// such as prefetching, take at most 6 of the slots, so the images the
+        /// user is waiting for never queue behind them.
+        public var dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 7, reservedTaskCount: 1)
 
         /// Image decoding queue. Default maximum concurrent task count is 2.
         ///

--- a/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline+Configuration.swift
@@ -191,12 +191,12 @@ extension ImagePipeline {
 
         // MARK: - Task Queues
 
-        /// Data loading queue. Default maximum concurrent task count is 7.
+        /// Data loading queue. Default maximum concurrent task count is 6.
         ///
         /// The requests with a priority lower than ``ImageRequest/Priority-swift.enum/normal``,
-        /// such as prefetching, take at most 6 of the slots, so the images the
-        /// user is waiting for never queue behind them.
-        public var dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 7, reservedTaskCount: 1)
+        /// such as prefetching, run in at most 3 of the slots, so the images the
+        /// user is waiting for don't queue behind them. See ``TaskQueue/reservedTaskCount``.
+        public var dataLoadingQueue = TaskQueue(maxConcurrentTaskCount: 6, reservedTaskCount: 3)
 
         /// Image decoding queue. Default maximum concurrent task count is 2.
         ///

--- a/Sources/Nuke/Pipeline/TaskQueue.swift
+++ b/Sources/Nuke/Pipeline/TaskQueue.swift
@@ -14,6 +14,7 @@ import os
 public final class TaskQueue: Sendable {
     var runningCount = 0
     var pendingCount = 0
+    private var runningLowPriorityCount = 0
     private let buckets = (0..<TaskPriority.allCases.count).map { _ in LinkedList<TaskQueue.Operation>() }
 
     /// Controls whether the queue drains pending work.
@@ -43,10 +44,10 @@ public final class TaskQueue: Sendable {
     /// operations like image processing, it's recommended to use a lower number
     /// to avoid fully saturating the CPU.
     nonisolated public var maxConcurrentTaskCount: Int {
-        get { _maxConcurrentTaskCount.withLock { $0 } }
+        get { _limits.withLock { $0.maxConcurrentTaskCount } }
         set {
-            let oldValue = _maxConcurrentTaskCount.withLock {
-                let old = $0; $0 = newValue; return old
+            let oldValue = _limits.withLock {
+                let old = $0.maxConcurrentTaskCount; $0.maxConcurrentTaskCount = newValue; return old
             }
             if newValue > oldValue {
                 Task { @ImagePipelineActor in drain() }
@@ -54,13 +55,31 @@ public final class TaskQueue: Sendable {
         }
     }
 
-    /// The number of slots that the work below the `.normal` priority – such as
-    /// prefetching – leaves free, so that the work added at a higher priority
-    /// never waits for it to finish. The low-priority work always gets at
-    /// least one slot.
-    nonisolated let reservedTaskCount: Int
+    /// The number of slots that the work with a priority lower than `.normal`,
+    /// such as prefetching, can't take, so that the work added at a higher
+    /// priority finds a free slot even when there is more low-priority work
+    /// than slots. The low-priority work always gets at least one slot.
+    ///
+    /// The work counts by its current priority: raising the priority of a
+    /// running task frees its low-priority slot. `0` by default.
+    nonisolated public var reservedTaskCount: Int {
+        get { _limits.withLock { $0.reservedTaskCount } }
+        set {
+            let oldValue = _limits.withLock {
+                let old = $0.reservedTaskCount; $0.reservedTaskCount = newValue; return old
+            }
+            if newValue < oldValue {
+                Task { @ImagePipelineActor in drain() }
+            }
+        }
+    }
 
-    nonisolated private let _maxConcurrentTaskCount: OSAllocatedUnfairLock<Int>
+    private struct Limits: Sendable {
+        var maxConcurrentTaskCount: Int
+        var reservedTaskCount: Int
+    }
+
+    nonisolated private let _limits: OSAllocatedUnfairLock<Limits>
     nonisolated private let _isSuspended = OSAllocatedUnfairLock(initialState: false)
 
     /// Events emitted by the queue for observation (testing only).
@@ -76,13 +95,17 @@ public final class TaskQueue: Sendable {
 
     /// Initializes the queue.
     nonisolated public init(maxConcurrentTaskCount: Int = ProcessInfo.processInfo.processorCount) {
-        self._maxConcurrentTaskCount = OSAllocatedUnfairLock(initialState: maxConcurrentTaskCount)
-        self.reservedTaskCount = 0
+        self._limits = OSAllocatedUnfairLock(initialState: Limits(maxConcurrentTaskCount: maxConcurrentTaskCount, reservedTaskCount: 0))
     }
 
-    nonisolated init(maxConcurrentTaskCount: Int, reservedTaskCount: Int) {
-        self._maxConcurrentTaskCount = OSAllocatedUnfairLock(initialState: maxConcurrentTaskCount)
-        self.reservedTaskCount = reservedTaskCount
+    /// Initializes the queue.
+    ///
+    /// - parameters:
+    ///   - maxConcurrentTaskCount: The maximum number of tasks that run at the same time.
+    ///   - reservedTaskCount: The number of slots that the work with a priority
+    ///     lower than `.normal` can't take. See ``reservedTaskCount``.
+    nonisolated public init(maxConcurrentTaskCount: Int, reservedTaskCount: Int) {
+        self._limits = OSAllocatedUnfairLock(initialState: Limits(maxConcurrentTaskCount: maxConcurrentTaskCount, reservedTaskCount: reservedTaskCount))
     }
 
     /// Adds work to the queue. The closure runs `@ImagePipelineActor`. The
@@ -113,13 +136,13 @@ public final class TaskQueue: Sendable {
 
     private func drain() {
         guard !isSuspended else { return }
-        // The limit is settable from any thread, so every read takes a lock.
-        // Read it once: a limit raised mid-drain schedules a drain of its own,
+        // The limits are settable from any thread, so every read takes a lock.
+        // Read them once: a limit raised mid-drain schedules a drain of its own,
         // and one lowered mid-drain is no different from one lowered right after.
-        let limit = maxConcurrentTaskCount
-        let lowPriorityLimit = max(1, limit - reservedTaskCount)
-        while runningCount < limit && pendingCount > 0 {
-            guard let operation = dequeueHighestPriority(isLowPriorityAllowed: runningCount < lowPriorityLimit) else { break }
+        let limits = _limits.withLock { $0 }
+        let lowPriorityLimit = max(1, limits.maxConcurrentTaskCount - limits.reservedTaskCount)
+        while runningCount < limits.maxConcurrentTaskCount && pendingCount > 0 {
+            guard let operation = dequeueHighestPriority(isLowPriorityAllowed: runningLowPriorityCount < lowPriorityLimit) else { break }
             execute(operation)
         }
     }
@@ -139,6 +162,10 @@ public final class TaskQueue: Sendable {
 
     private func execute(_ operation: TaskQueue.Operation) {
         runningCount += 1
+        if operation.priority < .normal {
+            operation.isRunningAsLowPriority = true
+            runningLowPriorityCount += 1
+        }
         // The operation is captured strongly to keep it alive while it executes:
         // it is no longer stored in the pending buckets and the clients typically
         // reference it weakly. The work is read _inside_ the task (instead of
@@ -150,18 +177,31 @@ public final class TaskQueue: Sendable {
                 try? await work()
             }
             operation.task = nil // Break the retain cycle
-            self?.operationFinished()
+            self?.operationFinished(operation)
         }
     }
 
-    fileprivate func operationFinished() {
+    fileprivate func operationFinished(_ operation: TaskQueue.Operation) {
         runningCount -= 1
+        if operation.isRunningAsLowPriority {
+            operation.isRunningAsLowPriority = false
+            runningLowPriorityCount -= 1
+        }
         drain()
         onEvent?(.finished)
     }
 
     fileprivate func operationPriorityChanged(_ operation: TaskQueue.Operation, from oldPriority: TaskPriority) {
-        guard let node = operation.node else { return }
+        guard let node = operation.node else {
+            // A running operation moves in or out of the low-priority slots.
+            let isLowPriority = operation.priority < .normal
+            if operation.task != nil, operation.isRunningAsLowPriority != isLowPriority {
+                operation.isRunningAsLowPriority = isLowPriority
+                runningLowPriorityCount += isLowPriority ? 1 : -1
+                if !isLowPriority { drain() }
+            }
+            return
+        }
         buckets[oldPriority.rawValue].remove(node)
         if operation.priority < oldPriority {
             buckets[operation.priority.rawValue].prepend(node)
@@ -191,9 +231,9 @@ public final class TaskQueue: Sendable {
     @ImagePipelineActor
     final class Operation: Sendable {
         /// The scheduling priority. Changing this while the operation is pending
-        /// moves it to the corresponding priority bucket. Changes to a running
-        /// or cancelled operation update the stored value but have no scheduling
-        /// effect.
+        /// moves it to the corresponding priority bucket. Changing it while the
+        /// operation runs decides whether it counts toward the slots of the
+        /// low-priority work. Changes to a cancelled operation have no effect.
         var priority: TaskPriority = .normal {
             didSet {
                 guard oldValue != priority else { return }
@@ -205,6 +245,7 @@ public final class TaskQueue: Sendable {
         fileprivate var work: (@ImagePipelineActor @Sendable () async throws -> Void)?
         private(set) var isCancelled = false
         fileprivate var task: Task<Void, Never>?
+        fileprivate var isRunningAsLowPriority = false
         fileprivate weak var node: LinkedList<TaskQueue.Operation>.Node?
         private weak var queue: TaskQueue?
 

--- a/Sources/Nuke/Pipeline/TaskQueue.swift
+++ b/Sources/Nuke/Pipeline/TaskQueue.swift
@@ -54,6 +54,12 @@ public final class TaskQueue: Sendable {
         }
     }
 
+    /// The number of slots that the work below the `.normal` priority – such as
+    /// prefetching – leaves free, so that the work added at a higher priority
+    /// never waits for it to finish. The low-priority work always gets at
+    /// least one slot.
+    nonisolated let reservedTaskCount: Int
+
     nonisolated private let _maxConcurrentTaskCount: OSAllocatedUnfairLock<Int>
     nonisolated private let _isSuspended = OSAllocatedUnfairLock(initialState: false)
 
@@ -71,16 +77,26 @@ public final class TaskQueue: Sendable {
     /// Initializes the queue.
     nonisolated public init(maxConcurrentTaskCount: Int = ProcessInfo.processInfo.processorCount) {
         self._maxConcurrentTaskCount = OSAllocatedUnfairLock(initialState: maxConcurrentTaskCount)
+        self.reservedTaskCount = 0
+    }
+
+    nonisolated init(maxConcurrentTaskCount: Int, reservedTaskCount: Int) {
+        self._maxConcurrentTaskCount = OSAllocatedUnfairLock(initialState: maxConcurrentTaskCount)
+        self.reservedTaskCount = reservedTaskCount
     }
 
     /// Adds work to the queue. The closure runs `@ImagePipelineActor`. The
     /// concurrency slot is freed when the closure returns.
     ///
+    /// The priority is passed here rather than set on the returned operation
+    /// because the work can start right away, and the priority decides whether
+    /// it may take a reserved slot.
+    ///
     /// If the work needs to be performed in a background, the caller needs to
     /// ensure that happens.
     @discardableResult
-    func add(_ work: @ImagePipelineActor @Sendable @escaping () async throws -> Void) -> TaskQueue.Operation {
-        let operation = TaskQueue.Operation(queue: self)
+    func add(priority: TaskPriority = .normal, _ work: @ImagePipelineActor @Sendable @escaping () async throws -> Void) -> TaskQueue.Operation {
+        let operation = TaskQueue.Operation(queue: self, priority: priority)
         operation.work = work
         enqueue(operation)
         return operation
@@ -101,14 +117,16 @@ public final class TaskQueue: Sendable {
         // Read it once: a limit raised mid-drain schedules a drain of its own,
         // and one lowered mid-drain is no different from one lowered right after.
         let limit = maxConcurrentTaskCount
+        let lowPriorityLimit = max(1, limit - reservedTaskCount)
         while runningCount < limit && pendingCount > 0 {
-            guard let operation = dequeueHighestPriority() else { break }
+            guard let operation = dequeueHighestPriority(isLowPriorityAllowed: runningCount < lowPriorityLimit) else { break }
             execute(operation)
         }
     }
 
-    private func dequeueHighestPriority() -> TaskQueue.Operation? {
-        for i in stride(from: buckets.count - 1, through: 0, by: -1) {
+    private func dequeueHighestPriority(isLowPriorityAllowed: Bool) -> TaskQueue.Operation? {
+        let lowest = isLowPriorityAllowed ? 0 : TaskPriority.normal.rawValue
+        for i in stride(from: buckets.count - 1, through: lowest, by: -1) {
             if let node = buckets[i].first {
                 buckets[i].remove(node)
                 node.value.node = nil
@@ -151,6 +169,10 @@ public final class TaskQueue: Sendable {
             buckets[operation.priority.rawValue].append(node)
         }
         onEvent?(.priorityChanged(operation))
+        // The work that is no longer low-priority can take a reserved slot.
+        if oldPriority < .normal && operation.priority >= .normal {
+            drain()
+        }
     }
 
     fileprivate func operationCancelled(_ operation: TaskQueue.Operation) {
@@ -190,8 +212,9 @@ public final class TaskQueue: Sendable {
         var onCancelled: (() -> Void)?
         var onPriorityChanged: ((TaskPriority) -> Void)?
 
-        init(queue: TaskQueue? = nil) {
+        init(queue: TaskQueue? = nil, priority: TaskPriority = .normal) {
             self.queue = queue
+            self.priority = priority
         }
 
         /// Cancels the operation. If the work hasn't started executing yet, it

--- a/Sources/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/Nuke/Prefetching/ImagePrefetcher.swift
@@ -146,13 +146,12 @@ public final class ImagePrefetcher: Sendable {
         let task = PrefetchTask(request: request, key: key)
         let pipeline = self.pipeline
         let isDataTask = destination == .diskCache
-        let operation = queue.add { [weak self] in
+        let operation = queue.add(priority: request.priority.taskPriority) { [weak self] in
             let imageTask = pipeline.makeStartedImageTask(with: task.request, isDataTask: isDataTask, isPrefetch: true)
             task.imageTask = imageTask
             _ = try? await imageTask.response
             self?._remove(task)
         }
-        operation.priority = request.priority.taskPriority
         task.operation = operation
         tasks[key] = task
     }

--- a/Sources/Nuke/Tasks/AsyncPipelineTask.swift
+++ b/Sources/Nuke/Tasks/AsyncPipelineTask.swift
@@ -53,7 +53,7 @@ extension AsyncPipelineTask {
     func decode(_ context: ImageDecodingContext, decoder: any ImageDecoding, _ completion: @escaping @ImagePipelineActor (Result<ImageResponse, ImagePipeline.Error>) -> Void) {
         if let decoder = decoder as? any AsyncImageDecoding {
             let stage = diagnostics?.beginStage(.decode, queued: true)
-            operation = pipeline.configuration.imageDecodingQueue.add { [weak self] in
+            operation = pipeline.configuration.imageDecodingQueue.add(priority: priority) { [weak self] in
                 self?.diagnostics?.startStage(stage)
                 let start: ContinuousClock.Instant? = stage != nil ? .now : nil
                 let result: Result<ImageResponse, ImagePipeline.Error> = await signpost(context.isCompleted ? "DecodeImageData" : "DecodeProgressiveImageData") {
@@ -86,7 +86,7 @@ extension AsyncPipelineTask {
             return completion(result)
         }
         let stage = diagnostics?.beginStage(.decode, queued: true)
-        operation = pipeline.configuration.imageDecodingQueue.add { [weak self] in
+        operation = pipeline.configuration.imageDecodingQueue.add(priority: priority) { [weak self] in
             self?.diagnostics?.startStage(stage)
             let (result, workDuration) = await performInBackground(decode)
             self?.operation = nil

--- a/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalData.swift
@@ -80,7 +80,7 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
         } else {
             // Wrap data request in an operation to limit the maximum number of
             // concurrent data tasks.
-            operation = pipeline.configuration.dataLoadingQueue.add { [weak self] in
+            operation = pipeline.configuration.dataLoadingQueue.add(priority: priority) { [weak self] in
                 guard let self else { return }
                 await self.performDataLoad(urlRequest: urlRequest)
             }
@@ -303,7 +303,7 @@ final class TaskFetchOriginalData: AsyncPipelineTask<(Data, URLResponse?)> {
                 self?.dataLoadTask?.cancel()
             }
         } else {
-            operation = pipeline.configuration.dataLoadingQueue.add { [weak self] in
+            operation = pipeline.configuration.dataLoadingQueue.add(priority: priority) { [weak self] in
                 await self?.performAsyncDataLoad(fetch)
             }
         }

--- a/Sources/Nuke/Tasks/TaskFetchOriginalImage.swift
+++ b/Sources/Nuke/Tasks/TaskFetchOriginalImage.swift
@@ -135,7 +135,7 @@ final class TaskFetchOriginalImage: AsyncPipelineTask<ImageResponse> {
 
     private func loadAsyncImage(_ fetch: @Sendable @escaping () async throws -> ImageContainer) {
         let stage = diagnostics?.beginStage(.download, queued: true)
-        operation = pipeline.configuration.dataLoadingQueue.add { [weak self] in
+        operation = pipeline.configuration.dataLoadingQueue.add(priority: priority) { [weak self] in
             await self?.performAsyncImageLoad(fetch, stage: stage)
         }
     }

--- a/Sources/Nuke/Tasks/TaskLoadImage.swift
+++ b/Sources/Nuke/Tasks/TaskLoadImage.swift
@@ -76,7 +76,7 @@ final class TaskLoadImage: AsyncPipelineTask<ImageResponse> {
         let context = ImageProcessingContext(request: request, response: response, isCompleted: isCompleted)
         let stage = diagnostics?.beginStage(.process, queued: true)
         let isRecording = stage != nil
-        operation = pipeline.configuration.imageProcessingQueue.add { [weak self] in
+        operation = pipeline.configuration.imageProcessingQueue.add(priority: priority) { [weak self] in
             guard let self else { return }
             self.diagnostics?.startStage(stage)
             let (result, workDuration) = await performInBackground { () -> (Result<ImageResponse, ImagePipeline.Error>, TimeInterval?) in
@@ -130,7 +130,7 @@ final class TaskLoadImage: AsyncPipelineTask<ImageResponse> {
         }
         let stage = diagnostics?.beginStage(.decompress, queued: true)
         let isRecording = stage != nil
-        operation = pipeline.configuration.imageDecompressingQueue.add { [weak self] in
+        operation = pipeline.configuration.imageDecompressingQueue.add(priority: priority) { [weak self] in
             guard let self else { return }
             self.diagnostics?.startStage(stage)
             let (response, workDuration) = await performInBackground { () -> (ImageResponse, TimeInterval?) in

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTests.swift
@@ -140,6 +140,35 @@ struct ImagePipelineTests {
         }
     }
 
+    @Test @ImagePipelineActor func lowPriorityRequestsLeaveReservedDataLoadingSlotFree() async {
+        // Given – a data loading queue with two slots, one of them reserved
+        let queue = TaskQueue(maxConcurrentTaskCount: 2, reservedTaskCount: 1)
+        let pipeline = pipeline.reconfigured { $0.dataLoadingQueue = queue }
+        dataLoader.isSuspended = true
+
+        // When – two low-priority requests start
+        _ = await queue.waitForOperations(count: 2) {
+            for index in 0..<2 {
+                var request = ImageRequest(url: URL(string: "https://example.com/\(index).jpeg"))
+                request.priority = .low
+                _ = pipeline.imageTask(with: request)
+            }
+        }
+
+        // Then – only one of them takes a slot
+        #expect(queue.runningCount == 1)
+        #expect(queue.pendingCount == 1)
+
+        // When – a normal-priority request starts
+        _ = await queue.waitForOperations(count: 1) {
+            _ = pipeline.imageTask(with: ImageRequest(url: URL(string: "https://example.com/2.jpeg")))
+        }
+
+        // Then – it takes the reserved slot
+        #expect(queue.runningCount == 2)
+        #expect(queue.pendingCount == 1)
+    }
+
     // MARK: - Cancellation
 
     @Test func dataLoadingOperationCancelled() async {

--- a/Tests/NukeTests/TaskQueueTests.swift
+++ b/Tests/NukeTests/TaskQueueTests.swift
@@ -526,6 +526,85 @@ struct TaskQueueTests {
         await queue.waitUntilAllOperationsAreFinished()
     }
 
+    @Test func normalPriorityWorkLeavesLowPrioritySlotAvailable() async {
+        // Given – two slots, one of them reserved, and normal-priority work running
+        let queue = TaskQueue(maxConcurrentTaskCount: 2, reservedTaskCount: 1)
+        let gate = AsyncGate()
+        queue.add { await gate.wait() }
+
+        // When
+        queue.add(priority: .low) { await gate.wait() }
+
+        // Then – only the low-priority work counts toward the low-priority slot
+        #expect(queue.runningCount == 2)
+
+        // Cleanup
+        gate.open()
+        await queue.waitUntilAllOperationsAreFinished()
+    }
+
+    @Test func raisingPriorityOfRunningWorkFreesLowPrioritySlot() async {
+        // Given – the low-priority slot taken and low-priority work waiting
+        let queue = TaskQueue(maxConcurrentTaskCount: 2, reservedTaskCount: 1)
+        let gate = AsyncGate()
+        let running = queue.add(priority: .low) { await gate.wait() }
+        queue.add(priority: .low) { await gate.wait() }
+        #expect(queue.pendingCount == 1)
+
+        // When
+        running.priority = .normal
+
+        // Then – the waiting work starts
+        #expect(queue.pendingCount == 0)
+        #expect(queue.runningCount == 2)
+
+        // Cleanup
+        gate.open()
+        await queue.waitUntilAllOperationsAreFinished()
+    }
+
+    @Test func loweringPriorityOfRunningWorkTakesLowPrioritySlot() async {
+        // Given – two slots, one of them reserved, and normal-priority work running
+        let queue = TaskQueue(maxConcurrentTaskCount: 2, reservedTaskCount: 1)
+        let gate = AsyncGate()
+        let running = queue.add { await gate.wait() }
+
+        // When
+        running.priority = .veryLow
+        queue.add(priority: .low) { await gate.wait() }
+
+        // Then – the lowered work holds the low-priority slot
+        #expect(queue.runningCount == 1)
+        #expect(queue.pendingCount == 1)
+
+        // Cleanup
+        gate.open()
+        await queue.waitUntilAllOperationsAreFinished()
+    }
+
+    @Test func decreasingReservedTaskCountDrainsPendingWork() async {
+        // Given – low-priority work waiting for the reserved slot
+        let queue = TaskQueue(maxConcurrentTaskCount: 2, reservedTaskCount: 1)
+        let gate = AsyncGate()
+        let secondStarted = TestExpectation()
+        queue.add(priority: .low) { await gate.wait() }
+        queue.add(priority: .low) {
+            secondStarted.fulfill()
+            await gate.wait()
+        }
+        #expect(queue.pendingCount == 1)
+
+        // When
+        queue.reservedTaskCount = 0
+
+        // Then – it starts without waiting for the first one to finish
+        await secondStarted.wait()
+
+        // Cleanup
+        gate.open()
+        await queue.waitUntilAllOperationsAreFinished()
+    }
+
     // MARK: - Cancellation
 
     @Test func cancelledOperationIsNotExecuted() async {

--- a/Tests/NukeTests/TaskQueueTests.swift
+++ b/Tests/NukeTests/TaskQueueTests.swift
@@ -432,6 +432,100 @@ struct TaskQueueTests {
         await queue.waitUntilAllOperationsAreFinished()
     }
 
+    // MARK: - Reserved Slots
+
+    @Test func lowPriorityWorkLeavesReservedSlotFree() async {
+        // Given – two slots, one of them reserved
+        let queue = TaskQueue(maxConcurrentTaskCount: 2, reservedTaskCount: 1)
+        let lowStarted = TestExpectation()
+        let secondLowStarted = Ref(false)
+        let gate = TestExpectation()
+
+        queue.add(priority: .low) {
+            lowStarted.fulfill()
+            await gate.wait()
+        }
+        queue.add(priority: .low) {
+            secondLowStarted.value = true
+        }
+        await lowStarted.wait()
+
+        // Then – the second low-priority item waits even though a slot is free
+        #expect(queue.runningCount == 1)
+        #expect(!secondLowStarted.value)
+
+        // When
+        let normalStarted = TestExpectation()
+        queue.add { normalStarted.fulfill() }
+
+        // Then – the normal-priority item takes the reserved slot right away
+        await normalStarted.wait()
+
+        // Cleanup
+        gate.fulfill()
+        await queue.waitUntilAllOperationsAreFinished()
+        #expect(secondLowStarted.value)
+    }
+
+    @Test func raisingPriorityOfPendingWorkLetsItTakeReservedSlot() async {
+        // Given – one low-priority item running and one waiting
+        let queue = TaskQueue(maxConcurrentTaskCount: 2, reservedTaskCount: 1)
+        let firstStarted = TestExpectation()
+        let secondStarted = TestExpectation()
+        let gate = TestExpectation()
+
+        queue.add(priority: .low) {
+            firstStarted.fulfill()
+            await gate.wait()
+        }
+        let second = queue.add(priority: .low) {
+            secondStarted.fulfill()
+        }
+        await firstStarted.wait()
+        #expect(queue.pendingCount == 1)
+
+        // When
+        second.priority = .normal
+
+        // Then – it starts without waiting for the first one to finish
+        #expect(queue.pendingCount == 0)
+        await secondStarted.wait()
+
+        // Cleanup
+        gate.fulfill()
+        await queue.waitUntilAllOperationsAreFinished()
+    }
+
+    @Test func lowPriorityWorkAlwaysGetsOneSlot() async {
+        // Given – the only slot is reserved
+        let queue = TaskQueue(maxConcurrentTaskCount: 1, reservedTaskCount: 1)
+        let executed = Ref(false)
+
+        // When
+        queue.add(priority: .veryLow) { executed.value = true }
+        await queue.waitUntilAllOperationsAreFinished()
+
+        // Then
+        #expect(executed.value)
+    }
+
+    @Test func queueReservesNoSlotsByDefault() async {
+        // Given
+        let queue = TaskQueue(maxConcurrentTaskCount: 2)
+        let gate = AsyncGate()
+
+        // When
+        queue.add(priority: .low) { await gate.wait() }
+        queue.add(priority: .low) { await gate.wait() }
+
+        // Then – the low-priority work takes both slots
+        #expect(queue.runningCount == 2)
+
+        // Cleanup
+        gate.open()
+        await queue.waitUntilAllOperationsAreFinished()
+    }
+
     // MARK: - Cancellation
 
     @Test func cancelledOperationIsNotExecuted() async {


### PR DESCRIPTION
Once low-priority work fills `dataLoadingQueue` – a prefetcher with a higher `maxConcurrentRequestCount`, several prefetchers, or `.low` requests – an image the user opens waits for one of those downloads to finish.

`dataLoadingQueue` now runs the work below `.normal` priority in at most 3 of its 6 slots, counted by the current priority of the running work, so the default prefetcher (2 at a time) is unaffected. Adds a public, settable `TaskQueue/reservedTaskCount` and a "Data Loading Slots" section to the performance guide.

### Measurements

A simulated grid against a real `ImagePipeline`, with the downloads sharing the bandwidth and a prefetcher at 6. Mean ms a cell on screen waits for its image, median of 5 interleaved rounds.

| Scenario | `main` | ≤ 3 low-priority slots |
|---|---|---|
| Open a screen while prefetching – thumbnails, LTE | 989 | 860 (−13%) |
| Same – large images | 1297 | 1054 (−19%) |
| Page to a new image – thumbnails, LTE | 301 | 265 (−12%) |
| Same – large images | 1429 | 965 (−32%) |
| Scroll with the default prefetcher – Wi-Fi | 56 | 56 |

The cost: prefetching thumbnails with nothing on screen takes 67–70% longer, and a grid that relies on a prefetcher at 6 on LTE shows blank cells for longer (128 → 283 ms). The 7-slot version and reserving slots against all running work measured worse.

### Testing

1. `NukeTests` (macOS): 1113 tests pass.
2. New `TaskQueueTests` cover the low-priority slots, and fail when the queue counts all running work or ignores the priority changes of running work.