### PR TITLE
Keep the task list's nodes off the refcount side table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Loading an image with `ImagePipeline/Configuration-swift.struct/dataCache` set makes 10 fewer allocations per download – https://github.com/kean/Nuke/pull/971
 - `ImagePipeline/Error` is now 8 bytes instead of 97, which shrinks `ImageTask/Event` from 99 bytes to 26 – https://github.com/kean/Nuke/pull/967
 - `LazyImage` checks whether its request changed up to 5× faster on every body update when it keeps the same request – https://github.com/kean/Nuke/pull/969
+- Loading an image makes one fewer allocation – https://github.com/kean/Nuke/pull/982
 
 **Bug Fixes**
 

--- a/Sources/Nuke/ImageTask.swift
+++ b/Sources/Nuke/ImageTask.swift
@@ -254,7 +254,10 @@ public final class ImageTask: Hashable, Identifiable, CustomStringConvertible, S
     @ImagePipelineActor var _streamContinuations = ContiguousArray<AsyncStream<Event>.Continuation>()
     @ImagePipelineActor var _subscription: TaskSubscription?
     @ImagePipelineActor var _diagnostics: ImagePipeline.Diagnostics.TaskRecord?
-    @ImagePipelineActor weak var _node: LinkedList<ImageTask>.Node?
+    /// Retains the node that retains the task: `removeTask` breaks the cycle
+    /// when it takes the task off the list. A weak reference would give every
+    /// node a side table.
+    @ImagePipelineActor var _node: LinkedList<ImageTask>.Node?
 
     init(taskId: UInt64, request: ImageRequest, isDataTask: Bool, isPrefetch: Bool = false, pipeline: ImagePipeline, onEvent: (@Sendable (Event, ImageTask) -> Void)?, createdAt: TimeInterval? = nil) {
         self.taskId = taskId

--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -234,7 +234,7 @@ public final class ImagePipeline: Sendable {
     private func removeTask(_ task: ImageTask) {
         guard let node = task._node else { return }
         tasks.remove(node)
-        task._node = nil
+        task._node = nil // Break the retain cycle
     }
 
     func imageTaskUpdatePriorityCalled(_ task: ImageTask, priority: ImageRequest.Priority) {

--- a/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
+++ b/Tests/NukeTests/ImagePipelineTests/ImagePipelineTaskLifetimeTests.swift
@@ -157,6 +157,164 @@ struct ImagePipelineTaskLifetimeTests {
 
     // MARK: - Task Deallocation
 
+    @Test func taskIsDeallocatedAfterAsynchronousCompletion() async throws {
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            _ = try await task.response
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(weakTask == nil)
+    }
+
+    @Test func dataTaskIsDeallocatedAfterAsynchronousCompletion() async throws {
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.makeStartedImageTask(with: Test.request, isDataTask: true)
+            weakTask = task
+            _ = try await task.response
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedAfterFailure() async throws {
+        // Given
+        dataLoader.results[Test.url] = .failure(URLError(.unknown) as NSError)
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await #expect(throws: (any Error).self) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedAfterCancellation() async throws {
+        // Given a task waiting for the data
+        dataLoader.isSuspended = true
+        let started = TestExpectation()
+        pipeline.onTaskStarted = { _ in started.fulfill() }
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await started.wait()
+            task.cancel()
+            await #expect(throws: ImagePipeline.Error.cancelled) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedAfterCancellationBeforeStart() async throws {
+        // When the task is cancelled before the pipeline starts it
+        let pipeline = pipeline
+        weak var weakTask: ImageTask?
+        do {
+            let task = await Task { @ImagePipelineActor in
+                let task = pipeline.imageTask(with: Test.request)
+                task._cancelTask()
+                return task
+            }.value
+            weakTask = task
+            await #expect(throws: ImagePipeline.Error.cancelled) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 0)
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedWhenPipelineIsInvalidated() async throws {
+        // Given a task waiting for the data
+        dataLoader.isSuspended = true
+        let started = TestExpectation()
+        pipeline.onTaskStarted = { _ in started.fulfill() }
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await started.wait()
+            pipeline.invalidate()
+            await #expect(throws: ImagePipeline.Error.cancelled) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func taskIsDeallocatedWhenStartedOnInvalidatedPipeline() async throws {
+        // Given
+        pipeline.invalidate()
+        await drainPipeline()
+
+        // When
+        weak var weakTask: ImageTask?
+        do {
+            let task = pipeline.imageTask(with: Test.request)
+            weakTask = task
+            await #expect(throws: ImagePipeline.Error.pipelineInvalidated) {
+                try await task.response
+            }
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(weakTask == nil)
+    }
+
+    @Test func coalescedTasksAreDeallocated() async throws {
+        // When two tasks wait for the same job
+        weak var weakTask1: ImageTask?
+        weak var weakTask2: ImageTask?
+        do {
+            let (task1, task2) = await withSuspendedDataLoading(for: pipeline, expectedCount: 2) {
+                (pipeline.imageTask(with: Test.request), pipeline.imageTask(with: Test.request))
+            }
+            weakTask1 = task1
+            weakTask2 = task2
+            _ = try await task1.response
+            _ = try await task2.response
+        }
+        await drainPipeline()
+
+        // Then
+        #expect(dataLoader.createdTaskCount == 1)
+        #expect(weakTask1 == nil)
+        #expect(weakTask2 == nil)
+    }
+
     @Test func taskIsDeallocatedAfterSynchronousCompletion() async throws {
         // Given
         imageCache[Test.request] = Test.container


### PR DESCRIPTION
Split from #974, which bundled three changes; #983 is another.

The pipeline keeps its running tasks in a `LinkedList`, and each `ImageTask` held its node weakly. The first weak reference to an object moves the object's reference count out of its header into a side table – a separate allocation – for the rest of its life, so every node got one: an allocation per request, a weak load in `removeTask`, and a side table to free with the node.

`_node` is now strong. The node retains the task, so that's a cycle, and `removeTask` – which every finish and cancellation already goes through – breaks it. A task that never gets a node, because it was cancelled before it started or started on an invalidated pipeline, has no cycle to break.

### Measurements

Apple M5 Max (18 cores), macOS 26.6.2, Xcode 26.5. The release rig uses a mock data loader and `ImageDecoders.Empty`. Its memory cache hits store 8×8 images, so all 5000 entries stay in the cache, which the benchmark asserts before and after timing. `main` and the three splits of #974 run interleaved, in an order that rotates by round; median per side.

**Per request** – release rig, over 5000; weak references counted by interposing the runtime's `swift_weak*` and `swift_unknownObjectWeak*` entry points, allocations through `malloc_logger`, median of 3

| | `main` | This PR |
|---|---|---|
| Side tables formed per memory cache hit / download / create and cancel | 2 / 6 / 6 | 1 / 5 / 5 |
| Weak references formed per memory cache hit / download / create and cancel | 5 / 21 / 17 | 4 / 20 / 16 |
| Allocations per memory cache hit | 17 | **16** |
| Allocations per download | 73.0 | 72.0 |
| Allocations per request, 5000 over 50 URLs, concurrent | 16.9 | 16.0 |
| Allocations per create and cancel | 51 | 50 |

**Timing** – release rig, 10 samples per run, 24 rounds (16 for the cache reads)

| Benchmark | `main` | This PR | Δ | Faster in |
|---|---|---|---|---|
| Memory cache hit, 5000 concurrent | 8.29 ms | 7.79 ms | **−6.1%** | 19 of 24 rounds |
| Memory cache hit, 20000 in sequence | 37.57 ms | 37.06 ms | −1.3% | 15 of 24 |
| `asyncAwait`: 5000 downloads | 45.36 ms | 43.79 ms | **−3.5%** | 23 of 24 |
| 5000 downloads through `imageTask(with:)` | 45.40 ms | 43.98 ms | −3.1% | 22 of 24 |
| 5000 requests over 50 URLs | 23.82 ms | 22.93 ms | −3.7% | 20 of 24 |
| 5000 requests over 50 URLs, coalescing disabled | 39.73 ms | 38.42 ms | −3.3% | 23 of 24 |
| Cache reads without an `ImageTask`, 5000 concurrent | 4.45 ms | 4.42 ms | −0.8% | 13 of 16 |

The cache reads are the control: the same task group and lookups on a pipeline no `ImageTask` has touched, in a process of their own. Run in the same process right after the hit loops they read +1.5%, faster in 6 of 24 rounds; run alone, that goes away.

**Suite** – `ImagePipelinePerformanceTests`, which the scheme builds in Release; `-only-testing`, not parallel; 5 rounds

| Test | `main` | This PR | Δ | Faster in |
|---|---|---|---|---|
| `memoryHitPerformance` | 11.55 ms | 11.01 ms | −4.7% | 5 of 5 |
| `asyncAwaitPerformance` | 63.24 ms | 63.13 ms | −0.2% | 4 of 5 |
| `asyncImageTaskPerformance` | 62.24 ms | 61.77 ms | −0.8% | 4 of 5 |

In an 8 s Time Profiler trace of resident memory cache hits, `decrementUnownedShouldFree` – the release that frees a side table – falls from 1.57% of the samples to 0.85%.

### Testing

1. `xcodebuild test -project Nuke.xcodeproj -scheme NukeTests -destination 'platform=macOS' -parallel-testing-enabled NO -retry-tests-on-failure CODE_SIGNING_ALLOWED=NO`, with `-skip-testing:` for `ImageTaskTests.subscribingMidDownloadPrimesTheStreamWithTheCurrentProgress` – 1111 pass: `main`'s 1103 plus 8 new. The skipped test aborts under ThreadSanitizer on a race inside the test mock `MockProgressiveDataLoader`, on `main` too; run on its own on this branch, it passes.
2. `xcodebuild test -project Nuke.xcodeproj -scheme NukeThreadSafetyTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` – 8 pass.
3. `ImagePipelineTaskLifetimeTests` – the first commit adds 8 tests, which pass against `main`'s sources too: a task is deallocated after a download, a data task, a failure, a cancellation before or after it starts, `invalidate()`, and a start on an invalidated pipeline, and so are two coalesced tasks. Leaving `_node` set in `removeTask` fails 7 tests: six of the new ones and `taskIsDeallocatedAfterSynchronousCompletion`.
4. `swiftlint` reports nothing new in the changed files.

#973 and #980 also edit `ImageTask.swift`, and #973 `ImagePipeline.swift` and the lifetime tests; this branch merges cleanly with both.
